### PR TITLE
Feature 1421 precision

### DIFF
--- a/met/src/libcode/vx_data2d_nccf/nccf_file.cc
+++ b/met/src/libcode/vx_data2d_nccf/nccf_file.cc
@@ -995,9 +995,9 @@ bool NcCfFile::getData(NcVar * v, const LongArray & a, DataPlane & plane) const
   //  get the data
   int    *i;
   short  *s;
-  double *d;
+  float  *f;
   const int plane_size = nx * ny;
-  float  *f = new float[plane_size];
+  double *d = new double[plane_size];
 
   size_t dim_size;
   long offsets[dim_count];
@@ -1039,26 +1039,26 @@ bool NcCfFile::getData(NcVar * v, const LongArray & a, DataPlane & plane) const
     case NcType::nc_SHORT:
       s = new short[plane_size];
       get_nc_data(v, s, lengths, offsets);
-      for (int x=0; x<plane_size; ++x) f[x] = (float)s[x];
+      for (int x=0; x<plane_size; ++x) d[x] = (double)s[x];
       delete [] s;
       break;
 
     case NcType::nc_INT:
       i = new int[plane_size];
       get_nc_data(v, i, lengths, offsets);
-      for (int x=0; x<plane_size; ++x) f[x] = (float)i[x];
+      for (int x=0; x<plane_size; ++x) d[x] = (double)i[x];
       delete [] i;
       break;
 
     case NcType::nc_FLOAT:
+      f = new float[plane_size];
       get_nc_data(v, f, lengths, offsets);
+      for (int x=0; x<plane_size; ++x) d[x] = (double)f[x];
+      delete [] f;
       break;
 
     case NcType::nc_DOUBLE:
-      d = new double[plane_size];
       get_nc_data(v, d, lengths, offsets);
-      for (int x=0; x<plane_size; ++x) f[x] = (float)d[x];
-      delete [] d;
       break;
   
     default:
@@ -1077,7 +1077,7 @@ bool NcCfFile::getData(NcVar * v, const LongArray & a, DataPlane & plane) const
       if (swap_to_north) y_offset = ny - 1 - y;
 
       for (int x = 0; x< nx; ++x) {
-        float value = f[offset++];
+        double value = d[offset++];
     
         if( is_eq(value, missing_value) || is_eq(value, fill_value) ) {
            value = bad_data_double;
@@ -1095,7 +1095,7 @@ bool NcCfFile::getData(NcVar * v, const LongArray & a, DataPlane & plane) const
         y_offset = y;
         if (swap_to_north) y_offset = ny - 1 - y;
 
-        float value = f[offset++];
+        double value = d[offset++];
 
         if( is_eq(value, missing_value) || is_eq(value, fill_value) ) {
            value = bad_data_double;
@@ -1108,7 +1108,7 @@ bool NcCfFile::getData(NcVar * v, const LongArray & a, DataPlane & plane) const
     }   //  for x
   }
 
-  delete [] f;
+  delete [] d;
 
   //  done
   mlog << Debug(6) << method_name << "took "

--- a/met/src/libcode/vx_nc_obs/nc_obs_util.cc
+++ b/met/src/libcode/vx_nc_obs/nc_obs_util.cc
@@ -1282,7 +1282,7 @@ int write_nc_string_array (NcVar *ncVar, StringArray &strArray, const int str_le
    // Initialize data_buf
    for (int indexX=0; indexX<buf_size; indexX++)
       for (int indexY=0; indexY<str_len; indexY++)
-        data_buf[indexX][indexY] = NULL;
+        data_buf[indexX][indexY] = 0;
 
    int buf_index = 0;
    int processed_count = 0;
@@ -1295,7 +1295,7 @@ int write_nc_string_array (NcVar *ncVar, StringArray &strArray, const int str_le
       len2 = strnlen(data_buf[buf_index], str_len);
       if (len2 < len) len2 = len;
       strncpy(data_buf[buf_index], string_data.c_str(), len);
-      if (len < str_len) data_buf[buf_index][len] = NULL;
+      if (len < str_len) data_buf[buf_index][len] = 0;
       for (int idx=len; idx<len2; idx++)
          data_buf[buf_index][idx] = bad_data_char;
 

--- a/met/src/tools/other/ioda2nc/ioda2nc.cc
+++ b/met/src/tools/other/ioda2nc/ioda2nc.cc
@@ -396,8 +396,8 @@ void process_ioda_file(int i_pb) {
    // Initialize
    filtered_times.clear();
    min_msg_ut = max_msg_ut = (unixtime) 0;
-   min_time_str[0] = NULL;
-   max_time_str[0] = NULL;
+   min_time_str[0] = 0;
+   max_time_str[0] = 0;
 
    // Set the file name for the IODA file
    file_name << ioda_files[i_pb];
@@ -658,7 +658,7 @@ void process_ioda_file(int i_pb) {
       if(has_msg_type) {
          int buf_len = sizeof(modified_hdr_typ);
          strncpy(hdr_typ, hdr_msg_types+(i_read*nstring), nstring);
-         hdr_typ[nstring] = NULL;
+         hdr_typ[nstring] = 0;
          // Null terminate the message type string
          cleanup_hdr_buf(hdr_typ, nstring);
 
@@ -681,13 +681,13 @@ void process_ioda_file(int i_pb) {
          else {
             strncpy(modified_hdr_typ, hdr_typ, buf_len);
          }
-         modified_hdr_typ[buf_len-1] = NULL;
+         modified_hdr_typ[buf_len-1] = 0;
       }
 
       if(has_station_id) {
          char tmp_sid[nstring+1];
          strncpy(tmp_sid, hdr_station_ids+(i_read*nstring), nstring);
-         tmp_sid[nstring] = NULL;
+         tmp_sid[nstring] = 0;
          cleanup_hdr_buf(tmp_sid, nstring);
          hdr_sid = tmp_sid;
       }


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

- [ ] Recommend testing for the reviewer to perform, including the location of input datasets:</br>

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [ ] After submitting the PR, select **Linked Issues** with the original issue number.



Two changes:
- Fix precision difference at the output of plot_data_plane (changed float to double)
- Remove the warning on compiling nc_obs_util.cc & ioda2nc.cc


        nc_obs_util.cc:1285:36: warning: converting to non-pointer type ‘char’ from NULL [-Wconversion-null]
                 data_buf[indexX][indexY] = NULL;
        nc_obs_util.cc:1298:53: warning: converting to non-pointer type ‘char’ from NULL [-Wconversion-null]
               if (len < str_len) data_buf[buf_index][len] = NULL;

How to test: 
1. run the plot_data_plane unit test.
2. the same unit test output of plot_data_plane.