### PR TITLE
Feature 1333 mask_type

### DIFF
--- a/met/src/tools/other/gen_vx_mask/gen_vx_mask.cc
+++ b/met/src/tools/other/gen_vx_mask/gen_vx_mask.cc
@@ -1444,7 +1444,16 @@ void usage() {
 ////////////////////////////////////////////////////////////////////////
 
 void set_type(const StringArray & a) {
+   if(type_is_set) {
+      mlog << Error << "\n" << program_name << " -> "
+           << "the -type command line option can only be used once!\n"
+           << "To apply multiple masks, run this tool multiple times "
+           << "using the output of one run as the input to the next."
+           << "\n\n"; 
+      exit(1);
+   }
    mask_type = string_to_masktype(a[0].c_str());
+   type_is_set = true;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1542,8 +1551,8 @@ void set_shapeno(const StringArray & a) {
    shape_number = atoi(a[0].c_str());
 
    if(shape_number < 0) {
-      mlog << Error << "\n" << program_name
-           << ": bad shapeno ... " << shape_number << "\n\n";
+      mlog << Error << "\n" << program_name << " -> "
+           << "bad shapeno ... " << shape_number << "\n\n";
       exit(1);
    }
 

--- a/met/src/tools/other/gen_vx_mask/gen_vx_mask.h
+++ b/met/src/tools/other/gen_vx_mask/gen_vx_mask.h
@@ -89,6 +89,7 @@ static ConcatString input_gridname, mask_filename, out_filename;
 
 // Optional arguments
 static MaskType mask_type = default_mask_type;
+static bool type_is_set = false;
 static ConcatString input_field_str, mask_field_str;
 static SetLogic set_logic = SetLogic_None;
 static bool complement = false;


### PR DESCRIPTION
Per #1333, print an error message if the -type command line option has been used more than once for gen_vx_mask.

Here's the resulting error message:
ERROR  :
ERROR  : gen_vx_mask -> the -type command line option can only be used once!
ERROR  : To apply multiple masks, run this tool multiple times using the output of one run as the input to the next.
ERROR  : 