### PR TITLE
Bugfix 1342 master_v9.0 ensemble_stat

### DIFF
--- a/met/src/tools/core/ensemble_stat/ensemble_stat.cc
+++ b/met/src/tools/core/ensemble_stat/ensemble_stat.cc
@@ -1887,6 +1887,8 @@ void process_grid_scores(int i_vx,
    pd.extend(grid.nx()*grid.ny());
 
    // Climatology flags
+   bool emn_flag = (emn_dp.nx() == obs_dp.nx() &&
+                    emn_dp.ny() == obs_dp.ny());
    bool cmn_flag = (cmn_dp.nx() == obs_dp.nx() &&
                     cmn_dp.ny() == obs_dp.ny());
    bool csd_flag = (csd_dp.nx() == obs_dp.nx() &&
@@ -1925,7 +1927,7 @@ void process_grid_scores(int i_vx,
          pd.add_obs_error_entry(e);
 
          // Add the ensemble mean value for this point
-         pd.mn_na.add(emn_dp(x, y));
+         pd.mn_na.add((emn_flag ? emn_dp(x, y) : bad_data_double));
 
       } // end for y
    } // end for x


### PR DESCRIPTION
Tina, please review this PR to fix the ensemble_stat bug you found. I setup a testing environment for you:
kiowa:/d1/projects/MET/MET_pull_requests/met-9.1_beta2/bugfix_1342/MET-bugfix_1342_master_v9.0_ensemble_stat_into_master_v9.0/met

Please test to verify that only requesting the RHIST output line type now runs without error, as described in the #1342 