### PR TITLE
Feature 1498 autoconf

### DIFF
--- a/met/src/tools/dev_utils/Makefile.am
+++ b/met/src/tools/dev_utils/Makefile.am
@@ -3,6 +3,7 @@
 ## @end 1
 
 MAINTAINERCLEANFILES	= Makefile.in
+AUTOMAKE_OPTIONS	= subdir-objects
 
 # Include the project definitions
 


### PR DESCRIPTION
This is just a one-line fix to a singe file to resolve warning messages from bootstrap.