### PR TITLE
bugfix 1370 develop day_fraction

### DIFF
--- a/met/src/basic/vx_cal/is_leap_year.cc
+++ b/met/src/basic/vx_cal/is_leap_year.cc
@@ -21,6 +21,7 @@ using namespace std;
 #include <cmath>
 
 #include "vx_cal.h"
+#include "vx_log.h"
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -93,7 +94,6 @@ unixtime add_to_unixtime(unixtime base_unixtime,
     int sec_per_unit, double time_value, bool no_leap) {
   unixtime ut;
   const char *ptr = getenv("MET_DEBUG");
-  bool debug = (NULL != ptr && 0 < strlen(ptr));
   
   if (!no_leap || sec_per_unit != 86400) {
     ut = (unixtime)(base_unixtime + sec_per_unit * time_value);
@@ -121,11 +121,10 @@ unixtime add_to_unixtime(unixtime base_unixtime,
     if (day == 0) day == 1;
     ut = mdyhms_to_unix(month, day, year, hour, minute, second);
     ut += (time_fraction * sec_per_unit);
-    if (debug) {
-      cout << "add_to_unixtime() -> " << unix_to_yyyymmdd_hhmmss(base_unixtime)
-           << " plus " << time_value << " days = "
-           << unix_to_yyyymmdd_hhmmss(ut) << "\n";
-    }
+    mlog << Debug(5) << "add_to_unixtime() -> "
+         << unix_to_yyyymmdd_hhmmss(base_unixtime)
+         << " plus " << time_value << " days = "
+         << unix_to_yyyymmdd_hhmmss(ut) << "\n";
   }
   
   return ut;

--- a/met/src/basic/vx_cal/is_leap_year.cc
+++ b/met/src/basic/vx_cal/is_leap_year.cc
@@ -16,6 +16,7 @@ using namespace std;
 
 #include <iostream>
 #include <unistd.h>
+#include <string.h>
 #include <stdlib.h>
 #include <cmath>
 
@@ -91,13 +92,16 @@ void increase_one_month(int &year, int &month) {
 unixtime add_to_unixtime(unixtime base_unixtime,
     int sec_per_unit, double time_value, bool no_leap) {
   unixtime ut;
-  bool debug = false;
+  const char *ptr = getenv("MET_DEBUG");
+  bool debug = (NULL != ptr && 0 < strlen(ptr));
+  
   if (!no_leap || sec_per_unit != 86400) {
     ut = (unixtime)(base_unixtime + sec_per_unit * time_value);
   }
   else {
     int day_offset;
     int month, day, year, hour, minute, second;
+    double time_fraction = time_value - (int)time_value;
     
     unix_to_mdyhms(base_unixtime, month, day, year, hour, minute, second);
     day_offset = day + (int)time_value;
@@ -116,9 +120,10 @@ unixtime add_to_unixtime(unixtime base_unixtime,
     day = day_offset;
     if (day == 0) day == 1;
     ut = mdyhms_to_unix(month, day, year, hour, minute, second);
+    ut += (time_fraction * sec_per_unit);
     if (debug) {
       cout << "add_to_unixtime() -> " << unix_to_yyyymmdd_hhmmss(base_unixtime)
-           << " plus " << (int)time_value << " days = "
+           << " plus " << time_value << " days = "
            << unix_to_yyyymmdd_hhmmss(ut) << "\n";
     }
   }

--- a/met/src/basic/vx_cal/is_leap_year.cc
+++ b/met/src/basic/vx_cal/is_leap_year.cc
@@ -93,7 +93,6 @@ void increase_one_month(int &year, int &month) {
 unixtime add_to_unixtime(unixtime base_unixtime,
     int sec_per_unit, double time_value, bool no_leap) {
   unixtime ut;
-  const char *ptr = getenv("MET_DEBUG");
   
   if (!no_leap || sec_per_unit != 86400) {
     ut = (unixtime)(base_unixtime + sec_per_unit * time_value);


### PR DESCRIPTION
The test file at dakota: /d3/personal/hsoh/data/git_1370_fraction_of_day/MetPlus.globe.2014-08-01-00000.cam.h0.2014-08-01-10800.nc

- successful time selection (20140801_060000 by 92.125):
./plot_data_plane MetPlus.globe.2014-08-01-00000.cam.h0.2014-08-01-10800.nc tmp_test.ps 'name="T"; level="(20140801_060000,0,*,*)";' -v 4

- failed time selection because wrong time (20140801_000000):
./plot_data_plane MetPlus.globe.2014-08-01-00000.cam.h0.2014-08-01-10800.nc tmp_test.ps 'name="T"; level="(20140801_000000,0,*,*)";' -v 4