### PR TITLE
Feature 1382 verbosity

### DIFF
--- a/met/src/tools/core/series_analysis/series_analysis.cc
+++ b/met/src/tools/core/series_analysis/series_analysis.cc
@@ -2294,6 +2294,12 @@ void set_log_file(const StringArray & a) {
 
 void set_verbosity(const StringArray & a) {
    mlog.set_verbosity_level(atoi(a[0].c_str()));
+
+   if(mlog.verbosity_level() >= 3) {
+      mlog << Warning << "\nRunning Series-Analysis at verbosity >= 3 "
+           << "produces excessive log output and can slow the runtime "
+           << "considerably.\n\n"; 
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Running Series-Analysis with -v 3 or higher now results in:
```
WARNING: 
WARNING: Running Series-Analysis at verbosity >= 3 produces excessive log output and can slow the runtime considerably.
WARNING: 
```