### PR TITLE
Feature 1493 time as byte

### DIFF
--- a/met/src/libcode/vx_data2d_nccf/nccf_file.cc
+++ b/met/src/libcode/vx_data2d_nccf/nccf_file.cc
@@ -320,7 +320,7 @@ bool NcCfFile::open(const char * filepath)
     bool no_leap_year = get_att_no_leap_year(valid_time_var);
     for(int i=0; i<n_times; i++)
     {
-      double time_value = get_double_var(valid_time_var, i);
+      double time_value = get_nc_time(valid_time_var, i);
       ValidTime.add(add_to_unixtime(ut, sec_per_unit, time_value, no_leap_year));
     }
   }
@@ -369,7 +369,7 @@ bool NcCfFile::open(const char * filepath)
 
     if (units_att) delete units_att;
 
-    double time_value = get_double_var(&init_time_var,(int)0);
+    double time_value = get_nc_time(&init_time_var,(int)0);
     InitTime = (unixtime)ut + sec_per_unit * time_value;
 
     //bool no_leap_year = get_att_no_leap_year(&init_time_var);
@@ -848,7 +848,6 @@ double NcCfFile::getData(NcVar * var, const LongArray & a) const
            << "bad type [" << GET_NC_TYPE_NAME_P(var)
            << "] for variable \"" << (GET_NC_NAME_P(var)) << "\"\n\n";
       exit(1);
-      break;
     }
   }   //  switch
   if ((add_offset != 0.0 || scale_factor != 1.0) && !is_eq(d, missing_value) && !is_eq(d, fill_value)) {
@@ -2824,7 +2823,6 @@ bool NcCfFile::get_grid_from_dimensions()
   NcVar coord_var;
   const NcVarAtt units_att;
   ConcatString dim_units;
-  string dim_units_str;
   ConcatString dim_name;
   for (int dim_num = 0; dim_num < _numDims; ++dim_num)
   {

--- a/met/src/libcode/vx_nc_util/nc_utils.cc
+++ b/met/src/libcode/vx_nc_util/nc_utils.cc
@@ -419,7 +419,7 @@ NcVarAtt *get_nc_att(const NcVar * var, const ConcatString &att_name, bool exit_
          mlog << Error << "\n" << method_name
               << "can't read attribute \"" << att_name
               << "\" from \"" << var->getName() << "\" variable.\n\n";
-         if (exit_on_error) exit(1);
+         exit(1);
       }
    }
    return(att);
@@ -451,11 +451,11 @@ NcGroupAtt *get_nc_att(const NcFile * nc, const ConcatString &att_name, bool exi
          }
       }
 
-      if(IS_INVALID_NC_P(att)) {
+      if(IS_INVALID_NC_P(att) && exit_on_error) {
          mlog << Error << "\n" << method_name
               << "can't read attribute \"" << att_name
               << "\" from \"" << nc->getName() << "\".\n\n";
-         if (exit_on_error) exit(1);
+         exit(1);
       }
    }
    return(att);

--- a/met/src/libcode/vx_nc_util/nc_utils.cc
+++ b/met/src/libcode/vx_nc_util/nc_utils.cc
@@ -1086,13 +1086,6 @@ int get_int_var(NcVar * var, const int index) {
 
 ////////////////////////////////////////////////////////////////////////
 
-//double get_nc_time(NcFile * nc, const char * var_name, const int index) {
-//   NcVar var = get_var(nc, var_name);
-//   return(get_nc_time(&var, index));
-//}
-
-////////////////////////////////////////////////////////////////////////
-
 double get_nc_time(NcVar * var, const int index) {
    double k;
    std::vector<size_t> start;

--- a/met/src/libcode/vx_nc_util/nc_utils.cc
+++ b/met/src/libcode/vx_nc_util/nc_utils.cc
@@ -438,19 +438,20 @@ NcGroupAtt *get_nc_att(const NcFile * nc, const ConcatString &att_name, bool exi
       mlog << Error << "\n" << method_name
            << "can't read attribute \"" << att_name
            << "\" from because NC is invalid.\n\n";
+      if (exit_on_error) exit(1);
    }
    else {
       multimap<string,NcGroupAtt>::iterator itAtt;
       multimap<string,NcGroupAtt> mapAttrs = nc->getAtts();
       for (itAtt = mapAttrs.begin(); itAtt != mapAttrs.end(); ++itAtt) {
-      if ( att_name == (*itAtt).first ) {
+         if ( att_name == (*itAtt).first ) {
             att = new NcGroupAtt();
             *att = (*itAtt).second;
             break;
          }
       }
 
-      if(IS_INVALID_NC_P(att) && exit_on_error) {
+      if(IS_INVALID_NC_P(att)) {
          mlog << Error << "\n" << method_name
               << "can't read attribute \"" << att_name
               << "\" from \"" << nc->getName() << "\".\n\n";
@@ -1085,17 +1086,18 @@ int get_int_var(NcVar * var, const int index) {
 
 ////////////////////////////////////////////////////////////////////////
 
-double get_double_var(NcFile * nc, const char * var_name, const int index) {
-   NcVar var = get_var(nc, var_name);
-   return(get_double_var(&var, index));
-}
+//double get_nc_time(NcFile * nc, const char * var_name, const int index) {
+//   NcVar var = get_var(nc, var_name);
+//   return(get_nc_time(&var, index));
+//}
 
 ////////////////////////////////////////////////////////////////////////
 
-double get_double_var(NcVar * var, const int index) {
+double get_nc_time(NcVar * var, const int index) {
    double k;
    std::vector<size_t> start;
    std::vector<size_t> count;
+   const char *method_name = "get_nc_time() -> ";
 
    k = bad_data_double;
    if (IS_VALID_NC_P(var)) {
@@ -1105,6 +1107,7 @@ double get_double_var(NcVar * var, const int index) {
       int vi;
       short vs;
       float vf;
+      ncbyte vb;
       long long vl;
       int dataType = GET_NC_TYPE_ID_P(var);
       switch (dataType) {
@@ -1119,6 +1122,10 @@ double get_double_var(NcVar * var, const int index) {
             var->getVar(start, count, &vs);
             k = (double)vs;
             break;
+         case NC_BYTE:
+            var->getVar(start, count, &vb);
+            k = (double)vs;
+            break;
          case NC_INT:
             var->getVar(start, count, &vi);
             k = (double)vi;
@@ -1129,16 +1136,16 @@ double get_double_var(NcVar * var, const int index) {
             k = (double)vl;
             converted_vl = (long long)k;
             if (converted_vl != vl) {
-               mlog << Warning << "\nget_double_var() -> "
+               mlog << Warning << "\n" << method_name
                     << " the value was changed during type conversion: "
                     << converted_vl << " (was  " << vl << ")\n";
             }
             break;
          default:
-            mlog << Error << "\nget_double_var() -> "
+            mlog << Error << "\n" << method_name
                  << "data type mismatch (double vs. \"" << GET_NC_TYPE_NAME_P(var)
-                 << "\").\nIt won't be converted because of dimension issue.\n"
-                 << "Please correct the data type to double for variable \"" << GET_NC_NAME_P(var) << "\".\n\n";
+                 << "\").\nPlease correct the data type to double for variable \""
+                 << GET_NC_NAME_P(var) << "\".\n\n";
             exit(1);
       }
    }

--- a/met/src/libcode/vx_nc_util/nc_utils.h
+++ b/met/src/libcode/vx_nc_util/nc_utils.h
@@ -216,7 +216,6 @@ extern char   get_char_val(NcVar *var, const int index);
 extern int    get_int_var(NcFile *, const char * var_name, const int index);
 extern int    get_int_var(NcVar *, const int index);
 
-//extern double get_nc_time(NcFile *, const char * var_name, const int index = 0);
 extern double get_nc_time(NcVar *, int index = 0);
 
 extern float  get_float_var(NcFile *, const char * var_name, const int index = 0);

--- a/met/src/libcode/vx_nc_util/nc_utils.h
+++ b/met/src/libcode/vx_nc_util/nc_utils.h
@@ -216,8 +216,8 @@ extern char   get_char_val(NcVar *var, const int index);
 extern int    get_int_var(NcFile *, const char * var_name, const int index);
 extern int    get_int_var(NcVar *, const int index);
 
-extern double get_double_var(NcFile *, const char * var_name, const int index = 0);
-extern double get_double_var(NcVar *, int index = 0);
+//extern double get_nc_time(NcFile *, const char * var_name, const int index = 0);
+extern double get_nc_time(NcVar *, int index = 0);
 
 extern float  get_float_var(NcFile *, const char * var_name, const int index = 0);
 extern float  get_float_var(NcVar *, int const index = 0);

--- a/met/src/tools/other/point2grid/point2grid.cc
+++ b/met/src/tools/other/point2grid/point2grid.cc
@@ -269,6 +269,13 @@ void process_command_line(int argc, char **argv) {
    RGInfo.name    = cline[1];
    OutputFilename = cline[2];
 
+   // Check if the input file
+   if ( !file_exists(InputFilename.c_str()) ) {
+      mlog << Error << "\n" << method_name
+           << "file does not exist \"" << InputFilename << "\"\n\n";
+      exit(1);
+   }
+
    // Check for at least one configuration string
    if(FieldSA.n() < 1) {
       mlog << Error << "\nprocess_command_line() -> "
@@ -1104,7 +1111,6 @@ void process_point_nccf_file(NcFile *nc_in, MetConfig &config,
    bool opt_all_attrs = false;
    Grid fr_grid = fr_mtddf->grid();
 
-   unixtime requested_valid_time, valid_time = 0;
    static const char *method_name = "process_point_file_with_latlon() -> ";
 
    NcVar var_lat = get_nc_var_lat(nc_in);
@@ -1127,7 +1133,7 @@ void process_point_nccf_file(NcFile *nc_in, MetConfig &config,
       usage();
    }
 
-   valid_time = find_valid_time(nc_in);
+   unixtime valid_time = find_valid_time(nc_in);
    to_dp.set_size(to_grid.nx(), to_grid.ny());
    IntArray *cellMapping = new IntArray[to_grid.nx() * to_grid.ny()];
    get_grid_mapping(fr_grid, to_grid, cellMapping, var_lat, var_lon);

--- a/test/xml/unit_netcdf.xml
+++ b/test/xml/unit_netcdf.xml
@@ -94,5 +94,18 @@
       <grid_nc>&OUTPUT_DIR;/netcdf/grid_stat/grid_stat_no_leap_000000L_19860101_000000V_pairs.nc</grid_nc>
     </output>
   </test>
-  
+
+  <test name="netcdf_1byte_time">
+    <exec>&MET_BIN;/plot_data_plane</exec>
+    <param> \
+      &DATA_DIR_MODEL;/nccf/cyg.ddmi.s20200803-003000-e20200803-233000.l3.grid-wind.a10.d21.nc \
+      &OUTPUT_DIR;/netcdf/test_1byte_time.ps \
+      'name="wind_speed"; level="(0,*,*)";' \
+      -v 4
+    </param>
+    <output>
+      <ps>&OUTPUT_DIR;/netcdf/test_1byte_time.ps</ps>
+    </output>
+  </test>
+
 </met_test>


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

- [x] Recommend testing for the reviewer to perform, including the location of input datasets:</br>

- [x] Will this PR result in changes to the test suite? **No**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] After merging, should the reviewer **DELETE** the feature branch from GitHub? **Yes**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [ ] After submitting the PR, select **Linked Issues** with the original issue number.

Updates:
- The API "get_double_var" at nc_utils.cc is renamed to "get_nc_time".
- point2grid: give the proper error message if the input file does not exist
- Added an unit test to unit_netcdf.xml

Note: The location of the test input file:
dakota:/d3/projects/MET/MET_test_data/unit_test/model_data/nccf/cyg.ddmi.s20200803-003000-e20200803-233000.l3.grid-wind.a10.d21.nc
kiowa:/d1/projects/MET/MET_test_data/unit_test/model_data/nccf/cyg.ddmi.s20200803-003000-e20200803-233000.l3.grid-wind.a10.d21.nc

At dakota:
./plot_data_plane /d3/projects/MET/MET_test_data/unit_test/model_data/nccf/cyg.ddmi.s20200803-003000-e20200803-233000.l3.grid-wind.a10.d21.nc time_as_byte.ps 'name="wind_speed"; level="(1,\*,\*)";' -v 2
OR
At kiowa:
./plot_data_plane /d1/projects/MET/MET_test_data/unit_test/model_data/nccf/cyg.ddmi.s20200803-003000-e20200803-233000.l3.grid-wind.a10.d21.nc time_as_byte.ps 'name="wind_speed"; level="(1,\*,\*)";' -v 2

for point2grid
./point2grid file_does_not_exist.nc G212 dumpy_output.nc -field 'name=\"AOD\"; level=\"\*\";'