### PR TITLE
Bugfix 1286 master_v9.0 pb2nc

### DIFF
--- a/met/src/basic/vx_util/grib_constants.h
+++ b/met/src/basic/vx_util/grib_constants.h
@@ -52,18 +52,22 @@ static const char vgrd_grib_name[] = "VGRD";    // 34 V-component of wind
 // Grib codes for quantities that can be derived from
 // the P, Q, T, Z, U, V variables
 //
-static const int dpt_grib_code   = 17; // Dewpoint temperature
-static const int wdir_grib_code  = 31; // Wind direction
-static const int wind_grib_code  = 32; // Wind speed
-static const int rh_grib_code    = 52; // Relative humidity
-static const int mixr_grib_code  = 53; // Humidity mixing ratio
-static const int prmsl_grib_code = 2;  // Pressure Reduced to MSL
-static const char dpt_grib_name[]   = "DPT";    // 17 Dewpoint temperature
-static const char wdir_grib_name[]  = "WDIR";   // 31 Wind direction
-static const char wind_grib_name[]  = "WIND";   // 32 Wind speed
-static const char rh_grib_name[]    = "RH";     // 52 Relative humidity
-static const char mixr_grib_name[]  = "MIXR";   // 53 Humidity mixing ratio
-static const char prmsl_grib_name[] = "PRMSL";  //  2 Pressure Reduced to MSL
+static const int dpt_grib_code   = 17;  // Dewpoint temperature
+static const int wdir_grib_code  = 31;  // Wind direction
+static const int wind_grib_code  = 32;  // Wind speed
+static const int rh_grib_code    = 52;  // Relative humidity
+static const int mixr_grib_code  = 53;  // Humidity mixing ratio
+static const int prmsl_grib_code = 2;   // Pressure Reduced to MSL
+static const int cape_grib_code  = 157; // Convective available potential energy
+static const int pbl_grib_code   = 221; // Planetary boundary layer height
+static const char dpt_grib_name[]   = "DPT";    //  17 Dewpoint temperature
+static const char wdir_grib_name[]  = "WDIR";   //  31 Wind direction
+static const char wind_grib_name[]  = "WIND";   //  32 Wind speed
+static const char rh_grib_name[]    = "RH";     //  52 Relative humidity
+static const char mixr_grib_name[]  = "MIXR";   //  53 Humidity mixing ratio
+static const char prmsl_grib_name[] = "PRMSL";  //   2 Pressure Reduced to MSL
+static const char cape_grib_name[]  = "CAPE";   // 157 Convective available potential energy
+static const char pbl_grib_name[]   = "PBL";    // 221 Planetary boundary layer height
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/met/src/tools/other/pb2nc/pb2nc.cc
+++ b/met/src/tools/other/pb2nc/pb2nc.cc
@@ -145,13 +145,14 @@ static const int var_gc[mxr8vt] = {
 };
 
 // Number of variable types which may be derived
-static const int n_derive_gc = 6;
+static const int n_derive_gc = 8;
 
 // Listing of grib codes for variable types which may be derived
 static const int derive_gc[n_derive_gc] = {
    dpt_grib_code,  wdir_grib_code,
    wind_grib_code, rh_grib_code,
-   mixr_grib_code, prmsl_grib_code
+   mixr_grib_code, prmsl_grib_code,
+   cape_grib_code, pbl_grib_code
 };
 static int bufr_var_code[mxr8vt];
 static int bufr_derive_code[n_derive_gc];


### PR DESCRIPTION
The pb2nc tool includes logic to derive 8 variables, not 6. Change n_derive_gc to 8 and add entries for the CAPE and PBL derivations. The resulting array overflow on line 2365 of pb2nc.cc in met-9.0, caused the dump_flag to be changed from false to true when running on the WCOSS Venus machine.