### PR TITLE
Feature 1339 develop

### DIFF
--- a/met/src/basic/vx_config/config_util.cc
+++ b/met/src/basic/vx_config/config_util.cc
@@ -244,7 +244,12 @@ void RegridInfo::validate_point() {
       mlog << Warning << "\nRegridInfo::validate_point() -> "
            << "Resetting the regridding method from \""
            << interpmthd_to_string(method) << "\" to \""
-           << interpmthd_uw_mean_str << ".\n\n";
+           << interpmthd_uw_mean_str << ".\n"
+           << "\tAvailable methods: "
+           << interpmthd_to_string(InterpMthd_UW_Mean) << ", "
+           << interpmthd_to_string(InterpMthd_Max) << ", "
+           << interpmthd_to_string(InterpMthd_Min) << ", "
+           << interpmthd_to_string(InterpMthd_Median) << ".\n\n";
       method = InterpMthd_UW_Mean;
    }
 

--- a/met/src/tools/other/point2grid/point2grid.cc
+++ b/met/src/tools/other/point2grid/point2grid.cc
@@ -295,16 +295,6 @@ int process_command_line(int argc, char **argv) {
             exit(1);
          }
       }
-      
-      if ((RGInfo.method != InterpMthd_Min)
-            && (RGInfo.method != InterpMthd_Max)
-            && (RGInfo.method != InterpMthd_Median)
-            && (RGInfo.method != InterpMthd_UW_Mean)) {
-         mlog << Error << "\n" << method_name << "The Interpolation method \""
-              << interpmthd_to_string(RGInfo.method)
-              << "\" is not supported for GOES data.\n\n";
-         exit(1);
-      }
    }
    
    return obs_type;


### PR DESCRIPTION
point2grid supports 4 regridding method: MIN, MAX, MEDIAN and UW_MEAN.

How to test: set the regriding method except above four.
-method NEAREST

./point2grid /d3/personal/hsoh/MET/MET_test_output/ascii2nc/edr_hourly.20130827.nc G212 gridded_ascii.nc -config ../../../../share/met/config/Point2GridConfig_default -field 'name="200"; level="*";' -method NEAREST -v 2