### PR TITLE
Feature 1291 develop gaussian to goes

### DIFF
--- a/met/doc/MET_Users_Guide/Reformat_Point/MET_Users_Guide_Reformat_Point.lyx
+++ b/met/doc/MET_Users_Guide/Reformat_Point/MET_Users_Guide_Reformat_Point.lyx
@@ -5973,15 +5973,7 @@ hskip 0.5in}
 
 \end_inset
 
-[-prob_cat_thresh 
-\begin_inset Quotes eld
-\end_inset
-
-<op>n
-\begin_inset Quotes erd
-\end_inset
-
-]
+[-prob_cat_thresh string]
 \end_layout
 
 \begin_layout LyX-Code
@@ -6247,18 +6239,9 @@ radius of influence for Gaussian interpolation.
 11.
  The 
 \series bold
--prob_cat_thresh 
-\begin_inset Quotes eld
-\end_inset
-
-<op>n
-\begin_inset Quotes erd
-\end_inset
-
-
+-prob_cat_thresh string
 \series default
  option sets the threshold to compute the probability of occurrence.
- <op> is an equality or inequality symbol like =, <, <=, >, or >=.
  The default is set to disabled.
  This option is relevant when calculating practically perfect forecasts.
 \end_layout

--- a/met/doc/MET_Users_Guide/Reformat_Point/MET_Users_Guide_Reformat_Point.lyx
+++ b/met/doc/MET_Users_Guide/Reformat_Point/MET_Users_Guide_Reformat_Point.lyx
@@ -5973,7 +5973,15 @@ hskip 0.5in}
 
 \end_inset
 
-[-prob_cat_thresh n]
+[-prob_cat_thresh 
+\begin_inset Quotes eld
+\end_inset
+
+<op>n
+\begin_inset Quotes erd
+\end_inset
+
+]
 \end_layout
 
 \begin_layout LyX-Code
@@ -6239,9 +6247,18 @@ radius of influence for Gaussian interpolation.
 11.
  The 
 \series bold
--prob_cat_thresh n
+-prob_cat_thresh 
+\begin_inset Quotes eld
+\end_inset
+
+<op>n
+\begin_inset Quotes erd
+\end_inset
+
+
 \series default
  option sets the threshold to compute the probability of occurrence.
+ <op> is an equality or inequality symbol like =, <, <=, >, or >=.
  The default is set to disabled.
  This option is relevant when calculating practically perfect forecasts.
 \end_layout

--- a/met/src/tools/other/point2grid/point2grid.cc
+++ b/met/src/tools/other/point2grid/point2grid.cc
@@ -2221,7 +2221,7 @@ void usage() {
         << "\t\t\"-gaussian_radius n\" specifies the radius of influence for Gaussian smoothing."
         << " The default is " << RGInfo.gaussian.radius << "). Ignored if not Gaussian method (optional).\n"
 
-        << "\t\t\"-prob_cat_thresh string\" sets observation value to compute the probability."
+        << "\t\t\"-prob_cat_thresh string\" sets the threshold to compute the probability of occurrence (optional)."
 
         << "\t\t\"-vld_thresh n\" overrides the default required "
         << "ratio of valid data for regridding (" << RGInfo.vld_thresh

--- a/met/src/tools/other/point2grid/point2grid.cc
+++ b/met/src/tools/other/point2grid/point2grid.cc
@@ -2221,7 +2221,7 @@ void usage() {
         << "\t\t\"-gaussian_radius n\" specifies the radius of influence for Gaussian smoothing."
         << " The default is " << RGInfo.gaussian.radius << "). Ignored if not Gaussian method (optional).\n"
 
-        << "\t\t\"-prob_cat_thresh string\" sets the threshold to compute the probability of occurrence (optional)."
+        << "\t\t\"-prob_cat_thresh string\" sets the threshold to compute the probability of occurrence (optional).\n"
 
         << "\t\t\"-vld_thresh n\" overrides the default required "
         << "ratio of valid data for regridding (" << RGInfo.vld_thresh

--- a/met/src/tools/other/point2grid/point2grid.cc
+++ b/met/src/tools/other/point2grid/point2grid.cc
@@ -2183,7 +2183,7 @@ void usage() {
         << "\t[-method type]\n"
         << "\t[-gaussian_dx n]\n"
         << "\t[-gaussian_radius n]\n"
-        << "\t[-prob_cat_thresh \"<op>n\"]\n"
+        << "\t[-prob_cat_thresh string]\n"
         << "\t[-vld_thresh n]\n"
         << "\t[-name list]\n"
         << "\t[-log file]\n"
@@ -2221,8 +2221,7 @@ void usage() {
         << "\t\t\"-gaussian_radius n\" specifies the radius of influence for Gaussian smoothing."
         << " The default is " << RGInfo.gaussian.radius << "). Ignored if not Gaussian method (optional).\n"
 
-        << "\t\t\"-prob_cat_thresh '<op>n'\" sets observation value to compute the probability."
-        << "<op> is a operator, like >, >=, <, <= ..."
+        << "\t\t\"-prob_cat_thresh string\" sets observation value to compute the probability."
         << " The default is disabled (optional).\n"
 
         << "\t\t\"-vld_thresh n\" overrides the default required "

--- a/met/src/tools/other/point2grid/point2grid.cc
+++ b/met/src/tools/other/point2grid/point2grid.cc
@@ -2222,7 +2222,6 @@ void usage() {
         << " The default is " << RGInfo.gaussian.radius << "). Ignored if not Gaussian method (optional).\n"
 
         << "\t\t\"-prob_cat_thresh string\" sets observation value to compute the probability."
-        << " The default is disabled (optional).\n"
 
         << "\t\t\"-vld_thresh n\" overrides the default required "
         << "ratio of valid data for regridding (" << RGInfo.vld_thresh

--- a/test/xml/unit_point2grid.xml
+++ b/test/xml/unit_point2grid.xml
@@ -53,7 +53,7 @@
       G212 \
       &OUTPUT_DIR;/regrid/pb2nc_TMP_prob.nc \
       -field 'name="TMP"; level="*"; valid_time="20120409_120000"; censor_thresh=[ &lt;0 ]; censor_val=[0];' \
-      -name TEMP -prob_cat_thresh 280.0 \
+      -name TEMP -prob_cat_thresh ">=280.0" \
       -v 1
     </param>
     <!--  -->
@@ -69,7 +69,7 @@
       G212 \
       &OUTPUT_DIR;/regrid/pb2nc_TMP_prob_gaussian.nc \
       -field 'name="TMP"; level="*"; valid_time="20120409_120000"; censor_thresh=[ &lt;0 ]; censor_val=[0];' \
-      -name TEMP -prob_cat_thresh 280.0 -method GAUSSIAN \
+      -name TEMP -prob_cat_thresh ">=280.0" -method GAUSSIAN \
       -v 1
     </param>
     <!--  -->
@@ -106,7 +106,7 @@
       G212 \
       &OUTPUT_DIR;/regrid/point2grid_GOES_16_AOD_TO_G212_gaussian.nc \
       -field 'name="AOD";  level="(*,*)";' \
-      -method MAX -prob_cat_thresh 1.0 -method GAUSSIAN \
+      -method MAX -prob_cat_thresh ">=1.0" -method GAUSSIAN \
       -v 1
     </param>
     <output>

--- a/test/xml/unit_point2grid.xml
+++ b/test/xml/unit_point2grid.xml
@@ -96,6 +96,24 @@
     </output>
   </test>
   
+  <test name="point2grid_GOES_16_AOD_TO_G212_GAUSSIAN">
+    <exec>&MET_BIN;/point2grid</exec>
+    <env>
+      <pair><name>MET_TMP_DIR</name>  <value>&OUTPUT_DIR;</value></pair>
+    </env>
+    <param> \
+      &DATA_DIR_MODEL;/goes_16/OR_ABI-L2-AODC-M3_G16_s20181341702215_e20181341704588_c20181341711418.nc \
+      G212 \
+      &OUTPUT_DIR;/regrid/point2grid_GOES_16_AOD_TO_G212_gaussian.nc \
+      -field 'name="AOD";  level="(*,*)";' \
+      -method MAX -prob_cat_thresh 1.0 -method GAUSSIAN \
+      -v 1
+    </param>
+    <output>
+      <grid_nc>&OUTPUT_DIR;/regrid/point2grid_GOES_16_AOD_TO_G212_gaussian.nc</grid_nc>
+    </output>
+  </test>
+  
   <test name="point2grid_GOES_16_ADP">
     <exec>&MET_BIN;/point2grid</exec>
     <env>


### PR DESCRIPTION

- Enabled Gaussian filtering for GOES16/17 data if -method GAUSSIAN is given
- Enabled "-prob_cat_thresh ": Adding <VAR_NAME>_prob because the Gaussian filtering is applied to the probability variable
- Added three attributes if Gaussian filtering is enabled:
    - TEMP_prob:gaussian_radius = 120. ;
    - TEMP_prob:gaussian_dx = 81.271 ;
    - TEMP_prob:trunc_factor = 3.5 ;
- Added an unit test, point2grid_GOES_16_AOD_TO_G212_GAUSSIAN. Used the default configurations. (The resolution of GOES is 0.00056 rad)

Note: there is one bug fix at lint 774: missing initialization

     if (has_prob_thresh || do_gaussian_filter) {
        prob_dp.set_constant(0);
        prob_mask_dp.set_constant(0);
     }

Some commands for manual tests (at dakota):

Add probability variable with Gaussian:

./point2grid /d3/personal/hsoh/data/GOES-16/OR_ABI-L2-AODC-M6_G16_s20191701601532_e20191701604305_c20191701607276.nc G212 goes_aod_gaussian.nc -field 'name="AOD"; level="*";' -method GAUSSIAN -v 5

OR

./point2grid /d3/personal/hsoh/data/GOES-16/OR_ABI-L2-AODC-M6_G16_s20191701601532_e20191701604305_c20191701607276.nc G212 goes_aod_prob_only.nc -field 'name="AOD"; level="*";' -prob_cat_thresh 1.0 -method GAUSSIAN -v 5

Add probability variable without Gaussian:

./point2grid /d3/personal/hsoh/data/GOES-16/OR_ABI-L2-AODC-M6_G16_s20191701601532_e20191701604305_c20191701607276.nc G212 goes_aod_prob_only.nc -field 'name="AOD"; level="*"; -v 5 -prob_cat_thresh 1.0