### PR TITLE
Feature 1331 cdo

### DIFF
--- a/met/src/libcode/vx_nc_util/nc_utils.h
+++ b/met/src/libcode/vx_nc_util/nc_utils.h
@@ -127,7 +127,7 @@ static const char nc_var_unit[]         = "obs_unit";
 static const string nc_att_use_var_id   = "use_var_id";
 static const char nc_att_obs_version[]  = "MET_Obs_version";
 
-static const char nc_time_unit_exp[]    = "^[a-z|A-Z]* since [0-9]\\{4\\}";
+static const char nc_time_unit_exp[]    = "^[a-z|A-Z]* since [0-9]\\{1,4\\}-[0-9]\\{1,2\\}-[0-9]\\{1,2\\}";
 
 static const char MET_NC_Obs_ver_1_2[]  = "1.02";
 static const char MET_NC_Obs_version[]  = "1.02";


### PR DESCRIPTION
Per #1331, update the nc_time_unit_exp regular expression to support 1 to 4 digit years, 1 to 2 digit months, and 1 to 2 digit days.

This enables MET to parse time unit strings like "hours since 1-1-1 00:00:00".
These appeared in the NetCDF output of the cdo -import_binary utility.