### PR TITLE
Fix link failure for vx_nc_util

### DIFF
--- a/met/internal_tests/libcode/vx_nc_util/Makefile.am
+++ b/met/internal_tests/libcode/vx_nc_util/Makefile.am
@@ -28,7 +28,7 @@ test_pressure_levels_LDADD = -lvx_tc_util \
 	-lvx_util \
 	-lvx_math \
 	-lvx_log \
-	-lnetcdf_c++4 -lgsl -lgslcblas
+	-lnetcdf_c++4 -lnetcdf -lgsl -lgslcblas
 
 if ENABLE_PYTHON
 test_pressure_levels_LDADD += $(MET_PYTHON_LD)


### PR DESCRIPTION
On my system, `vx_nc_util` would not compile because of missing symbols required by `libnetcdf_c++4` since `libnetcdf` was left behind.

