### PR TITLE
Bugfix 1387 develop valgrind uninitialized jump

### DIFF
--- a/met/src/basic/vx_config/config_util.cc
+++ b/met/src/basic/vx_config/config_util.cc
@@ -32,8 +32,9 @@ static MetConfig conf_const(replace_path(config_const_filename).c_str());
 
 ///////////////////////////////////////////////////////////////////////////////
 
-GaussianInfo::GaussianInfo() {
-   weights = (double *) 0;
+GaussianInfo::GaussianInfo()
+: weights(0)
+{
    clear();
 }
 
@@ -41,7 +42,7 @@ GaussianInfo::GaussianInfo() {
 
 void GaussianInfo::clear() {
    weight_sum = 0.0;
-   if (0 < max_r && weights) {
+   if (weights) {
       delete weights;
       weights = (double *)0;
    }

--- a/met/src/basic/vx_config/idstack.cc
+++ b/met/src/basic/vx_config/idstack.cc
@@ -388,6 +388,8 @@ IdentifierArray::~IdentifierArray()
 
 clear();
 
+if (i) delete [] i;
+
 }
 
 
@@ -471,6 +473,8 @@ void IdentifierArray::assign(const IdentifierArray & a)
 clear();
 
 int j;
+
+if (a.Nelements > Nalloc) extend(a.Nelements);
 
 Nelements = a.Nelements;
 

--- a/met/src/basic/vx_config/number_stack.cc
+++ b/met/src/basic/vx_config/number_stack.cc
@@ -64,7 +64,7 @@ NumberStack::~NumberStack()
 
 {
 
-clear();
+clear(false);
 
 }
 
@@ -120,7 +120,7 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void NumberStack::clear()
+void NumberStack::clear(bool initialize)
 
 {
 
@@ -131,9 +131,11 @@ Nelements = 0;
 
 Nalloc = 0;
 
-AllocInc = default_ns_alloc_inc;
+if (initialize) {
+   AllocInc = default_ns_alloc_inc;
 
-extend(default_ns_alloc_inc);
+   extend(default_ns_alloc_inc);
+}
 
 return;
 

--- a/met/src/basic/vx_config/number_stack.h
+++ b/met/src/basic/vx_config/number_stack.h
@@ -58,7 +58,7 @@ class NumberStack {
       NumberStack(const NumberStack &);
       NumberStack & operator=(const NumberStack &);
 
-      void clear();
+      void clear(bool initialize = true);
 
       void dump(ostream &, int = 0) const;
 

--- a/met/src/basic/vx_util/data_line.cc
+++ b/met/src/basic/vx_util/data_line.cc
@@ -379,6 +379,7 @@ return ( 1 );
 int DataLine::read_fwf_line(LineDataFile * ldf, const int *wdth, int n_wdth)
 
 {
+const char *method_name = "DataLine::read_fwf_line() -> ";
 
 clear();
 
@@ -400,16 +401,26 @@ int null_char_count;
 
 null_char_count = pos = count = 0;
 
+int line_len;
 for( i=0; i<n_wdth; i++ )  {
+   line_len = wdth[i];
+   if (wdth[i] >= max_str_len) {
+      line_len = (max_str_len-1);
+      mlog << Warning
+           << "\n" << method_name << "the line length " << wdth[i] << " for "
+           << i << "-th line is bigger than allocatcated buffer ("
+           << max_str_len << ").\n\n";
+   }
 
    if ( !f )  { clear();  return ( 0 ); }
 
    ++count;
 
+   
    //
    //  get the next entry
    //
-   f.read(buf, wdth[i]);
+   f.read(buf, line_len);
 
    //
    //  store the offset to this entry
@@ -420,7 +431,7 @@ for( i=0; i<n_wdth; i++ )  {
    //
    //  store this entry
    //
-   for( j=0; j<wdth[i]; j++ )  {
+   for( j=0; j<line_len; j++ )  {
 
      Line += buf[j]; pos++;
 
@@ -433,7 +444,7 @@ for( i=0; i<n_wdth; i++ )  {
      }
      else if(buf[j] == '\n') {
         mlog << Warning
-             << "\nDataLine::read_fwf_line() -> "
+             << "\n" << method_name
              << "Encountered newline while parsing line "
              << ldf->last_line_number() + 1 << ".\n\n";
      }
@@ -450,7 +461,7 @@ for( i=0; i<n_wdth; i++ )  {
 
 if (null_char_count > 0)
    mlog << Warning
-        << "\nDataLine::read_fwf_line() -> "
+        << "\n" << method_name
         << "Encountered " << null_char_count << " null character"
         << (null_char_count==1?"":"s") << " while parsing line "
         << ldf->last_line_number() + 1 << ".\n\n";

--- a/met/src/libcode/vx_data2d_nccf/nccf_file.cc
+++ b/met/src/libcode/vx_data2d_nccf/nccf_file.cc
@@ -92,6 +92,12 @@ void NcCfFile::init_from_scratch()
   Var = (NcVarInfo *) 0;
   _time_var_info = (NcVarInfo *)NULL;
 
+  _xDim = (NcDim *)0; 
+  _yDim = (NcDim *)0;
+  _tDim = (NcDim *)0;
+  _xCoordVar = (NcVar *)0;
+  _yCoordVar = (NcVar *)0;
+
   // Close any existing file
 
   close();

--- a/met/src/tools/other/madis2nc/madis2nc.cc
+++ b/met/src/tools/other/madis2nc/madis2nc.cc
@@ -355,6 +355,8 @@ void process_madis_file(const char *madis_file) {
 
 void clean_up() {
 
+   if (summary_obs) delete summary_obs;
+   
    //
    // Close the output NetCDF file
    //

--- a/met/src/tools/other/madis2nc/madis2nc.h
+++ b/met/src/tools/other/madis2nc/madis2nc.h
@@ -150,7 +150,7 @@ static NcObsOutputData nc_out_data;
 
 static bool do_summary;
 static bool save_summary_only = false;
-static SummaryObs *summary_obs;
+static SummaryObs *summary_obs = 0;
 
 #endif   //  __MADIS2NC_H__
 

--- a/test/bin/unit_test.sh
+++ b/test/bin/unit_test.sh
@@ -19,6 +19,12 @@ else
   echo "export MET_TEST_OUTPUT=${MET_TEST_OUTPUT}"
 fi
 
+PERL_UNIT_OPTS=""
+for arg in $@; do
+  [ $arg == "-memchk" -o $arg == "memchk" ] && PERL_UNIT_OPTS="$PERL_UNIT_OPTS -memchk"
+  [ $arg == "-callchk" -o $arg == "callchk" ] && PERL_UNIT_OPTS="$PERL_UNIT_OPTS -callchk"
+done
+
 # Unit test script
 PERL_UNIT=${MET_TEST_BASE}/perl/unit.pl
 
@@ -78,9 +84,9 @@ UNIT_XML="unit_ascii2nc.xml \
 for CUR_XML in ${UNIT_XML}; do
 
   echo
-  echo "CALLING: ${PERL_UNIT} ${MET_TEST_BASE}/xml/${CUR_XML}"
+  echo "CALLING: ${PERL_UNIT} $PERL_UNIT_OPTS ${MET_TEST_BASE}/xml/${CUR_XML}"
   echo
-  ${PERL_UNIT} ${MET_TEST_BASE}/xml/${CUR_XML}
+  ${PERL_UNIT} $PERL_UNIT_OPTS ${MET_TEST_BASE}/xml/${CUR_XML}
   RET_VAL=$?
 
   # Fail on non-zero return status

--- a/test/perl/unit.pl
+++ b/test/perl/unit.pl
@@ -12,13 +12,16 @@ use Data::Dumper;
 use Time::HiRes qw( gettimeofday tv_interval );
 use Getopt::Long;
 
+
 sub usage {
-  print "usage: $0 [-log {log_file}] [-cmd] [-noexit] {test_xml}
+  print "usage: $0 [-log {log_file}] [-cmd] [-memchk] [-callchk] [-noexit] {test_xml}
 
   where:
         log: if present, write output from each test to the specified file
         cmd: if present, print the test commands but do not run them, 
                overrides -log
+     memchk: if present, activate valgrind with memcheck
+    callchk: if present, activate valgrind with callcheck
      noexit: if present, the unit tester will continue executing subsequent
                tests when a test fails
    test_xml: file containing the unit test(s) to perform
@@ -27,8 +30,9 @@ sub usage {
 }
 
 # parse the input options
-my ($mgnc, $mpnc, $file_log, $cmd_only, $noexit);
-GetOptions("log=s" => \$file_log, "cmd" => \$cmd_only, "noexit" => \$noexit)
+my ($mgnc, $mpnc, $file_log, $cmd_only, $noexit, $memchk, $callchk);
+GetOptions("log=s" => \$file_log, "cmd" => \$cmd_only, "noexit" => \$noexit,
+           "memchk" => \$memchk, "callchk" => \$callchk)
   or die "ERROR: parsing input options";
 
 # parse the input test xml file parameter
@@ -61,6 +65,9 @@ $name_wid < length($_->{"name"}) and $name_wid = length($_->{"name"}) for @tests
 
 # default return value
 my $ret_val = 0;
+my $VALGRIND_OPT_MEM ="--leak-check=full --show-leak-kinds=all --error-limit=no -v";
+my $VALGRIND_OPT_CALL ="--tool=callgrind --dump-instr=yes --simulate-cache=yes --collect-jumps=yes";
+
 
 # run each test
 for my $test (@tests){
@@ -81,6 +88,12 @@ for my $test (@tests){
   # build the text command
   my ($cmd, $ret_ok, $out_ok) = ($test->{"exec"} . $test->{"param"});
   $cmd =~ s/[ \n\t]+$//m;
+  if ($memchk) {
+    $cmd = "valgrind ".$VALGRIND_OPT_MEM." ".$cmd;
+  }
+  elsif ($callchk) {
+    $cmd = "valgrind ".$VALGRIND_OPT_CALL." ".$cmd;
+  }
   
   # if writing a command file, print the environment and command, then loop
   if( $cmd_only ){


### PR DESCRIPTION
The valgrind option is activated for unit test.

test/bin/my_unit_test.sh -memchk 
OR
test/bin/my_unit_test.sh -callchk 

test/perl/unit.pl -memchk  unit_trmm2nc.xml
OR
test/perl/unit.pl -callchk  unit_trmm2nc.xml