### PR TITLE
Bugfix 1335 master v9.0

### DIFF
--- a/met/doc/MET_Users_Guide/Grid-Stat/MET_Users_Guide_Grid-Stat.lyx
+++ b/met/doc/MET_Users_Guide/Grid-Stat/MET_Users_Guide_Grid-Stat.lyx
@@ -6077,7 +6077,7 @@ MED_FO
 \begin_inset Text
 
 \begin_layout Plain Layout
-Mean-error Distance from forecast to observation
+Mean-error Distance from observation to forecast
 \end_layout
 
 \end_inset
@@ -6106,7 +6106,7 @@ MED_OF
 \begin_inset Text
 
 \begin_layout Plain Layout
-Mean-error Distance from observation to forecast
+Mean-error Distance from forecast to observation
 \end_layout
 
 \end_inset
@@ -6222,7 +6222,7 @@ FOM_FO
 \begin_inset Text
 
 \begin_layout Plain Layout
-Pratt's Figure of Merit from forecast to observation
+Pratt's Figure of Merit from observation to forecast
 \end_layout
 
 \end_inset
@@ -6251,7 +6251,7 @@ FOM_OF
 \begin_inset Text
 
 \begin_layout Plain Layout
-Pratt's Figure of Merit from observation to forecast
+Pratt's Figure of Merit from forecast to observation
 \end_layout
 
 \end_inset
@@ -6367,7 +6367,7 @@ ZHU_FO
 \begin_inset Text
 
 \begin_layout Plain Layout
-Zhu's Measure from forecast to observation
+Zhu's Measure from observation to forecast
 \end_layout
 
 \end_inset
@@ -6396,7 +6396,7 @@ ZHU_OF
 \begin_inset Text
 
 \begin_layout Plain Layout
-Zhu's Measure from observation to forecast
+Zhu's Measure from forecast to observation
 \end_layout
 
 \end_inset

--- a/met/doc/MET_Users_Guide/TC-Gen/MET_Users_Guide_TC-Gen.lyx
+++ b/met/doc/MET_Users_Guide/TC-Gen/MET_Users_Guide_TC-Gen.lyx
@@ -954,6 +954,42 @@ height "1pt"
 \begin_layout LyX-Code
 
 \series bold
+desc = "NA";
+\end_layout
+
+\begin_layout Standard
+
+\series medium
+The 
+\series bold
+desc
+\series medium
+ configuration option is common to many MET tools and is described in Section
+ 
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "subsec:IO_General-MET-Config-Options"
+
+\end_inset
+
+.
+ 
+\series default
+
+\begin_inset CommandInset line
+LatexCommand rule
+offset "0.5ex"
+width "100col%"
+height "1pt"
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout LyX-Code
+
+\series bold
 model = [];
 \end_layout
 
@@ -980,10 +1016,6 @@ height "1pt"
 
 \end_inset
 
-
-\end_layout
-
-\begin_layout LyX-Code
 
 \end_layout
 

--- a/met/src/basic/vx_config/config_util.cc
+++ b/met/src/basic/vx_config/config_util.cc
@@ -1167,7 +1167,7 @@ RegridInfo parse_conf_regrid(Dictionary *dict, bool error_out) {
    info.gaussian.radius = (is_bad_data(conf_value) ? default_gaussian_radius : conf_value);
    conf_value = regrid_dict->lookup_double(conf_key_trunc_factor, false);
    info.gaussian.trunc_factor = (is_bad_data(conf_value) ? default_trunc_factor : conf_value);
-   if (info.method == InterpMthd_Gaussian) info.gaussian.compute();
+   if(info.method == InterpMthd_Gaussian || info.method == InterpMthd_MaxGauss) info.gaussian.compute();
 
    info.validate();
 
@@ -1391,7 +1391,9 @@ InterpInfo parse_conf_interp(Dictionary *dict, const char *conf_key) {
 
          } // end for k
          
-         if (method == InterpMthd_Gaussian) info.gaussian.compute();
+         if(method == InterpMthd_Gaussian || method == InterpMthd_MaxGauss) {
+            info.gaussian.compute();
+         }
       } // end for j
    } // end for i
 

--- a/met/src/libcode/vx_statistics/contable_stats.cc
+++ b/met/src/libcode/vx_statistics/contable_stats.cc
@@ -1055,6 +1055,12 @@ for (j=0; j<Nrows; ++j)  {
 }
 
    //
+   //  replace nan with bad data
+   //
+
+if (isnan(sum))  sum = bad_data_double;
+
+   //
    //  done
    //
 

--- a/met/src/tools/other/ascii2nc/ascii2nc.cc
+++ b/met/src/tools/other/ascii2nc/ascii2nc.cc
@@ -73,7 +73,6 @@ using namespace netCDF;
 #include "vx_util.h"
 #include "vx_math.h"
 #include "vx_log.h"
-#include "global_python.h"
 
 #include "ascii2nc_conf_info.h"
 #include "file_handler.h"
@@ -84,6 +83,7 @@ using namespace netCDF;
 #include "aeronet_handler.h"
 
 #ifdef ENABLE_PYTHON
+#include "global_python.h"
 #include "python_handler.h"
 #endif
 


### PR DESCRIPTION
This fixes 5 issues:
(1) Gerrity score nan's (Julie P).
(2) MAXGAUSS in Grid-Stat (Tina K).
(3) Compile ascii2nc without python (Hank F).
(4) Correct docs for DMAP (Eric G/Sarah G).
(5) Correct docs for TC-Gen (Dan A).