### PR TITLE
Feature 1604 ens_config second try

### DIFF
--- a/met/src/libcode/vx_data2d_grib/data2d_grib_utils.cc
+++ b/met/src/libcode/vx_data2d_grib/data2d_grib_utils.cc
@@ -49,8 +49,12 @@ bool is_prelim_match( VarInfoGrib & vinfo, const GribRecord & g)
 
    ConcatString field_name = vinfo.name();
 
-   //clean up the code - exept for code 33 and 34 (UGRID and VGRID) and name WIND when we derive wind speed and direction
-   bool is_lookup_for_wind_components = (vinfo.code () == ugrd_grib_code || vinfo.code () == vgrd_grib_code) && field_name == "WIND";
+   // clean up the code - except for code 33 and 34 (UGRID and VGRID)
+   // and name WIND when we derive wind speed and direction
+   bool is_lookup_for_wind_components =
+      ( vinfo.code () == ugrd_grib_code || \
+        vinfo.code () == vgrd_grib_code ) && \
+      field_name == "WIND";
    if ( is_lookup_for_wind_components)
    {
       //set field_name to null to force lookup by code
@@ -81,13 +85,13 @@ bool is_prelim_match( VarInfoGrib & vinfo, const GribRecord & g)
    if(is_bad_data(vinfo_center))    vinfo_center    = center;
    if(is_bad_data(vinfo_subcenter)) vinfo_subcenter = subcenter;
 
-   vinfo_ens_type      = ens_type;
-   vinfo_ens_number    = ens_number;
+   vinfo_ens_type   = ens_type;
+   vinfo_ens_number = ens_number;
 
    // check the ensemble config parameters
-   bool isEnsMatch;
+   bool isEnsMatch = true;
    ConcatString vinfo_ens = vinfo.ens();
-   if( vinfo_ens.nonempty() ) {
+   if ( ens_application == 1 && vinfo_ens.nonempty() )  {
       if( vinfo_ens == conf_key_grib_ens_hi_res_ctl ) {
          vinfo_ens_type = 1;
          vinfo_ens_number = 1;
@@ -113,8 +117,8 @@ bool is_prelim_match( VarInfoGrib & vinfo, const GribRecord & g)
          // if the string is numeric
          if( check_reg_exp("^[0-9]*$", ens_number_str) ) {
             vinfo_ens_number= atoi(ens_number_str);
-            delete[] ens_number_str;
          }
+         delete[] ens_number_str;
 
          // if one of the parameters was not set - error
          if( is_bad_data(vinfo_ens_number) ||
@@ -131,10 +135,8 @@ bool is_prelim_match( VarInfoGrib & vinfo, const GribRecord & g)
       // check that both match
       isEnsMatch = ( vinfo_ens_type   == ens_type &&
                      vinfo_ens_number == ens_number );
-   }
-   else {
-      isEnsMatch = true;
-   }
+
+   } // end if ensemble
 
    // Check for matching parameters
    if ( vinfo_ptv       != ptv       ||


### PR DESCRIPTION
## Pull Request Testing ##

The nightly Fortify run flagged two new findings as a result of these changes, 1 high and 1 medium. I reviewed them and realized that 2 things should be changed.
- Failing to delete dynamically allocated memory led to a memory leak.
- We should still only apply the ensemble filters when the ensemble flag is true. That led to an unused variable Fortify finding.

- [x] Describe testing already performed for these changes:</br>
Reran the plot_data_plane commands listed in PR #1608 to confirm they still work as before, and they do.

- [x] Recommend testing for the reviewer to perform, including the location of input datasets:</br>
Review code changes.

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
