### PR TITLE
Feature 1527 log second try

### DIFF
--- a/met/src/basic/vx_util/command_line.cc
+++ b/met/src/basic/vx_util/command_line.cc
@@ -864,12 +864,11 @@ void CommandLine::do_verbosity()
 int i_arg;
 
    //
-   //  use the last -v option
+   //  parse and remove all the -v options
+   //  in case it is used more than once
    //
 
-args.has(verbosity_option, i_arg, false);
-
-if ( i_arg >= 0 )  {
+while ( args.has(verbosity_option, i_arg) )  {
 
    mlog.set_verbosity_level(atoi(args[i_arg+1].c_str()));
    args.shift_down(i_arg, 2);
@@ -891,12 +890,11 @@ void CommandLine::do_log()
 int i_arg;
 
    //
-   //  use the last -log option
+   //  parse and remove all the -log options
+   //  in case it is used more than once
    //
 
-args.has(log_option, i_arg, false);
-
-if ( i_arg >= 0 )  {
+while ( args.has(log_option, i_arg) )  {
 
    mlog.open_log_file(args[i_arg+1]);
    args.shift_down(i_arg, 2);


### PR DESCRIPTION
## Pull Request Testing ##

I found a problem with the code changes for #1527. In command_line.cc, do_verbosity() and do_log() only parsed the LAST instance of the -v and -log options, respectively. If they are used more than once on the command line, the extra ones remain in the list but the calling application doesn't know how to parse them. Fix this by having the do_verbosity() and do_log() parse and remove all of them from the command line object in the order provided.

- [x] Describe testing already performed for these changes:</br>
Tested by running:
```
met/bin/plot_point_obs met/out/pb2nc/sample_pb.nc plot.ps -v 1 -v 2 -log a -log b
```
Prior to the fix, this errors out. After the fix, it runs fine. This matches the behavior in the main_v9.1 branch.

- [x] Recommend testing for the reviewer to perform, including the location of input datasets:</br>
Review code changes. Run a couple of tests to confirm that the fix makes -v and -log work the same as they do in MET version 9.1.

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
