### PR TITLE
feature 1580 nccf

### DIFF
--- a/met/src/libcode/vx_nc_util/nc_utils.cc
+++ b/met/src/libcode/vx_nc_util/nc_utils.cc
@@ -1667,7 +1667,7 @@ template <typename T>
 int _apply_scale_factor(double *data, const T *packed_data,
                         const int cell_count, const T fill_value,
                         T &raw_min_val, T &raw_max_val, const char *data_type,
-                        float add_offset, float scale_factor) {
+                        double add_offset, double scale_factor) {
    int positive_cnt = 0;
    int unpacked_count = 0;
    double min_value =  10e10;

--- a/met/src/libcode/vx_nc_util/nc_utils.cc
+++ b/met/src/libcode/vx_nc_util/nc_utils.cc
@@ -1404,7 +1404,7 @@ void _apply_scale_factor(float *data, const T *packed_data,
       else {
          if (raw_min_val > packed_data[idx]) raw_min_val = packed_data[idx];
          if (raw_max_val < packed_data[idx]) raw_max_val = packed_data[idx];
-         data[idx] = (packed_data[idx] * scale_factor) + add_offset;
+         data[idx] = ((float)packed_data[idx] * scale_factor) + add_offset;
          if (data[idx] > 0) positive_cnt++;
          if (min_value > data[idx]) min_value = data[idx];
          if (max_value < data[idx]) max_value = data[idx];
@@ -1680,7 +1680,7 @@ int _apply_scale_factor(double *data, const T *packed_data,
       else {
          if (raw_min_val > packed_data[idx]) raw_min_val = packed_data[idx];
          if (raw_max_val < packed_data[idx]) raw_max_val = packed_data[idx];
-         data[idx] = (packed_data[idx] * scale_factor) + add_offset;
+         data[idx] = ((double)packed_data[idx] * scale_factor) + add_offset;
          if (data[idx] > 0) positive_cnt++;
          if (min_value > data[idx]) min_value = data[idx];
          if (max_value < data[idx]) max_value = data[idx];

--- a/test/xml/unit_plot_data_plane.xml
+++ b/test/xml/unit_plot_data_plane.xml
@@ -257,6 +257,20 @@
     </output>
   </test>
 
+  <test name="plot_data_plane_NCCF_time">
+    <exec>&MET_BIN;/plot_data_plane</exec>
+    <param> \
+      &DATA_DIR_MODEL;/nccf/GloTEC_TEC_2015_03_17.nc \
+      &OUTPUT_DIR;/plot_data_plane/plot_data_plane_NCCF_time.ps \
+      'name="TEC"; level="(20150317_000500,*,*)"; file_type=NETCDF_NCCF;' \
+      -title "NCCF GloTEC - Total Electron Content" \
+      -v 1
+    </param>
+    <output>
+      <ps>&OUTPUT_DIR;/plot_data_plane/plot_data_plane_NCCF_time.ps</ps>
+    </output>
+  </test>
+
   <test name="plot_data_plane_GRIB2_PROB">
     <exec>&MET_BIN;/plot_data_plane</exec>
     <param> \


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

- [x] Recommend testing for the reviewer to perform, including the location of input datasets:</br>

- [x] Will this PR result in changes to the test suite? **[Yes]**</br>
  - One more output because of a new unit test (plot_data_plane/plot_data_plane_NCCF_time.ps)
- [x] After merging, should the reviewer **DELETE** the feature branch from GitHub? **[Yes]**</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [ ] After submitting the PR, select **Linked Issues** with the original issue number.

## Summary ##
The problem was caused by precision:
The integer value (1426550700) was converted to a float. And converted back to integer becomes 1426550656. So no matching time.

./plot_data_plane \
/d1/projects/METplus/METplus_Data/model_applications/space_weather/glotec_vs_glotec/GLO_20190422_without_cosmic/GloTEC_TEC_2015_03_17.nc \
plot.ps \
'name="TEC"; level="(20150317_000500,*,*)"; file_type=NETCDF_NCCF;'
