### PR TITLE
feature 1514 logging

### DIFF
--- a/met/src/libcode/vx_statistics/pair_data_ensemble.cc
+++ b/met/src/libcode/vx_statistics/pair_data_ensemble.cc
@@ -1304,8 +1304,7 @@ void VxPairDataEnsemble::add_point_obs(float *hdr_arr, int *hdr_typ_arr,
    if((sid_inc_filt.n() && !sid_inc_filt.has(hdr_sid_str)) ||
       (sid_exc_filt.n() &&  sid_exc_filt.has(hdr_sid_str))) return;
 
-   // Check whether the GRIB code for the observation matches
-   // the specified code (rej_gc)
+   // Check whether the observation variable name matches (rej_var)
    if ((var_name != 0) && (0 < strlen(var_name))) {
       if ( var_name != obs_info->name() ) {
          return;

--- a/met/src/libcode/vx_statistics/pair_data_point.cc
+++ b/met/src/libcode/vx_statistics/pair_data_point.cc
@@ -317,7 +317,7 @@ void VxPairDataPoint::clear() {
 
    n_try       = 0;
    rej_sid     = 0;
-   rej_gc      = 0;
+   rej_var     = 0;
    rej_vld     = 0;
    rej_obs     = 0;
    rej_grd     = 0;
@@ -793,12 +793,12 @@ void VxPairDataPoint::add_point_obs(float *hdr_arr, const char *hdr_typ_str,
    // the specified code
    if((var_name != 0) && (0 < strlen(var_name))) {
       if ( var_name != obs_info->name() ) {
-         rej_gc++;
+         rej_var++;
          return;
       }
    }
    else if(obs_info->code() != nint(obs_arr[1])) {
-      rej_gc++;
+      rej_var++;
       return;
    }
 

--- a/met/src/libcode/vx_statistics/pair_data_point.h
+++ b/met/src/libcode/vx_statistics/pair_data_point.h
@@ -151,7 +151,7 @@ class VxPairDataPoint {
       //  Counts for observation rejection reason codes
       int n_try;                 // Number of observations processed
       int rej_sid;               // Reject based on SID inclusion and exclusion lists
-      int rej_gc;                // Reject based on GRIB code
+      int rej_var;               // Reject based on observation variable name
       int rej_vld;               // Reject based on valid time
       int rej_obs;               // Reject observation bad data
       int rej_grd;               // Reject based on location

--- a/met/src/tools/core/point_stat/point_stat.cc
+++ b/met/src/tools/core/point_stat/point_stat.cc
@@ -1009,7 +1009,7 @@ void process_scores() {
                     << "Number of matched pairs   = " << pd_ptr->n_obs << "\n"
                     << "Observations processed    = " << conf_info.vx_opt[i].vx_pd.n_try << "\n"
                     << "Rejected: station id      = " << conf_info.vx_opt[i].vx_pd.rej_sid << "\n"
-                    << "Rejected: obs type        = " << conf_info.vx_opt[i].vx_pd.rej_gc << "\n"
+                    << "Rejected: obs var name    = " << conf_info.vx_opt[i].vx_pd.rej_var << "\n"
                     << "Rejected: valid time      = " << conf_info.vx_opt[i].vx_pd.rej_vld << "\n"
                     << "Rejected: bad obs value   = " << conf_info.vx_opt[i].vx_pd.rej_obs << "\n"
                     << "Rejected: off the grid    = " << conf_info.vx_opt[i].vx_pd.rej_grd << "\n"


### PR DESCRIPTION
Julie, this is a quick and easy one from met-help. After making the change, the log message from Point-Stat now reads:

DEBUG 2: Processing TMP/P900-750 versus TMP/P900-750, for observation type ADPUPA, over region DTC165, for interpolation method NEAREST(1), using 132 matched pairs.
...
DEBUG 3: Rejected: obs var name    = 79788
...

Figured this would be an opportunity to try out GitHub's PR review tools.