### PR TITLE
Feature 1265 importlib

### DIFF
--- a/met/data/wrappers/write_pickle_dataplane.py
+++ b/met/data/wrappers/write_pickle_dataplane.py
@@ -11,22 +11,22 @@
 import os
 import sys
 import pickle
+import importlib.util
 
 print('Python Script:\t', sys.argv[0])
 print('User Command:\t',  sys.argv[2:])
 print('Write Pickle:\t',  sys.argv[1])
 
-pickle_filename = sys.argv[1];
+pickle_filename = sys.argv[1]
 
-pyembed_module_name = sys.argv[2].replace('.py','')
+pyembed_module_name = sys.argv[2]
 sys.argv = sys.argv[2:]
 
-user_dir  = os.path.dirname(pyembed_module_name) or '.'
-user_base = os.path.basename(pyembed_module_name)
+user_base = os.path.basename(pyembed_module_name).replace('.py','')
 
-sys.path.append(user_dir)
-
-met_in = __import__(user_base)
+spec = importlib.util.spec_from_file_location(user_base, pyembed_module_name)
+met_in = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(met_in)
 
 met_info = { 'attrs': met_in.attrs, 'met_data': met_in.met_data }
 

--- a/met/data/wrappers/write_pickle_dataplane.py
+++ b/met/data/wrappers/write_pickle_dataplane.py
@@ -22,6 +22,9 @@ pickle_filename = sys.argv[1]
 pyembed_module_name = sys.argv[2]
 sys.argv = sys.argv[2:]
 
+if not pyembed_module_name.endswith('.py'):
+    pyembed_module_name += '.py'
+
 user_base = os.path.basename(pyembed_module_name).replace('.py','')
 
 spec = importlib.util.spec_from_file_location(user_base, pyembed_module_name)

--- a/met/data/wrappers/write_pickle_mpr.py
+++ b/met/data/wrappers/write_pickle_mpr.py
@@ -19,8 +19,7 @@ print('Write Pickle:\t',  sys.argv[1])
 
 pickle_filename = sys.argv[1]
 
-pyembed_module_name = os.path.basename(sys.argv[2])
-
+pyembed_module_name = sys.argv[2]
 sys.argv = sys.argv[2:]
 
 user_base = os.path.basename(pyembed_module_name).replace('.py','')
@@ -28,9 +27,6 @@ user_base = os.path.basename(pyembed_module_name).replace('.py','')
 spec = importlib.util.spec_from_file_location(user_base, pyembed_module_name)
 met_in = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(met_in)
-
-sys.path.append(pyembed_module_dir)
-met_in = __import__(pyembed_module_name)
 
 print(met_in)
 

--- a/met/data/wrappers/write_pickle_mpr.py
+++ b/met/data/wrappers/write_pickle_mpr.py
@@ -11,17 +11,23 @@
 import os
 import sys
 import pickle
+import importlib.util
 
 print('Python Script:\t', sys.argv[0])
 print('User Command:\t',  sys.argv[2:])
 print('Write Pickle:\t',  sys.argv[1])
 
-pickle_filename = sys.argv[1];
+pickle_filename = sys.argv[1]
 
-pyembed_module_dir  = os.path.dirname(sys.argv[2]) or '.'
-pyembed_module_name = os.path.basename(sys.argv[2]).replace('.py','')
+pyembed_module_name = os.path.basename(sys.argv[2])
 
 sys.argv = sys.argv[2:]
+
+user_base = os.path.basename(pyembed_module_name).replace('.py','')
+
+spec = importlib.util.spec_from_file_location(user_base, pyembed_module_name)
+met_in = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(met_in)
 
 sys.path.append(pyembed_module_dir)
 met_in = __import__(pyembed_module_name)

--- a/met/data/wrappers/write_pickle_point.py
+++ b/met/data/wrappers/write_pickle_point.py
@@ -11,17 +11,23 @@
 import os
 import sys
 import pickle
+import importlib.util
 
 print('Python Script:\t', sys.argv[0])
 print('User Command:\t',  sys.argv[2:])
 print('Write Pickle:\t',  sys.argv[1])
 
-pickle_filename = sys.argv[1];
+pickle_filename = sys.argv[1]
 
-pyembed_module_dir  = os.path.dirname(sys.argv[2]) or '.'
-pyembed_module_name = os.path.basename(sys.argv[2]).replace('.py','')
+pyembed_module_name = os.path.basename(sys.argv[2])
 
 sys.argv = sys.argv[2:]
+
+user_base = os.path.basename(pyembed_module_name).replace('.py','')
+
+spec = importlib.util.spec_from_file_location(user_base, pyembed_module_name)
+met_in = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(met_in)
 
 sys.path.append(pyembed_module_dir)
 met_in = __import__(pyembed_module_name)

--- a/met/data/wrappers/write_pickle_point.py
+++ b/met/data/wrappers/write_pickle_point.py
@@ -19,8 +19,7 @@ print('Write Pickle:\t',  sys.argv[1])
 
 pickle_filename = sys.argv[1]
 
-pyembed_module_name = os.path.basename(sys.argv[2])
-
+pyembed_module_name = sys.argv[2]
 sys.argv = sys.argv[2:]
 
 user_base = os.path.basename(pyembed_module_name).replace('.py','')
@@ -28,8 +27,5 @@ user_base = os.path.basename(pyembed_module_name).replace('.py','')
 spec = importlib.util.spec_from_file_location(user_base, pyembed_module_name)
 met_in = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(met_in)
-
-sys.path.append(pyembed_module_dir)
-met_in = __import__(pyembed_module_name)
 
 pickle.dump( met_in.point_data, open( pickle_filename, "wb" ) )


### PR DESCRIPTION
Switch to using importlib.util to import user's python script when using pickle logic. This uses the full path to the user's py script so that it is guaranteed to import that script. Previous implementation appends the dir containing the script to the sys.path and imports the script, which will fail or use the wrong script if the user's script is the same name as another script found in the path.