### PR TITLE
Feature 1492 nc_unsigned_data_type

### DIFF
--- a/met/src/libcode/vx_data2d_nc_pinterp/get_pinterp_grid.cc
+++ b/met/src/libcode/vx_data2d_nc_pinterp/get_pinterp_grid.cc
@@ -1,5 +1,3 @@
-
-
 // *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 // ** Copyright UCAR (c) 1992 - 2020
 // ** University Corporation for Atmospheric Research (UCAR)
@@ -7,9 +5,6 @@
 // ** Research Applications Lab (RAL)
 // ** P.O.Box 3000, Boulder, Colorado, 80307-3000, USA
 // *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
-
-
-
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -147,7 +142,7 @@ data.name = ps_default_gridname;
    //  scale latitude
    //
 
-get_global_att_double(&nc, (string)"TRUELAT1", data.scale_lat, true);
+get_global_att(&nc, (string)"TRUELAT1", data.scale_lat, true);
 
    //
    //  hemisphere ... assume north?
@@ -167,8 +162,8 @@ get_dim(&nc, ny_dimension_name, data.ny, true);
    //  pin point
    //
 
-get_global_att_double(&nc, (string)"CEN_LAT", data.lat_pin, true);
-get_global_att_double(&nc, (string)"CEN_LON", data.lon_pin, true);
+get_global_att(&nc, (string)"CEN_LAT", data.lat_pin, true);
+get_global_att(&nc, (string)"CEN_LON", data.lon_pin, true);
 data.lon_pin *= -1.0;
 
 data.x_pin = 0.5*(data.nx - 1.0);
@@ -178,14 +173,14 @@ data.y_pin = 0.5*(data.ny - 1.0);
    //  orientation longitude
    //
 
-get_global_att_double(&nc, (string)"STAND_LON", data.lon_orient, true);
+get_global_att(&nc, (string)"STAND_LON", data.lon_orient, true);
 data.lon_orient *= -1.0;
 
    //
    //  D, R
    //
 
-get_global_att_double(&nc, (string)"DX", data.d_km, true);
+get_global_att(&nc, (string)"DX", data.d_km, true);
 data.d_km *= 0.001;
 
 data.r_km = default_grib_radius_km;
@@ -223,8 +218,8 @@ data.name = lambert_default_gridname;
    //  scale latitude(s)
    //
 
-get_global_att_double(&nc, (string)"TRUELAT1", data.scale_lat_1, true);
-get_global_att_double(&nc, (string)"TRUELAT2", data.scale_lat_2, true);
+get_global_att(&nc, (string)"TRUELAT1", data.scale_lat_1, true);
+get_global_att(&nc, (string)"TRUELAT2", data.scale_lat_2, true);
 
    //
    //  hemisphere ... assume north?
@@ -244,8 +239,8 @@ get_dim(&nc, ny_dimension_name, data.ny, true);
    //  pin point
    //
 
-get_global_att_double(&nc, (string)"CEN_LAT", data.lat_pin, true);
-get_global_att_double(&nc, (string)"CEN_LON", data.lon_pin, true);
+get_global_att(&nc, (string)"CEN_LAT", data.lat_pin, true);
+get_global_att(&nc, (string)"CEN_LON", data.lon_pin, true);
 data.lon_pin *= -1.0;
 
 data.x_pin = 0.5*(data.nx - 1.0);
@@ -255,14 +250,14 @@ data.y_pin = 0.5*(data.ny - 1.0);
    //  orientation longitude
    //
 
-get_global_att_double(&nc, (string)"STAND_LON", data.lon_orient, true);
+get_global_att(&nc, (string)"STAND_LON", data.lon_orient, true);
 data.lon_orient *= -1.0;
 
    //
    //  D, R
    //
 
-get_global_att_double(&nc, (string)"DX", data.d_km, true);
+get_global_att(&nc, (string)"DX", data.d_km, true);
 data.d_km *= 0.001;
 
 data.r_km = default_grib_radius_km;
@@ -317,22 +312,22 @@ get_dim(&nc, ny_dimension_name, data.ny, true);
    //  center lat, lon
    //
 
-get_global_att_double(&nc, (string)"CEN_LAT", lat_center, true);
-get_global_att_double(&nc, (string)"CEN_LON", lon_center, true);
+get_global_att(&nc, (string)"CEN_LAT", lat_center, true);
+get_global_att(&nc, (string)"CEN_LON", lon_center, true);
 lon_center *= -1.0;
 
    //
    //  D_km
    //
 
-get_global_att_double(&nc, (string)"DX", D_km, true);
+get_global_att(&nc, (string)"DX", D_km, true);
 D_km *= 0.001;
 
    //
    //  scale latitude
    //
 
-get_global_att_double(&nc, (string)"TRUELAT1", scale_lat, true);
+get_global_att(&nc, (string)"TRUELAT1", scale_lat, true);
 
    //
    //  do some calculations

--- a/met/src/libcode/vx_nc_util/nc_utils.cc
+++ b/met/src/libcode/vx_nc_util/nc_utils.cc
@@ -1406,18 +1406,12 @@ bool get_nc_data(NcVar *var, float *data) {
          float add_offset = 0.;
          float scale_factor = 1.;
          int unpacked_count = 0;
-         bool unsigned_value = false;
+         bool unsigned_value = has_unsigned_attribute(var);
          NcVarAtt *att_add_offset   = get_nc_att(var, string("add_offset"));
          NcVarAtt *att_scale_factor = get_nc_att(var, string("scale_factor"));
-         NcVarAtt *att_unsigned     = get_nc_att(var, string("_Unsigned"));
          NcVarAtt *att_fill_value   = get_nc_att(var, string("_FillValue"));
          if (IS_VALID_NC_P(att_add_offset)) add_offset = get_att_value_float(att_add_offset);
          if (IS_VALID_NC_P(att_scale_factor)) scale_factor = get_att_value_float(att_scale_factor);
-         if (IS_VALID_NC_P(att_unsigned)) {
-            ConcatString att_value;
-            get_att_value_chars(att_unsigned, att_value);
-            unsigned_value = ( att_value == "true" );
-         }
          mlog << Debug(4) << method_name << "add_offset = " << add_offset
               << ", scale_factor=" << scale_factor << ", cell_count=" << cell_count
               << ", is_unsigned_value: " << unsigned_value << "\n";
@@ -1592,7 +1586,6 @@ bool get_nc_data(NcVar *var, float *data) {
          }
          if(att_add_offset) delete att_add_offset;
          if(att_scale_factor) delete att_scale_factor;
-         if(att_unsigned) delete att_unsigned;
          if(att_fill_value) delete att_fill_value;
       }
       return_status = true;
@@ -1696,21 +1689,15 @@ bool get_nc_data(NcVar *var, double *data) {
 
          double add_offset = 0.;
          double scale_factor = 1.;
-         bool unsigned_value = false;
+         bool unsigned_value = has_unsigned_attribute(var);
          NcVarAtt *att_add_offset   = get_nc_att(var, (string)"add_offset");
          NcVarAtt *att_scale_factor = get_nc_att(var, (string)"scale_factor");
-         NcVarAtt *att_unsigned     = get_nc_att(var, (string)"_Unsigned");
          NcVarAtt *att_fill_value   = get_nc_att(var, (string)"_FillValue");
          if (IS_VALID_NC_P(att_add_offset)) {
             add_offset = get_att_value_double(att_add_offset);
          }
          if (IS_VALID_NC_P(att_scale_factor)) {
             scale_factor = get_att_value_double(att_scale_factor);
-         }
-         if (IS_VALID_NC_P(att_unsigned)) {
-            ConcatString att_value;
-            get_att_value_chars(att_unsigned, att_value);
-            unsigned_value = ("true" == att_value);
          }
          mlog << Debug(4) << method_name << "add_offset = " << add_offset
               << ", scale_factor=" << scale_factor << ", cell_count=" << cell_count
@@ -1885,7 +1872,6 @@ bool get_nc_data(NcVar *var, double *data) {
          }
          if(att_add_offset) delete att_add_offset;
          if(att_scale_factor) delete att_scale_factor;
-         if(att_unsigned) delete att_unsigned;
          if(att_fill_value) delete att_fill_value;
       }
       return_status = true;

--- a/met/src/libcode/vx_nc_util/nc_utils.cc
+++ b/met/src/libcode/vx_nc_util/nc_utils.cc
@@ -63,61 +63,55 @@ bool get_att_value(const NcAtt *att, ConcatString &value) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_att_value(const NcAtt *att, int &att_val) {
+template <typename T>
+bool _get_att_num_value(const NcAtt *att, T &att_val, int matching_type) {
    bool status = false;
    if (IS_VALID_NC_P(att)) {
       int nc_type_id = GET_NC_TYPE_ID_P(att);
-      if (NC_INT == nc_type_id) {
+      if (matching_type == nc_type_id) {
          att->getValues(&att_val);
          status = true;
       }
       else if (NC_CHAR == nc_type_id) {
          string att_value;
          att->getValues(att_value);
-         att_val = atoi(att_value.c_str());
+         if (matching_type == NC_FLOAT)
+            att_val = atof(att_value.c_str());
+         else if (matching_type == NC_DOUBLE)
+            att_val = (double)atof(att_value.c_str());
+         else // if (matching_type == NC_INT)
+            att_val = atoi(att_value.c_str());
          status = true;
       }
    }
+   return(status);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool get_att_value(const NcAtt *att, int &att_val) {
+   bool status = _get_att_num_value(att, att_val, NC_INT);
+   return(status);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool get_att_value(const NcAtt *att, unsigned int &att_val) {
+   bool status = _get_att_num_value(att, att_val, NC_UINT);
    return(status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_att_value(const NcAtt *att, float &att_val) {
-   bool status = false;
-   if (IS_VALID_NC_P(att)) {
-      int nc_type_id = GET_NC_TYPE_ID_P(att);
-      if (NC_FLOAT == nc_type_id) {
-         att->getValues(&att_val);
-         status = true;
-      }
-      else if (NC_CHAR == nc_type_id) {
-         string att_value;
-         att->getValues(att_value);
-         att_val = atof(att_value.c_str());
-         status = true;
-      }
-   }
+   bool status = _get_att_num_value(att, att_val, NC_FLOAT);
    return(status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_att_value(const NcAtt *att, double &att_val) {
-   bool status = false;
-   if (IS_VALID_NC_P(att)) {
-      int nc_type_id = GET_NC_TYPE_ID_P(att);
-      if (NC_FLOAT == nc_type_id) {
-         att->getValues(&att_val);
-         status = true;
-      }
-      else if (NC_CHAR == nc_type_id) {
-         string att_value;
-         att->getValues(att_value);
-         att_val = (double)atof(att_value.c_str());
-         status = true;
-      }
-   }
+   bool status = _get_att_num_value(att, att_val, NC_DOUBLE);
    return(status);
 }
 
@@ -125,9 +119,10 @@ bool get_att_value(const NcAtt *att, double &att_val) {
 
 int get_att_value_int(const NcAtt *att) {
    int value = bad_data_int;
+   static const char *method_name = "get_att_value_int(NcAtt) -> ";
    switch (att->getType().getId()) {
       case NC_BYTE:
-         signed char b_value;
+         ncbyte b_value;
          att->getValues(&b_value);
          value = (int)b_value;
          break;
@@ -144,14 +139,14 @@ int get_att_value_int(const NcAtt *att) {
          att->getValues(&l_value);
          value = (int)l_value;
          if ((long long)value != l_value) {
-            mlog << Warning << "\nget_att_value_int() -> "
+            mlog << Warning << "\n" << method_name
                  << "loosing precision during type conversion. "
                  << value << " from int64 \"" << l_value
                  << "\" for attribute \"" << GET_SAFE_NC_NAME_P(att) << "\".\n\n";
          }
          break;
       default:
-         mlog << Warning << "\nget_att_value_int() -> "
+         mlog << Warning << "\n" << method_name
               << "data type mismatch (int vs. \"" << GET_NC_TYPE_NAME_P(att)
               << "\" for attribute \"" << GET_SAFE_NC_NAME_P(att) << "\".\n\n";
          break;
@@ -163,13 +158,14 @@ int get_att_value_int(const NcAtt *att) {
 
 char get_att_value_char(const NcAtt *att) {
    char att_val = bad_data_char;
+   static const char *method_name = "get_att_value_char(NcAtt) -> ";
    if (IS_VALID_NC_P(att)) {
       nc_type attType = GET_NC_TYPE_ID_P(att);
       if (attType == NC_CHAR) {
          att->getValues(&att_val);
       }
       else {
-         mlog << Error << "\nget_att_value_char(NcAtt) -> "
+         mlog << Error << "\n" << method_name
               << "Please convert data type of \"" << GET_NC_NAME_P(att)
               << "\" to NC_CHAR type.\n\n";
          exit(1);
@@ -182,6 +178,7 @@ char get_att_value_char(const NcAtt *att) {
 
 bool get_att_value_chars(const NcAtt *att, ConcatString &value) {
    bool status = false;
+   static const char *method_name = "get_att_value_chars(NcAtt) -> ";
    if (IS_VALID_NC_P(att)) {
       nc_type attType = GET_NC_TYPE_ID_P(att);
       if (attType == NC_CHAR) {
@@ -190,7 +187,7 @@ bool get_att_value_chars(const NcAtt *att, ConcatString &value) {
          value = att_value;
       }
       else { // MET-788: to handle a custom modified NetCDF
-         mlog << Error << "\nget_att_value_chars(NcAtt) -> "
+         mlog << Error << "\n" << method_name
               << "Please convert data type of \"" << GET_NC_NAME_P(att)
               << "\" to NC_CHAR type.\n\n";
          exit(1);
@@ -245,6 +242,12 @@ float get_att_value_float(const NcAtt *att) {
 
 short get_att_value_short(const NcAtt *att) {
    short value = bad_data_int;
+   att->getValues(&value);
+   return value;
+}
+
+unsigned short get_att_value_ushort(const NcAtt *att) {
+   unsigned short value = bad_data_int;
    att->getValues(&value);
    return value;
 }
@@ -340,7 +343,7 @@ bool    get_att_no_leap_year(const NcVar *var) {
 
 ////////////////////////////////////////////////////////////////////////
 
-ConcatString get_nc_att_log(const NcVarAtt *att) {
+ConcatString get_log_msg_for_att(const NcVarAtt *att) {
    ConcatString log_msg("can't read attribute");
    if(IS_INVALID_NC_P(att)) {
       log_msg << " because attribute does not exist";
@@ -355,8 +358,8 @@ ConcatString get_nc_att_log(const NcVarAtt *att) {
 
 ////////////////////////////////////////////////////////////////////////
 
-ConcatString get_nc_att_log(const NcVarAtt *att, string var_name,
-                            const ConcatString att_name) {
+ConcatString get_log_msg_for_att(const NcVarAtt *att, string var_name,
+                             const ConcatString att_name) {
    ConcatString log_msg;
    log_msg << "can't read attribute" << " \""
            << ((att_name.length() > 0) ? att_name.c_str() : GET_SAFE_NC_NAME_P(att))
@@ -469,13 +472,14 @@ bool get_nc_att_value(const NcVar *var, const ConcatString &att_name,
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_att_value(const NcVar *var, const ConcatString &att_name,
-                      int &att_val, bool exit_on_error) {
+template <typename T>
+bool _get_nc_att_value(const NcVar *var, const ConcatString &att_name,
+                       T &att_val, bool exit_on_error,
+                       T bad_data, const char *caller_name) {
    bool status = false;
-   static const char *method_name = "get_nc_att_value(NcVar,int) -> ";
 
    // Initialize
-   att_val = bad_data_int;
+   att_val = bad_data;
 
    //
    // Retrieve the NetCDF variable attribute.
@@ -483,13 +487,12 @@ bool get_nc_att_value(const NcVar *var, const ConcatString &att_name,
    NcVarAtt *att = get_nc_att(var, att_name);
    status = get_att_value((NcAtt *)att, att_val);
    if (!status) {
-      mlog << Error << "\n" << method_name
-           << get_nc_att_log(att, GET_SAFE_NC_NAME_P(var), att_name);
-      if (att) {
-         delete att;
-         att = (NcVarAtt *)0;
+      mlog << Error << "\n" << caller_name
+           << get_log_msg_for_att(att, GET_SAFE_NC_NAME_P(var), att_name);
+      if (exit_on_error) {
+         if (att) delete att;
+         exit(1);
       }
-      if (exit_on_error) exit(1);
    }
    if (att) delete att;
 
@@ -499,29 +502,20 @@ bool get_nc_att_value(const NcVar *var, const ConcatString &att_name,
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_att_value(const NcVar *var, const ConcatString &att_name,
+                      int &att_val, bool exit_on_error) {
+   static const char *method_name = "get_nc_att_value(NcVar,int) -> ";
+   bool status = _get_nc_att_value(var, att_name, att_val, exit_on_error,
+                                   bad_data_int, method_name);
+   return(status);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool get_nc_att_value(const NcVar *var, const ConcatString &att_name,
                       float &att_val, bool exit_on_error) {
-   bool status = true;
    static const char *method_name = "get_nc_att_value(NcVar,float) -> ";
-
-   // Initialize
-   att_val = bad_data_float;
-
-   //
-   // Retrieve the NetCDF variable attribute.
-   //
-   NcVarAtt *att = get_nc_att(var, att_name);
-   status = get_att_value((NcAtt *)att, att_val);
-   if (!status) {
-      mlog << Error << "\n" << method_name
-           << get_nc_att_log(att, GET_SAFE_NC_NAME_P(var), att_name);
-      if (att) {
-         delete att;
-         att = (NcVarAtt *)0;
-      }
-      if (exit_on_error) exit(1);
-   }
-   if (att) delete att;
-
+   bool status = _get_nc_att_value(var, att_name, att_val, exit_on_error,
+                                   bad_data_float, method_name);
    return(status);
 }
 
@@ -546,67 +540,48 @@ bool get_nc_att_value(const NcVarAtt *att, ConcatString &att_val) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_att_value(const NcVarAtt *att, int &att_val, bool exit_on_error) {
+template <typename T>
+bool _get_nc_att_value(const NcVarAtt *att, T &att_val, bool exit_on_error,
+                       T bad_data, const char *caller_name) {
    bool status = true;
-   string attr_value;
-   static const char *method_name = "get_nc_att_value(NcVarAtt,int) -> ";
 
    // Initialize
-   att_val = bad_data_int;
+   att_val = bad_data;
 
    //
    // Retrieve the NetCDF variable attribute.
    //
    status = get_att_value((NcAtt *)att, att_val);
    if (!status) {
-      mlog << Error << "\n" << method_name
-           << get_nc_att_log(att);
+      mlog << Error << "\n" << caller_name << get_log_msg_for_att(att);
 
       if (exit_on_error) exit(1);
    }
 
+   return(status);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool get_nc_att_value(const NcVarAtt *att, int &att_val, bool exit_on_error) {
+   static const char *method_name = "get_nc_att_value(NcVarAtt,int) -> ";
+   bool status = _get_nc_att_value(att, att_val, exit_on_error, bad_data_int, method_name);
    return(status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_att_value(const NcVarAtt *att, float &att_val, bool exit_on_error) {
-   bool status = true;
-
-   // Initialize
-   att_val = bad_data_float;
-
-   //
-   // Retrieve the NetCDF variable attribute.
-   //
-   status = get_att_value((NcAtt *)att, att_val);
-   if (!status) {
-      mlog << Error << "\nget_nc_att_value(float) -> "
-           << get_nc_att_log(att);
-      if (exit_on_error) exit(1);
-   }
-
+   static const char *method_name = "get_nc_att_value(NcVarAtt,float) -> ";
+   bool status = _get_nc_att_value(att, att_val, exit_on_error, bad_data_float, method_name);
    return(status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_att_value(const NcVarAtt *att, double &att_val, bool exit_on_error) {
-   bool status = true;
-
-   // Initialize
-   att_val = bad_data_double;
-
-   //
-   // Retrieve the NetCDF variable attribute.
-   //
-   status = get_att_value((NcAtt *)att, att_val);
-   if (!status) {
-      mlog << Error << "\nget_nc_att_value(double) -> "
-           << get_nc_att_log(att);
-      if (exit_on_error) exit(1);
-   }
-
+   static const char *method_name = "get_nc_att_value(NcVarAtt,double) -> ";
+   bool status = _get_nc_att_value(att, att_val, exit_on_error, bad_data_double, method_name);
    return(status);
 }
 
@@ -622,11 +597,31 @@ bool has_att(NcFile * ncfile, const ConcatString att_name, bool exit_on_error)
       status = true;
    } else if(exit_on_error)  {
       mlog << Error << "\nhas_att() -> "
-           << "can't find global NetCDF attribute " << att_name << ".\n\n";
+           << "can't find global NetCDF attribute " << att_name
+           << ".\n\n";
       exit ( 1 );
    }
    if (att) delete att;
    return status;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool has_unsigned_attribute(NcVar *var) {
+   bool is_unsigned = false;
+   static const char *method_name = "has_unsigned_attribute() -> ";
+   NcVarAtt *att_unsigned     = get_nc_att(var, string("_Unsigned"));
+   if (IS_VALID_NC_P(att_unsigned)) {
+      ConcatString att_value;
+      get_att_value_chars(att_unsigned, att_value);
+      is_unsigned = ( att_value == "true" );
+   }
+   if(att_unsigned) delete att_unsigned;
+   mlog << Debug(6) << method_name
+        << GET_NC_NAME_P(var) << " " << (is_unsigned ? "has " : "does not have" )
+        << " _Unsigned attribute.\n";
+
+   return is_unsigned;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -716,31 +711,44 @@ bool get_global_att(const NcFile *nc, const ConcatString &att_name,
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_global_att(const NcFile *nc, const ConcatString& att_name,
-                    int &att_val, bool error_out) {
+template <typename T>
+bool _get_global_att_value(const NcFile *nc, const ConcatString& att_name,
+                     T &att_val, T bad_data, bool error_out, const char *caller_name) {
    bool status = false;
-   static const char *method_name = "\nget_global_att(int) -> ";
 
    // Initialize
-   att_val = bad_data_int;
+   att_val = bad_data;
 
    NcGroupAtt *nc_att = get_nc_att(nc, att_name);
    status = get_att_value((NcAtt *)nc_att, att_val);
+   string data_type = (IS_INVALID_NC_P(nc_att) ? C_unknown_str : GET_NC_TYPE_NAME_P(nc_att));
+   if (nc_att) delete nc_att;
    // Check error_out status
    if(error_out && !status) {
       if (IS_INVALID_NC_P(nc_att)) {
-         mlog << Error << method_name
+         mlog << Error << caller_name
               << "can't find global NetCDF attribute \"" << att_name
               << "\".\n\n";
       }
       else {
-         mlog << Error << method_name
-              << "The data type \"" << GET_NC_TYPE_NAME_P(nc_att)
+         mlog << Error << caller_name
+              << "The data type \"" << data_type
               << "\" for \"" << att_name << "\" is not supported...\n\n";
       }
       exit(1);
    }
-   if (nc_att) delete nc_att;
+
+   return(status);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+
+bool get_global_att(const NcFile *nc, const ConcatString& att_name,
+                    int &att_val, bool error_out) {
+   static const char *method_name = "\nget_global_att(int) -> ";
+   bool status = _get_global_att_value(nc, att_name, att_val, bad_data_int,
+                                       error_out, method_name);
 
    return(status);
 }
@@ -763,8 +771,7 @@ bool get_global_att(const NcFile *nc, const ConcatString& att_name,
    // Check error_out status
    if(error_out && !status) {
       mlog << Error << "\nget_global_att(int) -> "
-           << "can't find global NetCDF attribute \"" << att_name
-           << "\".\n\n";
+           << "can't find global NetCDF attribute \"" << att_name << "\".\n\n";
       exit(1);
    }
 
@@ -775,29 +782,9 @@ bool get_global_att(const NcFile *nc, const ConcatString& att_name,
 
 bool get_global_att(const NcFile *nc, const ConcatString& att_name,
                     float &att_val, bool error_out) {
-   bool status = false;
    static const char *method_name = "\nget_global_att(float) -> ";
-
-   // Initialize
-   att_val = bad_data_float;
-
-   NcGroupAtt *nc_att = get_nc_att(nc, att_name);
-   status = get_att_value((NcAtt *)nc_att, att_val);
-   // Check error_out status
-   if(error_out && !status) {
-      if (IS_INVALID_NC_P(nc_att)) {
-         mlog << Error << method_name
-              << "can't find global NetCDF attribute \"" << att_name
-              << "\".\n\n";
-      }
-      else {
-         mlog << Error << method_name
-              << "The data type \"" << GET_NC_TYPE_NAME_P(nc_att)
-              << "\" for \"" << att_name << "\" is not supported.\n\n";
-      }
-      exit(1);
-   }
-   if (nc_att) delete nc_att;
+   bool status = _get_global_att_value(nc, att_name, att_val, bad_data_float,
+                                       error_out, method_name);
 
    return(status);
 }
@@ -806,61 +793,11 @@ bool get_global_att(const NcFile *nc, const ConcatString& att_name,
 
 bool get_global_att(const NcFile *nc, const ConcatString& att_name,
                     double &att_val, bool error_out) {
-   bool status = false;
-   bool exit_on_error = true;
    static const char *method_name = "\nget_global_att(double) -> ";
-
-   // Initialize
-   att_val = bad_data_double;
-
-   NcGroupAtt *nc_att = get_nc_att(nc, att_name);
-   status = get_att_value((NcAtt *)nc_att, att_val);
-   // Check error_out status
-   if(error_out && !status) {
-      if (IS_INVALID_NC_P(nc_att)) {
-         mlog << Error << method_name
-              << "can't find global NetCDF attribute \"" << att_name
-              << "\".\n\n";
-      }
-      else {
-         mlog << Error << method_name
-              << "The data type \"" << GET_NC_TYPE_NAME_P(nc_att)
-              << "\" for \"" << att_name << "\" is not supported.\n\n";
-      }
-      exit(1);
-   }
-   if (nc_att) delete nc_att;
+   bool status = _get_global_att_value(nc, att_name, att_val, bad_data_double,
+                                       error_out, method_name);
 
    return (status);
-}
-
-////////////////////////////////////////////////////////////////////////
-
-bool get_global_att_double(const NcFile *nc, const ConcatString &att_name,
-                           double &att_val, bool error_out) {
-   NcGroupAtt *att;
-   bool status = false;
-
-   // Initialize
-   att_val = bad_data_double;
-
-   att = get_nc_att(nc, att_name);
-
-   if(IS_VALID_NC_P(att)) {
-      att->getValues(&att_val);
-      status = true;
-   }
-   if (att) delete att;
-
-   // Check error_out status
-   if(error_out && !status) {
-      mlog << Error << "\nget_global_att_double() -> "
-           << "can't find global NetCDF attribute \"" << att_name
-           << "\".\n\n";
-      exit(1);
-   }
-
-   return(status);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -876,58 +813,55 @@ int get_version_no(const NcFile *nc) {
 ////////////////////////////////////////////////////////////////////////
 
 bool is_version_less_than_1_02(const NcFile *nc) {
-   int version_no;
-   float att_version_no;
-   get_global_att(nc, (const ConcatString) nc_att_obs_version, att_version_no);
-   version_no = (int)(att_version_no * 100);
+   int version_no = get_version_no(nc);
    return (version_no < 102);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-void add_att(NcFile *nc, const string att_name, const int att_val) {
+void add_att(NcFile *nc, const string &att_name, const int att_val) {
    nc->putAtt(att_name, NcType::nc_INT, att_val);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-void add_att(NcFile *nc, const string att_name, const string att_val) {
+void add_att(NcFile *nc, const string &att_name, const string att_val) {
    nc->putAtt(att_name, att_val);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-void add_att(NcFile *nc, const string att_name, const char *att_val) {
+void add_att(NcFile *nc, const string &att_name, const char *att_val) {
    nc->putAtt(att_name, att_val);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-void add_att(NcFile *nc, const string att_name, const ConcatString att_val) {
+void add_att(NcFile *nc, const string &att_name, const ConcatString att_val) {
   nc->putAtt(att_name, att_val.text());
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-void add_att(NcVar *var, const string att_name, const string att_val) {
+void add_att(NcVar *var, const string &att_name, const string att_val) {
    var->putAtt(att_name, att_val);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-void add_att(NcVar *var, const string att_name, const int att_val) {
+void add_att(NcVar *var, const string &att_name, const int att_val) {
    var->putAtt(att_name, NcType::nc_INT, att_val);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-void add_att(NcVar *var, const string att_name, const float att_val) {
+void add_att(NcVar *var, const string &att_name, const float att_val) {
    var->putAtt(att_name, NcType::nc_FLOAT, att_val);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-void add_att(NcVar *var, const string att_name, const double att_val) {
+void add_att(NcVar *var, const string &att_name, const double att_val) {
    var->putAtt(att_name, NcType::nc_DOUBLE, att_val);
 }
 
@@ -952,25 +886,25 @@ int get_var_names(NcFile *nc, StringArray *varNames) {
 
    if (i != varCount) {
       mlog << Error << "\n\tget_var_names() -> "
-           << "does not match array, allocated " << varCount << " but assigned " << i << ".\n\n";
+           << "does not match array, allocated " << varCount << " but assigned "
+           << i << ".\n\n";
    }
    return(varCount);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_var_att_double(const NcVar *var, const ConcatString &att_name,
-                        double &att_val) {
-   NcVarAtt *att;
+template <typename T>
+bool _get_var_att_num(const NcVar *var, const ConcatString &att_name,
+                      T &att_val, T bad_data) {
    bool status = false;
 
    // Initialize
-   att_val = bad_data_double;
+   att_val = bad_data;
 
-   att = get_nc_att(var, att_name);
-
+   NcVarAtt *att = get_nc_att(var, att_name);
    // Look for a match
-   if (!IS_INVALID_NC_P(att)) {
+   if (IS_VALID_NC_P(att)) {
       att->getValues(&att_val);
       status = true;
    }
@@ -981,22 +915,18 @@ bool get_var_att_double(const NcVar *var, const ConcatString &att_name,
 
 ////////////////////////////////////////////////////////////////////////
 
+bool get_var_att_double(const NcVar *var, const ConcatString &att_name,
+                        double &att_val) {
+   bool status = _get_var_att_num(var, att_name, att_val, bad_data_double);
+
+   return(status);
+}
+
+////////////////////////////////////////////////////////////////////////
+
 bool get_var_att_float(const NcVar *var, const ConcatString &att_name,
                        float &att_val) {
-   NcVarAtt *att;
-   bool status = false;
-
-   // Initialize
-   att_val = bad_data_float;
-
-   att = get_nc_att(var, att_name);
-
-   // Look for a match
-   if (!IS_INVALID_NC_P(att)) {
-      att->getValues(&att_val);
-      status = true;
-   }
-   if (att) delete att;
+   bool status = _get_var_att_num(var, att_name, att_val, bad_data_float);
 
    return(status);
 }
@@ -1178,7 +1108,6 @@ double get_double_var(NcVar * var, const int index) {
                  << "\").\nIt won't be converted because of dimension issue.\n"
                  << "Please correct the data type to double for variable \"" << GET_NC_NAME_P(var) << "\".\n\n";
             exit(1);
-            break;
       }
    }
 
@@ -1211,22 +1140,32 @@ float get_float_var(NcVar * var, const int index) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcFile *nc, const char *var_name, int *data,
+template <typename T>
+bool _get_nc_data(NcFile *nc, const char *var_name, T *data,
                  const long *dim, const long *cur) {
 
    //
    // Retrieve the input variables
    //
-   NcVar var    = get_var(nc, var_name);
+   NcVar var = get_var(nc, var_name);
    return get_nc_data(&var, data, dim, cur);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, time_t *data) {
+bool get_nc_data(NcFile *nc, const char *var_name, int *data,
+                 const long *dim, const long *cur) {
+
+   return _get_nc_data(nc, var_name, data, dim, cur);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+bool _get_nc_data(NcVar *var, T *data) {
    bool return_status = false;
 
-   if (!IS_INVALID_NC_P(var)) {
+   if (IS_VALID_NC_P(var)) {
       //
       // Retrieve the float value from the NetCDF variable.
       // Note: missing data was checked here
@@ -1234,20 +1173,46 @@ bool get_nc_data(NcVar *var, time_t *data) {
       var->getVar(data);
       return_status = true;
    }
+   return(return_status);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool get_nc_data(NcVar *var, time_t *data) {
+   bool return_status = _get_nc_data(var, data);
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcVar *var, int *data) {
+   bool return_status = _get_nc_data(var, data);
+   return(return_status);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+bool _get_nc_data(NcVar *var, T *data, T bad_data, const long *curs) {
    bool return_status = false;
 
-   if (!IS_INVALID_NC_P(var)) {
+   if (IS_VALID_NC_P(var)) {
+      std::vector<size_t> start;
+      std::vector<size_t> count;
+
+      const int dimC = get_dim_count(var);
+      for (int idx = 0 ; idx < dimC; idx++) {
+         start.push_back((size_t)curs[idx]);
+         count.push_back((size_t)1);
+      }
+
+      *data = bad_data;
+
       //
       // Retrieve the float value from the NetCDF variable.
       // Note: missing data was checked here
       //
-      var->getVar(data);
+      var->getVar(start, count, data);
       return_status = true;
    }
    return(return_status);
@@ -1255,20 +1220,28 @@ bool get_nc_data(NcVar *var, int *data) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, int *data, const long *cur) {
+
+bool get_nc_data(NcVar *var, int *data, const long *curs) {
+   bool return_status = _get_nc_data(var, data, bad_data_int, curs);
+
+   return(return_status);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+bool _get_nc_data(NcVar *var, T *data, T bad_data, const long dim, const long cur) {
    bool return_status = false;
 
-   if (!IS_INVALID_NC_P(var)) {
+   if (IS_VALID_NC_P(var)) {
       std::vector<size_t> start;
       std::vector<size_t> count;
+      start.push_back((size_t)cur);
+      count.push_back((size_t)dim);
 
-      const int dimC = get_dim_count(var);
-      for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)1);
+      for (int idx1=0; idx1<dim; idx1++) {
+         data[idx1] = bad_data;
       }
-
-      *data = bad_data_int;
 
       //
       // Retrieve the float value from the NetCDF variable.
@@ -1285,7 +1258,7 @@ bool get_nc_data(NcVar *var, int *data, const long *cur) {
 bool get_nc_data(NcVar *var, int *data, const long dim, const long cur) {
    bool return_status = false;
 
-   if (!IS_INVALID_NC_P(var)) {
+   if (IS_VALID_NC_P(var)) {
       std::vector<size_t> start;
       std::vector<size_t> count;
       start.push_back((size_t)cur);
@@ -1307,23 +1280,24 @@ bool get_nc_data(NcVar *var, int *data, const long dim, const long cur) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, int *data, const long *dim, const long *cur) {
+template <typename T>
+bool _get_nc_data(NcVar *var, T *data, T bad_data, const long *dims, const long *curs) {
    bool return_status = false;
 
-   if (!IS_INVALID_NC_P(var)) {
+   if (IS_VALID_NC_P(var)) {
       std::vector<size_t> start;
       std::vector<size_t> count;
 
       int data_size = 1;
-      const int dimC = get_dim_count(var);
+      int dimC = get_dim_count(var);
       for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)dim[idx]);
-         data_size *= dim[idx];
+         start.push_back((size_t)curs[idx]);
+         count.push_back((size_t)dims[idx]);
+         data_size *= dims[idx];
       }
 
       for (int idx1=0; idx1<data_size; idx1++) {
-         data[idx1] = bad_data_char;
+         data[idx1] = bad_data;
       }
 
       //
@@ -1338,71 +1312,73 @@ bool get_nc_data(NcVar *var, int *data, const long *dim, const long *cur) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, short *data, const long *cur) {
-   bool return_status = false;
+bool get_nc_data(NcVar *var, int *data, const long *dims, const long *curs) {
+   bool return_status = _get_nc_data(var, data, bad_data_int, dims, curs);
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-
-      const int dimC = get_dim_count(var);
-      for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)1);
-      }
-      *data = bad_data_int;
-
-      //
-      // Retrieve the float value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, short *data, const long *dim, const long *cur) {
-   bool return_status = false;
+bool get_nc_data(NcVar *var, short *data, const long *curs) {
+   bool return_status = _get_nc_data(var, data, (short)bad_data_int, curs);
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
+   return(return_status);
+}
 
-      int data_size = 1;
-      const int dimC = get_dim_count(var);
-      for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)dim[idx]);
-         data_size *= dim[idx];
-      }
+////////////////////////////////////////////////////////////////////////
 
-      for (int idx1=0; idx1<data_size; idx1++) {
-         data[idx1] = bad_data_char;
-      }
+bool get_nc_data(NcVar *var, short *data, const long *dims, const long *curs) {
+   bool return_status = _get_nc_data(var, data, (short)bad_data_int, dims, curs);
 
-      //
-      // Retrieve the float value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcFile *nc, const char *var_name, float *data,
-                 const long *dim, const long *cur) {
+                 const long *dims, const long *curs) {
 
    //
    // Retrieve the input variables
    //
    NcVar var    = get_var(nc, var_name);
-   return get_nc_data(&var, data, dim, cur);
+   return _get_nc_data(&var, data, bad_data_float, dims, curs);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+void _apply_scale_factor(float *data, const T *packed_data,
+                        const int cell_count, const T fill_value,
+                        T &raw_min_val, T &raw_max_val, const char *data_type,
+                        float add_offset, float scale_factor) {
+   int positive_cnt = 0;
+   int unpacked_count = 0;
+   float min_value =  10e10;
+   float max_value = -10e10;
+   const char *method_name = "apply_scale_factor(float)";
+
+   for (int idx=0; idx<cell_count; idx++) {
+      if (fill_value == packed_data[idx])
+         data[idx] = bad_data_float;
+      else {
+         if (raw_min_val > packed_data[idx]) raw_min_val = packed_data[idx];
+         if (raw_max_val < packed_data[idx]) raw_max_val = packed_data[idx];
+         data[idx] = (packed_data[idx] * scale_factor) + add_offset;
+         if (data[idx] > 0) positive_cnt++;
+         if (min_value > data[idx]) min_value = data[idx];
+         if (max_value < data[idx]) max_value = data[idx];
+         unpacked_count++;
+      }
+   }
+   mlog << Debug(4) << method_name << " unpacked data: count="
+        << unpacked_count << " out of " << cell_count
+        << ". FillValue(" << data_type << ")=" << fill_value
+        << " data range [" << min_value << " - " << max_value
+        << "] raw data: [" << raw_min_val << " - " << raw_max_val << "] Positive count: "
+        << positive_cnt << "\n";
+   return;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1411,12 +1387,11 @@ bool get_nc_data(NcVar *var, float *data) {
    bool return_status = false;
    static const char *method_name = "get_nc_data(NcVar *, float *) ";
 
-   if (!IS_INVALID_NC_P(var)) {
+   if (IS_VALID_NC_P(var)) {
       //
       // Retrieve the float value from the NetCDF variable.
       // Note: missing data was checked here
       //
-      int unpacked_count = 0;
       int type_id = GET_NC_TYPE_ID_P(var);
       if (NcType::nc_FLOAT == type_id) {
          var->getVar(data);
@@ -1430,14 +1405,15 @@ bool get_nc_data(NcVar *var, float *data) {
 
          float add_offset = 0.;
          float scale_factor = 1.;
+         int unpacked_count = 0;
          bool unsigned_value = false;
          NcVarAtt *att_add_offset   = get_nc_att(var, string("add_offset"));
-	 NcVarAtt *att_scale_factor = get_nc_att(var, string("scale_factor"));
+         NcVarAtt *att_scale_factor = get_nc_att(var, string("scale_factor"));
          NcVarAtt *att_unsigned     = get_nc_att(var, string("_Unsigned"));
          NcVarAtt *att_fill_value   = get_nc_att(var, string("_FillValue"));
-         if (!IS_INVALID_NC_P(att_add_offset)) add_offset = get_att_value_float(att_add_offset);
-         if (!IS_INVALID_NC_P(att_scale_factor)) scale_factor = get_att_value_float(att_scale_factor);
-         if (!IS_INVALID_NC_P(att_unsigned)) {
+         if (IS_VALID_NC_P(att_add_offset)) add_offset = get_att_value_float(att_add_offset);
+         if (IS_VALID_NC_P(att_scale_factor)) scale_factor = get_att_value_float(att_scale_factor);
+         if (IS_VALID_NC_P(att_unsigned)) {
             ConcatString att_value;
             get_att_value_chars(att_unsigned, att_value);
             unsigned_value = ( att_value == "true" );
@@ -1447,34 +1423,6 @@ bool get_nc_data(NcVar *var, float *data) {
               << ", is_unsigned_value: " << unsigned_value << "\n";
 
          switch ( type_id )  {
-            case NcType::nc_INT64:
-               if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
-                  long long fill_value = bad_data_int;
-                  long long min_value =  2147483647; // 9223372036854775807;
-                  long long max_value = -2147483648; //−9223372036854775808;
-                  long long *packed_data = new long long[cell_count];
-
-                  if (!IS_INVALID_NC_P(att_fill_value))
-                     fill_value = get_att_value_int(att_fill_value);
-
-                  var->getVar(packed_data);
-                  for (int idx=0; idx<cell_count; idx++) {
-                     if (fill_value == packed_data[idx])
-                        data[idx] = bad_data_float;
-                     else {
-                        if (min_value > packed_data[idx]) min_value = packed_data[idx];
-                        if (max_value < packed_data[idx]) max_value = packed_data[idx];
-                        data[idx] = (packed_data[idx] * scale_factor) + add_offset;
-                        unpacked_count++;
-                     }
-                  }
-                  delete [] packed_data;
-                  mlog << Debug(4) << method_name << " unpacked_count "
-                       << unpacked_count << " out of " << cell_count
-                       << ". FillValue(int) " << fill_value
-                       << " between " << min_value << " and " << max_value << "\n";
-               }
-               break;
             case NcType::nc_INT:
                if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
                   int fill_value = bad_data_int;
@@ -1486,21 +1434,10 @@ bool get_nc_data(NcVar *var, float *data) {
                      fill_value = get_att_value_int(att_fill_value);
 
                   var->getVar(packed_data);
-                  for (int idx=0; idx<cell_count; idx++) {
-                     if (fill_value == packed_data[idx])
-                        data[idx] = bad_data_float;
-                     else {
-                        if (min_value > packed_data[idx]) min_value = packed_data[idx];
-                        if (max_value < packed_data[idx]) max_value = packed_data[idx];
-                        data[idx] = (packed_data[idx] * scale_factor) + add_offset;
-                        unpacked_count++;
-                     }
-                  }
+                  _apply_scale_factor(data, packed_data,
+                        cell_count, fill_value, min_value, max_value, "int",
+                        add_offset, scale_factor);
                   delete [] packed_data;
-                  mlog << Debug(4) << method_name << " unpacked_count "
-                       << unpacked_count << " out of " << cell_count
-                       << ". FillValue(int) " << fill_value
-                       << " between " << min_value << " and " << max_value << "\n";
                }
                break;
             case NcType::nc_SHORT:
@@ -1525,18 +1462,7 @@ bool get_nc_data(NcVar *var, float *data) {
                            unpacked_count++;
                         }
                      }
-                  }
-                  else {
-                     for (int idx=0; idx<cell_count; idx++) {
-                        if (fill_value == packed_data[idx])
-                           data[idx] = bad_data_float;
-                        else {
-                           data[idx] = (packed_data[idx] * scale_factor) + add_offset;
-                           unpacked_count++;
-                        }
-                     }
-                  }
-                  if(mlog.verbosity_level() > 6) {
+                  
                      int positive_cnt = 0;
                      int raw_min_value =  70000;
                      int raw_max_value = -70000;
@@ -1545,9 +1471,7 @@ bool get_nc_data(NcVar *var, float *data) {
                      int tmp_value;
                      for (int idx=0; idx<cell_count; idx++) {
                         if (fill_value != packed_data[idx]) {
-                           tmp_value = packed_data[idx];
-                           if (unsigned_value) tmp_value = (unsigned short)packed_data[idx];
-
+                           tmp_value = (unsigned short)packed_data[idx];
                            if (raw_min_value > tmp_value) raw_min_value = tmp_value;
                            if (raw_max_value < tmp_value) raw_max_value = tmp_value;
                            if (data[idx] > 0) positive_cnt++;
@@ -1555,26 +1479,49 @@ bool get_nc_data(NcVar *var, float *data) {
                            if (max_value < data[idx]) max_value = data[idx];
                         }
                      }
-                     mlog << Debug(5) << method_name << "unpacked_count "
+                     mlog << Debug(4) << method_name << " unpacked data: count="
                           << unpacked_count << " out of " << cell_count
-                          << ".\n     FillValue(short) " << fill_value
-                          << ", Positive count: " << positive_cnt
-                          << "\n     Scaled range: " << min_value << " and " << max_value
-                          //<< "   packed range: " << raw_min_value << " and " << raw_max_value;
-                          << "\n";
+                          << ". FillValue(short with unsigned) " << fill_value
+                          << " data range [" << min_value << " - " << max_value
+                          << "] raw data: [" << raw_min_value << " - " << raw_max_value << "] Positive count: "
+                          << positive_cnt << "\n";
                   }
+                  else {
+                     short min_value =  32766;
+                     short max_value = -32767;
+                     _apply_scale_factor(data, packed_data,
+                           cell_count, fill_value, min_value, max_value, "short",
+                           add_offset, scale_factor);
+                  }
+                  delete [] packed_data;
+               }
+               break;
+            case NcType::nc_USHORT:
+               if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
+                  unsigned short fill_value = (unsigned short)bad_data_int;
+                  unsigned short min_value = 65535;
+                  unsigned short max_value = 0;
+                  unsigned short *packed_data = new unsigned short[cell_count];
+
+                  if (IS_VALID_NC_P(att_fill_value))
+                     fill_value = get_att_value_ushort(att_fill_value);
+
+                  var->getVar(packed_data);
+
+                  _apply_scale_factor(data, packed_data,
+                        cell_count, fill_value, min_value, max_value, "unsigned short",
+                        add_offset, scale_factor);
                   delete [] packed_data;
                }
                break;
             case NcType::nc_BYTE:
                if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
                   ncbyte fill_value = (ncbyte)bad_data_int;
-                  char *packed_data = new char[cell_count];
+                  ncbyte *packed_data = new ncbyte[cell_count];
 
                   if (!IS_INVALID_NC_P(att_fill_value)) {
                      fill_value = get_att_value_char(att_fill_value);
                   }
-
 
                   if (unsigned_value) {
                      int value, unsigned_fill_value;
@@ -1588,18 +1535,6 @@ bool get_nc_data(NcVar *var, float *data) {
                            unpacked_count++;
                         }
                      }
-                  }
-                  else {
-                     for (int idx=0; idx<cell_count; idx++) {
-                        if (fill_value == packed_data[idx])
-                           data[idx] = bad_data_float;
-                        else {
-                           data[idx] = (packed_data[idx] * scale_factor) + add_offset;
-                           unpacked_count++;
-                        }
-                     }
-                  }
-                  if(mlog.verbosity_level() > 6) {
                      int positive_cnt = 0;
                      int raw_min_value =  70000;
                      int raw_max_value = -70000;
@@ -1608,9 +1543,7 @@ bool get_nc_data(NcVar *var, float *data) {
                      int tmp_value;
                      for (int idx=0; idx<cell_count; idx++) {
                         if (fill_value != packed_data[idx]) {
-                           tmp_value = packed_data[idx];
-                           if (unsigned_value) tmp_value = (unsigned char)packed_data[idx];
-
+                           tmp_value = (unsigned char)packed_data[idx];
                            if (raw_min_value > tmp_value) raw_min_value = tmp_value;
                            if (raw_max_value < tmp_value) raw_max_value = tmp_value;
                            if (data[idx] > 0) positive_cnt++;
@@ -1618,21 +1551,44 @@ bool get_nc_data(NcVar *var, float *data) {
                            if (max_value < data[idx]) max_value = data[idx];
                         }
                      }
-                     mlog << Debug(5) << method_name << "unpacked_count "
+                     mlog << Debug(4) << method_name << " unpacked data: count="
                           << unpacked_count << " out of " << cell_count
-                          << ".\n     FillValue(short) " << fill_value
-                          << ", Positive count: " << positive_cnt
-                          << "\n     Scaled range: " << min_value << " and " << max_value
-                          //<< "   packed range: " << raw_min_value << " and " << raw_max_value;
-                          << "\n";
+                          << ". FillValue(byte with unsigned) " << fill_value
+                          << " data range [" << min_value << " - " << max_value
+                          << "] raw data: [" << raw_min_value << " - " << raw_max_value << "] Positive count: "
+                          << positive_cnt << "\n";
+                  }
+                  else {
+                     ncbyte min_value =  127;
+                     ncbyte max_value = -127;
+                     _apply_scale_factor(data, packed_data,
+                           cell_count, fill_value, min_value, max_value, "ncbyte",
+                           add_offset, scale_factor);
                   }
                   delete [] packed_data;
                }
                break;
+            case NcType::nc_UBYTE:
+               if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
+                  unsigned char min_value = 255;
+                  unsigned char max_value = 0;
+                  unsigned char fill_value = (unsigned char)-99;
+                  unsigned char *packed_data = new unsigned char[cell_count];
+
+                  if (!IS_INVALID_NC_P(att_fill_value)) {
+                     fill_value = get_att_value_char(att_fill_value);
+                  }
+
+                  _apply_scale_factor(data, packed_data,
+                        cell_count, fill_value, min_value, max_value, "unsigned char",
+                        add_offset, scale_factor);
+                  delete [] packed_data;
+               }
+               break;
             default:
-                 mlog << Debug(1) << method_name << "type_id =============== "
-                      << type_id << " type name: " << GET_NC_TYPE_NAME_P(var)
-                      << "\n";
+               mlog << Debug(1) << method_name << "type_id: "
+                    << type_id << " type name: " << GET_NC_TYPE_NAME_P(var)
+                    << "\n";
          }
          if(att_add_offset) delete att_add_offset;
          if(att_scale_factor) delete att_scale_factor;
@@ -1646,96 +1602,73 @@ bool get_nc_data(NcVar *var, float *data) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, float *data, const long *cur) {
-   bool return_status = false;
+bool get_nc_data(NcVar *var, float *data, const long *curs) {
+   bool return_status = _get_nc_data(var, data, bad_data_float, curs);
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-
-      const int dimC = get_dim_count(var);
-      for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)1);
-      }
-      *data = bad_data_double;
-
-      //
-      // Retrieve the float value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, float *data, const long *dim, const long *cur) {
-   bool return_status = false;
+bool get_nc_data(NcVar *var, float *data, const long *dims, const long *curs) {
+   bool return_status = _get_nc_data(var, data, bad_data_float, dims, curs);
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-
-      int data_size = 1;
-      const int dimC = get_dim_count(var);
-      for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)dim[idx]);
-         data_size *= dim[idx];
-      }
-
-      for (int idx1=0; idx1<data_size; idx1++) {
-         data[idx1] = bad_data_char;
-      }
-
-      //
-      // Retrieve the float value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcVar *var, float *data, const long dim, const long cur) {
-   bool return_status = false;
+   bool return_status = _get_nc_data(var, data, bad_data_float, dim, cur);
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-      start.push_back((size_t)cur);
-      count.push_back((size_t)dim);
-
-      for (int idx1=0; idx1<dim; idx1++) {
-         data[idx1] = bad_data_double;
-      }
-
-      //
-      // Retrieve the float value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcFile *nc, const char *var_name, double *data,
-                 const long *dim, const long *cur) {
+                 const long *dims, const long *curs) {
 
    //
    // Retrieve the input variables
    //
    NcVar var    = get_var(nc, var_name);
-   return get_nc_data(&var, data, dim, cur);
+   return get_nc_data(&var, data, dims, curs);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+int _apply_scale_factor(double *data, const T *packed_data,
+                        const int cell_count, const T fill_value,
+                        T &raw_min_val, T &raw_max_val, const char *data_type,
+                        float add_offset, float scale_factor) {
+   int positive_cnt = 0;
+   int unpacked_count = 0;
+   double min_value =  10e10;
+   double max_value = -10e10;
+   const char *method_name = "apply_scale_factor(double)";
+
+   for (int idx=0; idx<cell_count; idx++) {
+      if (fill_value == packed_data[idx])
+         data[idx] = bad_data_float;
+      else {
+         if (raw_min_val > packed_data[idx]) raw_min_val = packed_data[idx];
+         if (raw_max_val < packed_data[idx]) raw_max_val = packed_data[idx];
+         data[idx] = (packed_data[idx] * scale_factor) + add_offset;
+         if (data[idx] > 0) positive_cnt++;
+         if (min_value > data[idx]) min_value = data[idx];
+         if (max_value < data[idx]) max_value = data[idx];
+         unpacked_count++;
+      }
+   }
+   mlog << Debug(4) << method_name << " unpacked data: count="
+        << unpacked_count << " out of " << cell_count
+        << ". FillValue(" << data_type << ")=" << fill_value
+        << " data range [" << min_value << " - " << max_value
+        << "] raw data: [" << raw_min_val << " - " << raw_max_val << "] Positive count: "
+        << positive_cnt << "\n";
+   return unpacked_count;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1744,7 +1677,7 @@ bool get_nc_data(NcVar *var, double *data) {
    bool return_status = false;
    static const char *method_name = "get_nc_data(NcVar *, double *) ";
 
-   if (!IS_INVALID_NC_P(var)) {
+   if (IS_VALID_NC_P(var)) {
       //
       // Retrieve the double value from the NetCDF variable.
       // Note: missing data was checked here
@@ -1768,13 +1701,13 @@ bool get_nc_data(NcVar *var, double *data) {
          NcVarAtt *att_scale_factor = get_nc_att(var, (string)"scale_factor");
          NcVarAtt *att_unsigned     = get_nc_att(var, (string)"_Unsigned");
          NcVarAtt *att_fill_value   = get_nc_att(var, (string)"_FillValue");
-         if (!IS_INVALID_NC_P(att_add_offset)) {
+         if (IS_VALID_NC_P(att_add_offset)) {
             add_offset = get_att_value_double(att_add_offset);
          }
-         if (!IS_INVALID_NC_P(att_scale_factor)) {
+         if (IS_VALID_NC_P(att_scale_factor)) {
             scale_factor = get_att_value_double(att_scale_factor);
          }
-         if (!IS_INVALID_NC_P(att_unsigned)) {
+         if (IS_VALID_NC_P(att_unsigned)) {
             ConcatString att_value;
             get_att_value_chars(att_unsigned, att_value);
             unsigned_value = ("true" == att_value);
@@ -1784,34 +1717,6 @@ bool get_nc_data(NcVar *var, double *data) {
               << ", is_unsigned_value: " << unsigned_value << "\n";
 
          switch ( type_id )  {
-            case NcType::nc_INT64:
-               if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
-                  int fill_value = bad_data_int;
-                  long long min_value =  2147483647; // 9223372036854775807;
-                  long long max_value = -2147483648; //−9223372036854775808;
-                  long long *packed_data = new long long[cell_count];
-
-                  if (!IS_INVALID_NC_P(att_fill_value))
-                     fill_value = get_att_value_int(att_fill_value);
-
-                  var->getVar(packed_data);
-                  for (int idx=0; idx<cell_count; idx++) {
-                     if (fill_value == packed_data[idx])
-                        data[idx] = bad_data_double;
-                     else {
-                        if (min_value > packed_data[idx]) min_value = packed_data[idx];
-                        if (max_value < packed_data[idx]) max_value = packed_data[idx];
-                        data[idx] = (packed_data[idx] * scale_factor) + add_offset;
-                        unpacked_count++;
-                     }
-                  }
-                  delete [] packed_data;
-                  mlog << Debug(4) << method_name << " unpacked_count "
-                       << unpacked_count << " out of " << cell_count
-                       << ". FillValue(int) " << fill_value
-                       << " between " << min_value << " and " << max_value << "\n";
-               }
-               break;
             case NcType::nc_INT:
                if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
                   int fill_value = bad_data_int;
@@ -1823,21 +1728,10 @@ bool get_nc_data(NcVar *var, double *data) {
                      fill_value = get_att_value_int(att_fill_value);
 
                   var->getVar(packed_data);
-                  for (int idx=0; idx<cell_count; idx++) {
-                     if (fill_value == packed_data[idx])
-                        data[idx] = bad_data_double;
-                     else {
-                        if (min_value > packed_data[idx]) min_value = packed_data[idx];
-                        if (max_value < packed_data[idx]) max_value = packed_data[idx];
-                        data[idx] = (packed_data[idx] * scale_factor) + add_offset;
-                        unpacked_count++;
-                     }
-                  }
+                  _apply_scale_factor(data, packed_data,
+                        cell_count, fill_value, min_value, max_value, "int",
+                        add_offset, scale_factor);
                   delete [] packed_data;
-                  mlog << Debug(4) << method_name << " unpacked_count "
-                       << unpacked_count << " out of " << cell_count
-                       << ". FillValue(int) " << fill_value
-                       << " between " << min_value << " and " << max_value << "\n";
                }
                break;
             case NcType::nc_SHORT:
@@ -1862,29 +1756,15 @@ bool get_nc_data(NcVar *var, double *data) {
                            unpacked_count++;
                         }
                      }
-                  }
-                  else {
-                     for (int idx=0; idx<cell_count; idx++) {
-                        if (fill_value == packed_data[idx])
-                           data[idx] = bad_data_double;
-                        else {
-                           data[idx] = (packed_data[idx] * scale_factor) + add_offset;
-                           unpacked_count++;
-                        }
-                     }
-                  }
-                  if(mlog.verbosity_level() > 6) {
                      int positive_cnt = 0;
                      int raw_min_value =  70000;
                      int raw_max_value = -70000;
-                     double min_value =  10e10;
-                     double max_value = -10e10;
+                     float min_value =  10e10;
+                     float max_value = -10e10;
                      int tmp_value;
                      for (int idx=0; idx<cell_count; idx++) {
                         if (fill_value != packed_data[idx]) {
-                           tmp_value = packed_data[idx];
-                           if (unsigned_value) tmp_value = (unsigned short)packed_data[idx];
-
+                           tmp_value = (unsigned short)packed_data[idx];
                            if (raw_min_value > tmp_value) raw_min_value = tmp_value;
                            if (raw_max_value < tmp_value) raw_max_value = tmp_value;
                            if (data[idx] > 0) positive_cnt++;
@@ -1892,26 +1772,49 @@ bool get_nc_data(NcVar *var, double *data) {
                            if (max_value < data[idx]) max_value = data[idx];
                         }
                      }
-                     mlog << Debug(5) << method_name << "unpacked_count "
+                     mlog << Debug(4) << method_name << " unpacked data: count="
                           << unpacked_count << " out of " << cell_count
-                          << ".\n     FillValue(short) " << fill_value
-                          << ", Positive count: " << positive_cnt
-                          << "\n     Scaled range: " << min_value << " and " << max_value
-                          //<< "   packed range: " << raw_min_value << " and " << raw_max_value;
-                          << "\n";
+                          << ". FillValue(short with unsigned) " << fill_value
+                          << " data range [" << min_value << " - " << max_value
+                          << "] raw data: [" << raw_min_value << " - " << raw_max_value << "] Positive count: "
+                          << positive_cnt << "\n";
                   }
+                  else {
+                     short min_value =  32766;
+                     short max_value = -32767;
+                     _apply_scale_factor(data, packed_data,
+                           cell_count, fill_value, min_value, max_value, "int",
+                           add_offset, scale_factor);
+                  }
+                  delete [] packed_data;
+               }
+               break;
+            case NcType::nc_USHORT:
+               if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
+                  unsigned short fill_value = (unsigned short)bad_data_int;
+                  unsigned short *packed_data = new unsigned short[cell_count];
+
+                  if (!IS_INVALID_NC_P(att_fill_value))
+                     fill_value = get_att_value_short(att_fill_value);
+
+                  var->getVar(packed_data);
+
+                  unsigned short min_value = 65535;
+                  unsigned short max_value = 0;
+                  _apply_scale_factor(data, packed_data,
+                        cell_count, fill_value, min_value, max_value, "int",
+                        add_offset, scale_factor);
                   delete [] packed_data;
                }
                break;
             case NcType::nc_BYTE:
                if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
                   ncbyte fill_value = (ncbyte)bad_data_int;
-                  char *packed_data = new char[cell_count];
+                  ncbyte *packed_data = new ncbyte[cell_count];
 
                   if (!IS_INVALID_NC_P(att_fill_value)) {
                      fill_value = get_att_value_char(att_fill_value);
                   }
-
 
                   if (unsigned_value) {
                      int value, unsigned_fill_value;
@@ -1925,29 +1828,15 @@ bool get_nc_data(NcVar *var, double *data) {
                            unpacked_count++;
                         }
                      }
-                  }
-                  else {
-                     for (int idx=0; idx<cell_count; idx++) {
-                        if (fill_value == packed_data[idx])
-                           data[idx] = bad_data_double;
-                        else {
-                           data[idx] = (packed_data[idx] * scale_factor) + add_offset;
-                           unpacked_count++;
-                        }
-                     }
-                  }
-                  if(mlog.verbosity_level() > 6) {
                      int positive_cnt = 0;
                      int raw_min_value =  70000;
                      int raw_max_value = -70000;
-                     double min_value =  10e10;
-                     double max_value = -10e10;
+                     float min_value =  10e10;
+                     float max_value = -10e10;
                      int tmp_value;
                      for (int idx=0; idx<cell_count; idx++) {
                         if (fill_value != packed_data[idx]) {
-                           tmp_value = packed_data[idx];
-                           if (unsigned_value) tmp_value = (unsigned char)packed_data[idx];
-
+                           tmp_value = (unsigned char)packed_data[idx];
                            if (raw_min_value > tmp_value) raw_min_value = tmp_value;
                            if (raw_max_value < tmp_value) raw_max_value = tmp_value;
                            if (data[idx] > 0) positive_cnt++;
@@ -1955,19 +1844,42 @@ bool get_nc_data(NcVar *var, double *data) {
                            if (max_value < data[idx]) max_value = data[idx];
                         }
                      }
-                     mlog << Debug(5) << method_name << "unpacked_count "
+                     mlog << Debug(4) << method_name << " unpacked data: count="
                           << unpacked_count << " out of " << cell_count
-                          << ".\n     FillValue(short) " << fill_value
-                          << ", Positive count: " << positive_cnt
-                          << "\n     Scaled range: " << min_value << " and " << max_value
-                          //<< "   packed range: " << raw_min_value << " and " << raw_max_value;
-                          << "\n";
+                          << ". FillValue(short with unsigned) " << fill_value
+                          << " data range [" << min_value << " - " << max_value
+                          << "] raw data: [" << raw_min_value << " - " << raw_max_value << "] Positive count: "
+                          << positive_cnt << "\n";
+                  }
+                  else {
+                     ncbyte min_value =  127;
+                     ncbyte max_value = -127;
+                     _apply_scale_factor(data, packed_data,
+                           cell_count, fill_value, min_value, max_value, "ncbyte",
+                           add_offset, scale_factor);
                   }
                   delete [] packed_data;
                }
                break;
+            case NcType::nc_UBYTE:
+               if (!is_eq(0., add_offset) && !is_eq(1., scale_factor)) {
+                  signed char fill_value = (signed char)bad_data_int;
+                  signed char *packed_data = new signed char[cell_count];
+
+                  if (!IS_INVALID_NC_P(att_fill_value)) {
+                     fill_value = get_att_value_char(att_fill_value);
+                  }
+
+                  signed char min_value = 255;
+                  signed char max_value = 0;
+                  _apply_scale_factor(data, packed_data,
+                        cell_count, fill_value, min_value, max_value, "ncbyte",
+                        add_offset, scale_factor);
+                  delete [] packed_data;
+               }
+               break;
             default:
-                 mlog << Debug(1) << method_name << "type_id =============== "
+                 mlog << Debug(1) << method_name << "type_id: "
                       << type_id << " type name: " << GET_NC_TYPE_NAME_P(var)
                       << "\n";
          }
@@ -1983,99 +1895,32 @@ bool get_nc_data(NcVar *var, double *data) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, double *data, const long *cur) {
-   bool return_status = false;
-
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-
-      const int dimC = get_dim_count(var);
-      for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)1);
-      }
-      *data = bad_data_double;
-
-      //
-      // Retrieve the double value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
+bool get_nc_data(NcVar *var, double *data, const long *curs) {
+   bool return_status = _get_nc_data(var, data, bad_data_double, curs);
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcVar *var, double *data, const long dim, const long cur) {
-   bool return_status = false;
+   bool return_status = _get_nc_data(var, data, bad_data_double, dim, cur);;
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-      start.push_back((size_t)cur);
-      count.push_back((size_t)dim);
-
-      for (int idx1=0; idx1<dim; idx1++) {
-         data[idx1] = bad_data_double;
-      }
-
-      //
-      // Retrieve the float value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, double *data, const long *dim, const long *cur) {
-   bool return_status = false;
+bool get_nc_data(NcVar *var, double *data, const long *dims, const long *curs) {
+   bool return_status = _get_nc_data(var, data, bad_data_double, dims, curs);
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-
-      int data_size = 1;
-      const int dimC = get_dim_count(var);
-      for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)dim[idx]);
-         data_size *= dim[idx];
-      }
-
-      for (int idx1=0; idx1<data_size; idx1++) {
-         data[idx1] = bad_data_char;
-      }
-
-      //
-      // Retrieve the float value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcVar *var, char *data) {
-   bool return_status = false;
+   bool return_status = _get_nc_data(var, data);
 
-   if (!IS_INVALID_NC_P(var)) {
-      //
-      // Retrieve the float value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(data);
-      return_status = true;
-   }
    return(return_status);
 }
 
@@ -2083,14 +1928,29 @@ bool get_nc_data(NcVar *var, char *data) {
 
 bool get_nc_data(NcVar *var, uchar *data) {
    bool return_status = false;
-
-   if (!IS_INVALID_NC_P(var)) {
-      //
-      // Retrieve the unsigned char value from the NetCDF variable.
-      //
-      var->getVar(data);
-      return_status = true;
+   int data_type = GET_NC_TYPE_ID_P(var);
+   static const char *method_name = "get_nc_data(NcVar *, uchar *) -> ";
+   if (NC_UBYTE == data_type) return_status = _get_nc_data(var, data);
+   else if (NC_BYTE == data_type && has_unsigned_attribute(var)) {
+      int cell_count = 1;
+      for (int idx=0; idx<var->getDimCount(); idx++) {
+         NcDim dim = var->getDim(idx);
+         cell_count *= get_dim_size(&dim);
+      }
+      ncbyte *signed_data = new ncbyte[cell_count];
+      return_status = _get_nc_data(var, signed_data);
+      for (int idx=0; idx<cell_count; idx++) {
+         data[idx] = (uchar)signed_data[idx];
+      }
+      delete [] signed_data;
    }
+   else {
+      mlog << Error << "\n" << method_name
+           << "does not process \"" << GET_NC_TYPE_NAME_P(var)
+           << "\" data type for variable \"" << GET_NC_NAME_P(var) << "\".\n\n";
+      exit(1);
+   }
+
    return(return_status);
 }
 
@@ -2098,80 +1958,63 @@ bool get_nc_data(NcVar *var, uchar *data) {
 
 bool get_nc_data(NcVar *var, unsigned short *data) {
    bool return_status = false;
-
-   if (!IS_INVALID_NC_P(var)) {
-      //
-      // Retrieve the unsigned char value from the NetCDF variable.
-      //
-      var->getVar(data);
-      return_status = true;
+   int data_type = GET_NC_TYPE_ID_P(var);
+   static const char *method_name = "get_nc_data(NcVar *, unsigned short *) -> ";
+   if (NC_USHORT == data_type) return_status = _get_nc_data(var, data);
+   else if (NC_SHORT == data_type && has_unsigned_attribute(var)) {
+      int cell_count = 1;
+      short fill_value = (short)bad_data_int;
+      NcVarAtt *att_fill_value   = get_nc_att(var, (string)"_FillValue");
+      bool has_fill_value = IS_VALID_NC_P(att_fill_value);
+      if (has_fill_value) fill_value = get_att_value_int(att_fill_value);
+      for (int idx=0; idx<var->getDimCount(); idx++) {
+         NcDim dim = var->getDim(idx);
+         cell_count *= get_dim_size(&dim);
+      }
+      short *short_data = new short[cell_count];
+      return_status = _get_nc_data(var, short_data);
+      for (int idx=0; idx<cell_count; idx++) {
+         if (has_fill_value && fill_value == short_data[idx])
+            data[idx] = (unsigned short)bad_data_int;
+         else
+            data[idx] = (unsigned short)short_data[idx];
+      }
+      delete [] short_data;
    }
+   else {
+      mlog << Error << "\n" << method_name
+           << "does not process \"" << GET_NC_TYPE_NAME_P(var)
+           << "\" data type for variable \"" << GET_NC_NAME_P(var) << "\".\n\n";
+      exit(1);
+   }
+
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcFile *nc, const char *var_name, char *data,
-                 const long *dim, const long *cur) {
+                 const long *dims, const long *curs) {
 
    //
    // Retrieve the input variables
    //
    NcVar var    = get_var(nc, var_name);
-   return get_nc_data(&var, data, dim, cur);
+   return get_nc_data(&var, data, dims, curs);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcVar *var, char *data, const long dim, const long cur) {
-   bool return_status = false;
+   bool return_status = _get_nc_data(var, data, bad_data_char, dim, cur);
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-      start.push_back((size_t)cur);
-      count.push_back((size_t)dim);
-
-      for (int idx1=0; idx1<dim; idx1++) {
-         data[idx1] = bad_data_char;
-      }
-
-      //
-      // Retrieve the char value from the NetCDF variable.
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, char *data, const long *dim, const long *cur) {
-   bool return_status = false;
-
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-
-      int data_size = 1;
-      const int dimC = get_dim_count(var);
-      for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)dim[idx]);
-         data_size *= dim[idx];
-      }
-
-      for (int idx1=0; idx1<data_size; idx1++) {
-         data[idx1] = bad_data_char;
-      }
-
-      //
-      // Retrieve the char value from the NetCDF variable.
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
+bool get_nc_data(NcVar *var, char *data, const long *dims, const long *curs) {
+   bool return_status = _get_nc_data(var, data, bad_data_char, dims, curs);
 
    return(return_status);
 }
@@ -2179,82 +2022,36 @@ bool get_nc_data(NcVar *var, char *data, const long *dim, const long *cur) {
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcVar *var, ncbyte *data) {
-   bool return_status = false;
+   bool return_status = _get_nc_data(var, data);
 
-   if (!IS_INVALID_NC_P(var)) {
-      //
-      // Retrieve the byte (unsigned char) value from the NetCDF variable.
-      // Note: missing data was checked here
-      //
-      var->getVar(data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcFile *nc, const char *var_name, ncbyte *data,
-                 const long *dim, const long *cur) {
+                 const long *dims, const long *curs) {
 
    //
    // Retrieve the input variables
    //
    NcVar var = get_var(nc, var_name);
-   return get_nc_data(&var, data, dim, cur);
+   return get_nc_data(&var, data, dims, curs);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool get_nc_data(NcVar *var, ncbyte *data, const long dim, const long cur) {
-   bool return_status = false;
+   bool return_status = _get_nc_data(var, data, (ncbyte)bad_data_char, dim, cur);
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-      start.push_back((size_t)cur);
-      count.push_back((size_t)dim);
-
-      for (int idx1=0; idx1<dim; idx1++) {
-         data[idx1] = bad_data_char;
-      }
-
-      //
-      // Retrieve the char value from the NetCDF variable.
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool get_nc_data(NcVar *var, ncbyte *data, const long *dim, const long *cur) {
-   bool return_status = false;
+bool get_nc_data(NcVar *var, ncbyte *data, const long *dims, const long *curs) {
+   bool return_status = _get_nc_data(var, data, (ncbyte)bad_data_char, dims, curs);
 
-   if (!IS_INVALID_NC_P(var)) {
-      std::vector<size_t> start;
-      std::vector<size_t> count;
-
-      int data_size = 1;
-      const int dimC = get_dim_count(var);
-      for (int idx = 0 ; idx < dimC; idx++) {
-         start.push_back((size_t)cur[idx]);
-         count.push_back((size_t)dim[idx]);
-         data_size *= dim[idx];
-      }
-
-      for (int idx1=0; idx1<data_size; idx1++) {
-         data[idx1] = bad_data_char;
-      }
-
-      //
-      // Retrieve the char value from the NetCDF variable.
-      //
-      var->getVar(start, count, data);
-      return_status = true;
-   }
    return(return_status);
 }
 
@@ -2347,7 +2144,8 @@ int get_nc_string_length(NcFile *nc_file, NcVar var, const char *var_name) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool put_nc_data(NcVar *var, const int data,    long offset0, long offset1, long offset2) {
+template <typename T>
+bool _put_nc_data(NcVar *var, const T data, long offset0, long offset1, long offset2) {
    vector<size_t> offsets;
    offsets.push_back((size_t)offset0);
    if (0 <= offset1) {
@@ -2362,61 +2160,36 @@ bool put_nc_data(NcVar *var, const int data,    long offset0, long offset1, long
 
 ////////////////////////////////////////////////////////////////////////
 
-bool put_nc_data(NcVar *var, const char data,   long offset0, long offset1, long offset2) {
-   vector<size_t> offsets;
-   offsets.push_back((size_t)offset0);
-   if (0 <= offset1) {
-     offsets.push_back((size_t)offset1);
-   }
-   if (0 <= offset2) {
-     offsets.push_back((size_t)offset2);
-   }
-   var->putVar(offsets, data);
+bool put_nc_data(NcVar *var, const int data, long offset0, long offset1, long offset2) {
+   _put_nc_data(var, data, offset0, offset1, offset2);
+   return true;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool put_nc_data(NcVar *var, const char data, long offset0, long offset1, long offset2) {
+   _put_nc_data(var, data, offset0, offset1, offset2);
    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool put_nc_data(NcVar *var, const float data , long offset0, long offset1, long offset2) {
-   vector<size_t> offsets;
-   offsets.push_back((size_t)offset0);
-   if (0 <= offset1) {
-     offsets.push_back((size_t)offset1);
-   }
-   if (0 <= offset2) {
-     offsets.push_back((size_t)offset2);
-   }
-   var->putVar(offsets, data);
+   _put_nc_data(var, data, offset0, offset1, offset2);
    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool put_nc_data(NcVar *var, const double data, long offset0, long offset1, long offset2) {
-   vector<size_t> offsets;
-   offsets.push_back((size_t)offset0);
-   if (0 <= offset1) {
-     offsets.push_back((size_t)offset1);
-   }
-   if (0 <= offset2) {
-     offsets.push_back((size_t)offset2);
-   }
-   var->putVar(offsets, data);
+   _put_nc_data(var, data, offset0, offset1, offset2);
    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool put_nc_data(NcVar *var, const ncbyte data, long offset0, long offset1, long offset2) {
-   vector<size_t> offsets;
-   offsets.push_back((size_t)offset0);
-   if (0 <= offset1) {
-     offsets.push_back((size_t)offset1);
-   }
-   if (0 <= offset2) {
-     offsets.push_back((size_t)offset2);
-   }
-   var->putVar(offsets, data);
+   _put_nc_data(var, data, offset0, offset1, offset2);
    return true;
 }
 
@@ -2457,35 +2230,12 @@ bool put_nc_data(NcVar *var, const ncbyte *data ) {
 
 ////////////////////////////////////////////////////////////////////////
 
-bool put_nc_data(NcVar *var, const int *data,    const long length, const long offset) {
-   vector<size_t> offsets, counts;
-   offsets.push_back(offset);
-   offsets.push_back(0);
-   counts.push_back(1);
-   counts.push_back(length);
-   var->putVar(offsets, counts, data);
-   return true;
-}
-
-////////////////////////////////////////////////////////////////////////
-
-bool put_nc_data(NcVar *var, const char *data,   const long length, const long offset) {
-   vector<size_t> offsets, counts;
-   offsets.push_back(offset);
-   offsets.push_back(0);
-   counts.push_back(1);
-   counts.push_back(length);
-   var->putVar(offsets, counts, data);
-   return true;
-}
-
-////////////////////////////////////////////////////////////////////////
-
-bool put_nc_data(NcVar *var, const float *data , const long length, const long offset) {
+template <typename T>
+bool _put_nc_data(NcVar *var, const T *data,    const long length, const long offset) {
    vector<size_t> offsets, counts;
    int dim_count = get_dim_count(var);
    offsets.push_back(offset);
-   if (dim_count == 2) {
+   if (dim_count >= 2) {
       offsets.push_back(0);
       counts.push_back(1);
    }
@@ -2496,83 +2246,80 @@ bool put_nc_data(NcVar *var, const float *data , const long length, const long o
 
 ////////////////////////////////////////////////////////////////////////
 
+bool put_nc_data(NcVar *var, const int *data,    const long length, const long offset) {
+   _put_nc_data(var, data, length, offset);
+   return true;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool put_nc_data(NcVar *var, const char *data,   const long length, const long offset) {
+   _put_nc_data(var, data, length, offset);
+   return true;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool put_nc_data(NcVar *var, const float *data , const long length, const long offset) {
+   _put_nc_data(var, data, length, offset);
+   return true;
+}
+
+////////////////////////////////////////////////////////////////////////
+
 bool put_nc_data(NcVar *var, const double *data, const long length, const long offset) {
-   vector<size_t> offsets, counts;
-   offsets.push_back(offset);
-   offsets.push_back(0);
-   counts.push_back(1);
-   counts.push_back(length);
-   var->putVar(offsets, counts, data);
+   _put_nc_data(var, data, length, offset);
    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 bool put_nc_data(NcVar *var, const ncbyte *data, const long length, const long offset) {
-   vector<size_t> offsets, counts;
-   offsets.push_back(offset);
-   offsets.push_back(0);
-   counts.push_back(1);
-   counts.push_back(length);
-   var->putVar(offsets, counts, data);
+   _put_nc_data(var, data, length, offset);
    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool put_nc_data(NcVar *var, const float *data , const long *length, const long *offset) {
+template <typename T>
+bool _put_nc_data(NcVar *var, const T *data , const long *lengths, const long *offsets) {
    int dim = get_dim_count(var);
-   vector<size_t> offsets, counts;
+   vector<size_t> nc_offsets, counts;
    for (int idx = 0 ; idx < dim; idx++) {
-      offsets.push_back(offset[idx]);
+      nc_offsets.push_back(offsets[idx]);
    }
    for (int idx = 0 ; idx < dim; idx++) {
-      counts.push_back(length[idx]);
+      counts.push_back(lengths[idx]);
    }
-   var->putVar(offsets, counts, data);
+   var->putVar(nc_offsets, counts, data);
    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool put_nc_data(NcVar *var, const char *data , const long *length, const long *offset) {
-   int dim = get_dim_count(var);
-   vector<size_t> offsets, counts;
-   for (int idx = 0 ; idx < dim; idx++) {
-      offsets.push_back(offset[idx]);
-   }
-   for (int idx = 0 ; idx < dim; idx++) {
-      counts.push_back(length[idx]);
-   }
-   var->putVar(offsets, counts, data);
+bool put_nc_data(NcVar *var, const float *data , const long *lengths, const long *offsets) {
+   _put_nc_data(var, data , lengths, offsets);
    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool put_nc_data(NcVar *var, const int *data , const long *length, const long *offset) {
-   int dim = get_dim_count(var);
-   vector<size_t> offsets, counts;
-   for (int idx = 0 ; idx < dim; idx++) {
-      offsets.push_back(offset[idx]);
-   }
-   for (int idx = 0 ; idx < dim; idx++) {
-      counts.push_back(length[idx]);
-   }
-   var->putVar(offsets, counts, data);
+bool put_nc_data(NcVar *var, const char *data , const long *lengths, const long *offsets) {
+   _put_nc_data(var, data , lengths, offsets);
    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool put_nc_data_with_dims(NcVar *var, const int *data,
-                           const int len0, const int len1, const int len2) {
-   return put_nc_data_with_dims(var, data, (long)len0, (long)len1, (long)len2);
+bool put_nc_data(NcVar *var, const int *data , const long *lengths, const long *offsets) {
+   _put_nc_data(var, data , lengths, offsets);
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-bool put_nc_data_with_dims(NcVar *var, const int *data,
+template <typename T>
+bool _put_nc_data_with_dims(NcVar *var, const T *data,
                            const long len0, const long len1, const long len2) {
    vector<size_t> offsets, counts;
    if (0 < len0) {
@@ -2593,6 +2340,21 @@ bool put_nc_data_with_dims(NcVar *var, const int *data,
 
 ////////////////////////////////////////////////////////////////////////
 
+bool put_nc_data_with_dims(NcVar *var, const int *data,
+                           const int len0, const int len1, const int len2) {
+   return put_nc_data_with_dims(var, data, (long)len0, (long)len1, (long)len2);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+bool put_nc_data_with_dims(NcVar *var, const int *data,
+                           const long len0, const long len1, const long len2) {
+   _put_nc_data_with_dims(var, data, len0, len1, len2);
+   return true;
+}
+
+////////////////////////////////////////////////////////////////////////
+
 bool put_nc_data_with_dims(NcVar *var, const float *data,
                            const int len0, const int len1, const int len2) {
    return put_nc_data_with_dims(var, data, (long)len0, (long)len1, (long)len2);
@@ -2602,20 +2364,7 @@ bool put_nc_data_with_dims(NcVar *var, const float *data,
 
 bool put_nc_data_with_dims(NcVar *var, const float *data,
                            const long len0, const long len1, const long len2) {
-   vector<size_t> offsets, counts;
-   if (0 < len0) {
-      offsets.push_back(0);
-      counts.push_back(len0);
-   }
-   if (0 < len1) {
-      offsets.push_back(0);
-      counts.push_back(len1);
-   }
-   if (0 < len2) {
-      offsets.push_back(0);
-      counts.push_back(len2);
-   }
-   var->putVar(offsets, counts, data);
+   _put_nc_data_with_dims(var, data, len0, len1, len2);
    return true;
 }
 
@@ -2630,20 +2379,7 @@ bool put_nc_data_with_dims(NcVar *var, const double *data,
 
 bool put_nc_data_with_dims(NcVar *var, const double *data,
                            const long len0, const long len1, const long len2) {
-   vector<size_t> offsets, counts;
-   if (0 < len0) {
-     offsets.push_back(0);
-     counts.push_back(len0);
-   }
-   if (0 < len1) {
-     offsets.push_back(0);
-     counts.push_back(len1);
-   }
-   if (0 < len2) {
-     offsets.push_back(0);
-     counts.push_back(len2);
-   }
-   var->putVar(offsets, counts, data);
+   _put_nc_data_with_dims(var, data, len0, len1, len2);
    return true;
 }
 
@@ -3259,7 +2995,7 @@ bool has_var(NcFile *nc, const char * var_name) {
 
 ////////////////////////////////////////////////////////////////////////
 
-NcVar add_var(NcFile *nc, const string var_name, const NcType ncType, const int deflate_level) {
+NcVar add_var(NcFile *nc, const string &var_name, const NcType ncType, const int deflate_level) {
    std::vector<NcDim> ncDimVector;
    string new_var_name = var_name;
    patch_nc_name(&new_var_name);
@@ -3274,7 +3010,7 @@ NcVar add_var(NcFile *nc, const string var_name, const NcType ncType, const int 
 
 ////////////////////////////////////////////////////////////////////////
 
-NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
+NcVar add_var(NcFile *nc, const string &var_name, const NcType ncType,
               const NcDim ncDim, const int deflate_level) {
    string new_var_name = var_name;
    patch_nc_name(&new_var_name);
@@ -3289,7 +3025,7 @@ NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
 
 ////////////////////////////////////////////////////////////////////////
 
-NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
+NcVar add_var(NcFile *nc, const string &var_name, const NcType ncType,
               const NcDim ncDim1, const NcDim ncDim2, const int deflate_level) {
    vector<NcDim> ncDims;
    ncDims.push_back(ncDim1);
@@ -3299,7 +3035,7 @@ NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
 
 ////////////////////////////////////////////////////////////////////////
 
-NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
+NcVar add_var(NcFile *nc, const string &var_name, const NcType ncType,
               const NcDim ncDim1, const NcDim ncDim2, const NcDim ncDim3, const int deflate_level) {
    vector<NcDim> ncDims;
    ncDims.push_back(ncDim1);
@@ -3310,7 +3046,7 @@ NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
 
 ////////////////////////////////////////////////////////////////////////
 
-NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
+NcVar add_var(NcFile *nc, const string &var_name, const NcType ncType,
               const NcDim ncDim1, const NcDim ncDim2, const NcDim ncDim3,
               const NcDim ncDim4, const int deflate_level) {
    vector<NcDim> ncDims;
@@ -3323,7 +3059,7 @@ NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
 
 ////////////////////////////////////////////////////////////////////////
 
-NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
+NcVar add_var(NcFile *nc, const string &var_name, const NcType ncType,
               const vector<NcDim> ncDims, const int deflate_level) {
    string new_var_name = var_name;
    patch_nc_name(&new_var_name);
@@ -3337,7 +3073,7 @@ NcVar add_var(NcFile *nc, const string var_name, const NcType ncType,
 
 ////////////////////////////////////////////////////////////////////////
 
-NcDim add_dim(NcFile *nc, string dim_name) {
+NcDim add_dim(NcFile *nc, const string &dim_name) {
    string new_dim_name = dim_name;
    patch_nc_name(&new_dim_name);
    return nc->addDim(new_dim_name);
@@ -3345,7 +3081,7 @@ NcDim add_dim(NcFile *nc, string dim_name) {
 
 ////////////////////////////////////////////////////////////////////////
 
-NcDim add_dim(NcFile *nc, string dim_name, size_t dim_size) {
+NcDim add_dim(NcFile *nc, const string &dim_name, const size_t dim_size) {
    string new_dim_name = dim_name;
    patch_nc_name(&new_dim_name);
    return nc->addDim(new_dim_name, dim_size);
@@ -3406,7 +3142,7 @@ int get_dim_size(const NcDim *dim) {
 
 ////////////////////////////////////////////////////////////////////////
 
-int get_dim_value(const NcFile *nc, string dim_name, bool error_out) {
+int get_dim_value(const NcFile *nc, const string &dim_name, const bool error_out) {
    NcDim dim;
    int dim_val;
    bool status = false;
@@ -3434,13 +3170,13 @@ int get_dim_value(const NcFile *nc, string dim_name, bool error_out) {
 
 ////////////////////////////////////////////////////////////////////////
 
-NcDim get_nc_dim(const NcFile *nc, string dim_name) {
+NcDim get_nc_dim(const NcFile *nc, const string &dim_name) {
    return nc->getDim(dim_name);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-NcDim get_nc_dim(const NcVar *var, string dim_name) {
+NcDim get_nc_dim(const NcVar *var, const string &dim_name) {
    NcDim d;
    int dimCount = var->getDimCount();
    for (int idx=0; idx<dimCount; idx++) {
@@ -3455,7 +3191,7 @@ NcDim get_nc_dim(const NcVar *var, string dim_name) {
 
 ////////////////////////////////////////////////////////////////////////
 
-NcDim get_nc_dim(const NcVar *var, int dim_offset) {
+NcDim get_nc_dim(const NcVar *var, const int dim_offset) {
    if (var->getDimCount() > dim_offset)
       return var->getDim(dim_offset);
    else {
@@ -3663,7 +3399,7 @@ NcVar get_nc_var_time(const NcFile *nc) {
    NcVar var;
    bool found = false;
    multimap<string,NcVar> mapVar = GET_NC_VARS_P(nc);
-   static const char *method_name = "get_nc_var_time()) ";
+   static const char *method_name = "get_nc_var_time() ";
 
    for (multimap<string,NcVar>::iterator itVar = mapVar.begin();
         itVar != mapVar.end(); ++itVar) {
@@ -3740,7 +3476,7 @@ unixtime get_reference_unixtime(NcVar *time_var, int &sec_per_unit,
                                 bool &no_leap_year) {
    unixtime ref_ut = 0;
    ConcatString time_unit_str;
-   static const char *method_name = "get_reference_unixtime()) -> ";
+   static const char *method_name = "get_reference_unixtime() -> ";
 
    if (get_nc_att_value(time_var, (string)"units", time_unit_str)) {
       parse_cf_time_string(time_unit_str.c_str(), ref_ut, sec_per_unit);
@@ -3785,9 +3521,9 @@ bool is_nc_unit_time(const char *units) {
 
 ////////////////////////////////////////////////////////////////////////
 
-
 void parse_cf_time_string(const char *str, unixtime &ref_ut,
                           int &sec_per_unit) {
+   static const char *method_name = "parse_cf_time_string() -> ";
 
    // Initialize
    ref_ut = sec_per_unit = 0;
@@ -3795,7 +3531,7 @@ void parse_cf_time_string(const char *str, unixtime &ref_ut,
    // Check for expected time string format:
    //   [seconds|minutes|hours|days] since YYYY-MM-DD HH:MM:SS
    if(!check_reg_exp(nc_time_unit_exp, str)) {
-      mlog << Warning << "\nparse_cf_time_string() -> "
+      mlog << Warning << "\n" << method_name
            << "unexpected NetCDF CF convention time unit \""
            << str << "\"\n\n";
       return;
@@ -3824,7 +3560,7 @@ void parse_cf_time_string(const char *str, unixtime &ref_ut,
               tok.has("days")    ||
               tok.has("d"))      sec_per_unit = 86400;
       else {
-         mlog << Warning << "\nparse_cf_time_string() -> "
+         mlog << Warning << "\n" << method_name
               << "Unsupported time step in the CF convention time unit \""
               << str << "\"\n\n";
          return;
@@ -3841,7 +3577,7 @@ void parse_cf_time_string(const char *str, unixtime &ref_ut,
                               hms.n_elements() > 2 ? atoi(hms[2].c_str()) : 0);
    }
 
-   mlog << Debug(4) << "parse_cf_time_string() -> "
+   mlog << Debug(4) << method_name
         << "parsed NetCDF CF convention time unit string \"" << str
         << "\"\n\t\t as a reference time of " << unix_to_yyyymmdd_hhmmss(ref_ut)
         << " and " << sec_per_unit << " second(s) per time step.\n";

--- a/met/src/libcode/vx_nc_util/nc_utils.h
+++ b/met/src/libcode/vx_nc_util/nc_utils.h
@@ -22,8 +22,10 @@ using namespace std;
 using namespace netCDF;
 #ifndef ncbyte
 typedef signed char ncbyte; // from ncvalues.h
-typedef unsigned char uchar;
 #endif   /*  ncbyte  */
+#ifndef uchar
+typedef unsigned char uchar;
+#endif   /*  uchar  */
 
 #include "concat_string.h"
 #include "int_array.h"
@@ -35,7 +37,7 @@ typedef unsigned char uchar;
 static const string C_unknown_str = string("unknown");
 
 #define IS_VALID_NC(ncObj)          (!ncObj.isNull())
-#define IS_VALID_NC_P(ncObjPtr)     (!(ncObjPtr == 0 || ncObjPtr->isNull()))
+#define IS_VALID_NC_P(ncObjPtr)     ((ncObjPtr != 0 && !ncObjPtr->isNull()))
 
 #define IS_INVALID_NC(ncObj)        ncObj.isNull()
 #define IS_INVALID_NC_P(ncObjPtr)   (ncObjPtr == 0 || ncObjPtr->isNull())
@@ -159,7 +161,6 @@ extern bool      get_att_value_string(const NcFile *, const ConcatString& , Conc
 extern int       get_att_value_int   (const NcFile *, const ConcatString& );
 extern long long get_att_value_llong (const NcFile *, const ConcatString& );
 extern double    get_att_value_double(const NcFile *, const ConcatString& );
-
 extern bool      get_att_no_leap_year(const NcVar *);
 
 extern NcVarAtt    *get_nc_att(const NcVar  *, const ConcatString &, bool exit_on_error = false);
@@ -174,28 +175,28 @@ extern bool get_nc_att_value(const NcVar *, const ConcatString &, int          &
 extern bool get_nc_att_value(const NcVar *, const ConcatString &, float        &, bool exit_on_error = false);
 
 extern bool has_att(NcFile *, const ConcatString name, bool exit_on_error = false);
+extern bool has_unsigned_attribute(NcVar *);
 
 extern bool get_global_att(const NcGroupAtt *, ConcatString &);
-extern bool get_global_att(const char *, const ConcatString &, bool &);
-extern bool get_global_att(const char *, const ConcatString &, ConcatString &);
+extern bool get_global_att(const char *,   const ConcatString &, bool &);
+extern bool get_global_att(const char *,   const ConcatString &, ConcatString &);
 extern bool get_global_att(const NcFile *, const ConcatString &, ConcatString &, bool error_out = false);
-extern bool get_global_att(const NcFile *, const ConcatString&, int &, bool error_out = false);
-extern bool get_global_att(const NcFile *, const ConcatString&, bool &, bool error_out = false);
-extern bool get_global_att(const NcFile *, const ConcatString&, float &, bool error_out = false);
-extern bool get_global_att(const NcFile *, const ConcatString&, double &, bool error_out = false);
-extern bool get_global_att_double(const NcFile *, const ConcatString &, double &, bool error_out = false);
+extern bool get_global_att(const NcFile *, const ConcatString &, int &, bool error_out = false);
+extern bool get_global_att(const NcFile *, const ConcatString &, bool &, bool error_out = false);
+extern bool get_global_att(const NcFile *, const ConcatString &, float &, bool error_out = false);
+extern bool get_global_att(const NcFile *, const ConcatString &, double &, bool error_out = false);
 
 extern  int get_version_no(const NcFile *);
 extern bool is_version_less_than_1_02(const NcFile *nc);
 
-extern void add_att(NcFile *, const string, const int   );
-extern void add_att(NcFile *, const string, const string);
-extern void add_att(NcFile *, const string, const char *);
-extern void add_att(NcFile *, const string, const ConcatString);
-extern void add_att(NcVar  *, const string, const string);
-extern void add_att(NcVar  *, const string, const int   );
-extern void add_att(NcVar  *, const string, const float );
-extern void add_att(NcVar  *, const string, const double);
+extern void add_att(NcFile *, const string &, const int   );
+extern void add_att(NcFile *, const string &, const string);
+extern void add_att(NcFile *, const string &, const char *);
+extern void add_att(NcFile *, const string &, const ConcatString);
+extern void add_att(NcVar  *, const string &, const string);
+extern void add_att(NcVar  *, const string &, const int   );
+extern void add_att(NcVar  *, const string &, const float );
+extern void add_att(NcVar  *, const string &, const double);
 
 extern int    get_var_names(NcFile *, StringArray *varNames);
 
@@ -203,34 +204,26 @@ extern bool   get_var_att_float (const NcVar *, const ConcatString &, float  &);
 extern bool   get_var_att_double(const NcVar *, const ConcatString &, double &);
 
 extern bool   get_var_units(const NcVar *, ConcatString &);
-
 extern bool   get_var_level(const NcVar *, ConcatString &);
-
 extern double get_var_missing_value(const NcVar *);
-
 extern double get_var_fill_value(const NcVar *);
 
 extern bool   args_ok(const LongArray &);
 
 extern char   get_char_val(NcFile *, const char * var_name, const int index);
-
 extern char   get_char_val(NcVar *var, const int index);
 
 extern int    get_int_var(NcFile *, const char * var_name, const int index);
-
 extern int    get_int_var(NcVar *, const int index);
 
 extern double get_double_var(NcFile *, const char * var_name, const int index = 0);
-
 extern double get_double_var(NcVar *, int index = 0);
 
 extern float  get_float_var(NcFile *, const char * var_name, const int index = 0);
-
 extern float  get_float_var(NcVar *, int const index = 0);
 
 extern ConcatString* get_string_val(NcFile *, const char * var_name, const int index,
-                    const int len, ConcatString &tmp_cs);
-
+                                    const int len, ConcatString &tmp_cs);
 extern ConcatString* get_string_val(NcVar *var, const int index, const int len, ConcatString &tmp_cs);
 
 extern bool get_nc_data(NcVar *, int    *data);
@@ -242,11 +235,11 @@ extern bool get_nc_data(NcVar *, time_t *data);
 extern bool get_nc_data(NcVar *, ncbyte *data);
 extern bool get_nc_data(NcVar *, unsigned short *data);
 
-extern bool get_nc_data(NcVar *, int    *data, const long *cur);
-extern bool get_nc_data(NcVar *, char   *data, const long *cur);
-extern bool get_nc_data(NcVar *, short  *data, const long *cur);
-extern bool get_nc_data(NcVar *, float  *data, const long *cur);
-extern bool get_nc_data(NcVar *, double *data, const long *cur);
+extern bool get_nc_data(NcVar *, int    *data, const long *curs);
+extern bool get_nc_data(NcVar *, char   *data, const long *curs);
+extern bool get_nc_data(NcVar *, short  *data, const long *curs);
+extern bool get_nc_data(NcVar *, float  *data, const long *curs);
+extern bool get_nc_data(NcVar *, double *data, const long *curs);
 
 extern bool get_nc_data(NcVar *, int    *data, const long dim, const long cur=0);
 extern bool get_nc_data(NcVar *, char   *data, const long dim, const long cur=0);
@@ -254,18 +247,18 @@ extern bool get_nc_data(NcVar *, float  *data, const long dim, const long cur=0)
 extern bool get_nc_data(NcVar *, double *data, const long dim, const long cur=0);
 extern bool get_nc_data(NcVar *, ncbyte *data, const long dim, const long cur=0);
 
-extern bool get_nc_data(NcVar *, int    *data, const long *dim, const long *cur);
-extern bool get_nc_data(NcVar *, char   *data, const long *dim, const long *cur);
-extern bool get_nc_data(NcVar *, short  *data, const long *dim, const long *cur);
-extern bool get_nc_data(NcVar *, float  *data, const long *dim, const long *cur);
-extern bool get_nc_data(NcVar *, double *data, const long *dim, const long *cur);
-extern bool get_nc_data(NcVar *, ncbyte *data, const long *dim, const long *cur);
+extern bool get_nc_data(NcVar *, int    *data, const long *dims, const long *curs);
+extern bool get_nc_data(NcVar *, char   *data, const long *dims, const long *curs);
+extern bool get_nc_data(NcVar *, short  *data, const long *dims, const long *curs);
+extern bool get_nc_data(NcVar *, float  *data, const long *dims, const long *curs);
+extern bool get_nc_data(NcVar *, double *data, const long *dims, const long *curs);
+extern bool get_nc_data(NcVar *, ncbyte *data, const long *dims, const long *curs);
 
-extern bool get_nc_data(NcFile *, const char *var_name, int    *data, const long *cur, const long *dim);
-extern bool get_nc_data(NcFile *, const char *var_name, char   *data, const long *cur, const long *dim);
-extern bool get_nc_data(NcFile *, const char *var_name, float  *data, const long *cur, const long *dim);
-extern bool get_nc_data(NcFile *, const char *var_name, double *data, const long *cur, const long *dim);
-extern bool get_nc_data(NcFile *, const char *var_name, ncbyte *data, const long *cur, const long *dim);
+extern bool get_nc_data(NcFile *, const char *var_name, int    *data, const long *curs, const long *dims);
+extern bool get_nc_data(NcFile *, const char *var_name, char   *data, const long *curs, const long *dims);
+extern bool get_nc_data(NcFile *, const char *var_name, float  *data, const long *curs, const long *dims);
+extern bool get_nc_data(NcFile *, const char *var_name, double *data, const long *curs, const long *dims);
+extern bool get_nc_data(NcFile *, const char *var_name, ncbyte *data, const long *curs, const long *dims);
 
 extern bool get_nc_data_to_array(NcVar  *, StringArray *);
 extern bool get_nc_data_to_array(NcFile *, const char *, StringArray *);
@@ -289,9 +282,9 @@ extern bool put_nc_data(NcVar *, const char   *data, const long length, const lo
 extern bool put_nc_data(NcVar *, const float  *data, const long length, const long offset);
 extern bool put_nc_data(NcVar *, const double *data, const long length, const long offset);
 extern bool put_nc_data(NcVar *, const ncbyte *data, const long length, const long offset);
-extern bool put_nc_data(NcVar *, const int    *data, const long *length, const long *offset);
-extern bool put_nc_data(NcVar *, const char   *data, const long *length, const long *offset);
-extern bool put_nc_data(NcVar *, const float  *data, const long *length, const long *offset);
+extern bool put_nc_data(NcVar *, const int    *data, const long *lengths, const long *offsets);
+extern bool put_nc_data(NcVar *, const char   *data, const long *lengths, const long *offsets);
+extern bool put_nc_data(NcVar *, const float  *data, const long *lengths, const long *offsets);
 
 extern bool put_nc_data_with_dims(NcVar *, const int *data, const int len0,
                                   const int len1=0, const int len2=0);
@@ -317,24 +310,24 @@ extern void copy_nc_var_data(NcVar *, NcVar *);
 
 extern bool has_var(NcFile *, const char * var_name);
 
-extern NcVar  add_var(NcFile *, const string, const NcType, const int deflate_level=DEF_DEFLATE_LEVEL);
-extern NcVar  add_var(NcFile *, const string, const NcType, const NcDim, const int deflate_level=DEF_DEFLATE_LEVEL);
-extern NcVar  add_var(NcFile *, const string, const NcType, const NcDim, const NcDim, const int deflate_level=DEF_DEFLATE_LEVEL);
-extern NcVar  add_var(NcFile *, const string, const NcType, const NcDim, const NcDim, const NcDim, const int deflate_level=DEF_DEFLATE_LEVEL);
-extern NcVar  add_var(NcFile *, const string, const NcType, const NcDim, const NcDim, const NcDim, const NcDim, const int deflate_level=DEF_DEFLATE_LEVEL);
-extern NcVar  add_var(NcFile *, const string, const NcType, const vector<NcDim>, const int deflate_level=DEF_DEFLATE_LEVEL);
+extern NcVar  add_var(NcFile *, const string &, const NcType, const int deflate_level=DEF_DEFLATE_LEVEL);
+extern NcVar  add_var(NcFile *, const string &, const NcType, const NcDim, const int deflate_level=DEF_DEFLATE_LEVEL);
+extern NcVar  add_var(NcFile *, const string &, const NcType, const NcDim, const NcDim, const int deflate_level=DEF_DEFLATE_LEVEL);
+extern NcVar  add_var(NcFile *, const string &, const NcType, const NcDim, const NcDim, const NcDim, const int deflate_level=DEF_DEFLATE_LEVEL);
+extern NcVar  add_var(NcFile *, const string &, const NcType, const NcDim, const NcDim, const NcDim, const NcDim, const int deflate_level=DEF_DEFLATE_LEVEL);
+extern NcVar  add_var(NcFile *, const string &, const NcType, const vector<NcDim>, const int deflate_level=DEF_DEFLATE_LEVEL);
 
-extern NcDim  add_dim(NcFile *, string);
-extern NcDim  add_dim(NcFile *, string, size_t);
-extern bool   has_dim(NcFile *, const char * dim_name);
+extern NcDim  add_dim(NcFile *, const string &);
+extern NcDim  add_dim(NcFile *, const string &, const size_t);
+extern bool   has_dim(NcFile *, const char *dim_name);
 extern bool   get_dim(const NcFile *, const ConcatString &, int &, bool error_out = false);
 extern int    get_dim_count(const NcVar *);
 extern int    get_dim_count(const NcFile *);
 extern int    get_dim_size(const NcDim *);
-extern int    get_dim_value(const NcFile *, const string, bool error_out = false);
-extern NcDim  get_nc_dim(const NcFile *, string dim_name);
-extern NcDim  get_nc_dim(const NcVar *, string dim_name);
-extern NcDim  get_nc_dim(const NcVar *, int dim_offset);
+extern int    get_dim_value(const NcFile *, const string &, const bool error_out = false);
+extern NcDim  get_nc_dim(const NcFile *, const string &dim_name);
+extern NcDim  get_nc_dim(const NcVar *, const string &dim_name);
+extern NcDim  get_nc_dim(const NcVar *, const int dim_offset);
 extern bool   get_dim_names(const NcVar *var, StringArray *dimNames);
 extern bool   get_dim_names(const NcFile *nc, StringArray *dimNames);
 

--- a/met/src/tools/other/point2grid/point2grid.cc
+++ b/met/src/tools/other/point2grid/point2grid.cc
@@ -2271,15 +2271,15 @@ void regrid_goes_variable(NcFile *nc_in, VarInfo *vinfo,
    ConcatString goes_var_name;
    ConcatString goes_var_sub_name;
    ConcatString qc_var_name;
-   ncbyte qc_value;
-   ncbyte *qc_data = new ncbyte[from_data_size];
+   uchar qc_value;
+   uchar *qc_data = new uchar[from_data_size];
    uchar *adp_data = new uchar[from_data_size];
    float *from_data = new float[from_data_size];
    unsigned short *adp_qc_data = new unsigned short[from_data_size];
    static const char *method_name = "regrid_goes_variable() ";
 
    // -99 is arbitrary number as invalid QC value
-   memset(qc_data, -99, from_data_size*sizeof(ncbyte));
+   memset(qc_data, -99, from_data_size*sizeof(uchar));
 
    NcVar var_qc;
    NcVar var_adp;

--- a/test/xml/unit_point2grid.xml
+++ b/test/xml/unit_point2grid.xml
@@ -218,4 +218,22 @@
       <grid_nc>&OUTPUT_DIR;/point2grid/point2grid_NCCF_TO_G231.nc</grid_nc>
     </output>
   </test>
+
+  <test name="point2grid_GOES_16_AOD_TO_G212_unsigned">
+    <exec>&MET_BIN;/point2grid</exec>
+    <env>
+      <pair><name>MET_TMP_DIR</name>  <value>&OUTPUT_DIR;</value></pair>
+    </env>
+    <param> \
+      &DATA_DIR_MODEL;/goes_16/OR_ABI-L2-AODC-M6_G16_s20202581441152_e20202581443525_c20202581445493.nc \
+      G212 \
+      &OUTPUT_DIR;/point2grid/point2grid_GOES_16_AOD_TO_G212_unsigned.nc \
+      -field 'name="AOD";  level="(*,*)";' \
+      -qc 1,2,3 -method MAX \
+      -v 1
+    </param>
+    <output>
+      <grid_nc>&OUTPUT_DIR;/point2grid/point2grid_GOES_16_AOD_TO_G212_unsigned.nc</grid_nc>
+    </output>
+  </test>
 </met_test>


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

- [x] Recommend testing for the reviewer to perform, including the location of input datasets:</br>

- [x] Will this PR result in changes to the regression test output? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.

The new AOD outputs have the unsigned byte and unsigned short instead of signed byte/short with "_Unsigned" attribute. The segmentation fault happened at the NetCDF library because that the values at the data value range attributes is out of scope. This was fixed at the vx_nc_util library. In addition, the duplicated codes were reduced by using template. Some APIs which pass the argument as call by value were changed to call by reference for better performance (avoid copying argument value).

get_pinterp_grid.cc : renamed API "get_global_att_double" to "get_global_att".
met/src/libcode/vx_nc_util/nc_utils.h: changes for call by reference


The input data file is added to dakota:
     /d3/projects/MET/MET_test_data/unit_test/model_data/goes_16/OR_ABI-L2-AODC-M6_G16_s20202581441152_e20202581443525_c20202581445493.nc

New output from the Unittest:
     &OUTPUT_DIR;/point2grid/point2grid_GOES_16_AOD_TO_G212_unsigned.nc

How to test:

- run unittest with "unit_point2grid.xml"
- Or run the following command
```
./bin/point2grid \
      /d3/projects/MET/MET_test_data/unit_test/model_data/goes_16/OR_ABI-L2-AODC-M6_G16_s20202581441152_e20202581443525_c20202581445493.nc \
      G212 \
      ./point2grid_GOES_16_AOD_TO_G212_unsigned.nc \
      -field 'name="AOD";  level="(*,*)";' \
      -qc 1,2,3 -method MAX \
      -v 1
```
