### PR TITLE
Update Uniform Fractions Skill Score UFSS in appendixC.rst

### DIFF
--- a/met/docs/Users_Guide/appendixC.rst
+++ b/met/docs/Users_Guide/appendixC.rst
@@ -1007,7 +1007,7 @@ Uniform Fractions Skill Score
 
 Called "UFSS" in NBRCNT output :numref:`table_GS_format_info_NBRCNT`
 
-The Uniform Fractions Skill Score (UFSS) is a reference statistic for the Fractions Skill score based on a uniform distribution of the total forecast events across the grid. This no-skill forecast defines the UFSS, and thus a skilled forecast must have a higher value of FSS than the UFSS. Again, the formula is the same as for FSS as above, the forecast proportion in each neighborhood is the same, and is equivalent to the overall forecast event proportion.
+The Uniform Fractions Skill Score (UFSS) is a reference statistic for the Fractions Skill score based on a uniform distribution of the total observed events across the grid. UFSS represents the FSS that would be obtained at the grid scale from a forecast with a fraction/probability equal to the total observed event proportion at every point. The formula is :math:`UFSS = (1 + f_o)/2` (i.e., halfway between perfect skill and random forecast skill) where :math:`f_o` is the total observed event proportion (i.e. observation rate).
 
 Forecast Rate
 ~~~~~~~~~~~~~


### PR DESCRIPTION
In Roberts and Lean 2008, UFSS is defined as 0.5 +􏰆 fo/2 where fo is observed frequency (fraction of observed points exceeding the threshold over the domain)--see Section 2d, halfway down the right column of page 83.  The critical word is observed.  

However, the User's Guide v9.0.3 it says UFSS is equivalent to the forecast event proportion--a subtle but important difference if there is any forecast frequency bias. UFSS will differ depending on if it is based on observed event proportion or forecasted event proportion. 

Now, I do believe, behind the scenes, MET based the UFSS on the observed frequency, consistent with Roberts and Lean 2008. Only the User's Guide needs to be revised.

I also revised the description of UFSS and formulation to match Roberts and Lean 2008. UFSS is simply halfway between perfect skill (unity) and a random FSS (equal to observed event proportion).