### PR TITLE
Bugfix 1646 develop set_attr_accum

### DIFF
--- a/met/src/libcode/vx_data2d/data2d_utils.cc
+++ b/met/src/libcode/vx_data2d/data2d_utils.cc
@@ -315,7 +315,7 @@ void set_attrs(const VarInfo *info, DataPlane &dp) {
       mlog << Debug(3) << "Resetting accumulation interval from "
            << sec_to_hhmmss(dp.accum()) << " to "
            << sec_to_hhmmss(info->accum_attr()) << ".\n";
-      dp.set_lead(info->accum_attr());
+      dp.set_accum(info->accum_attr());
    }
 
    return;


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Re-tested the command listed in the issue to prove that set_attr_accum now works:
```
bin/plot_data_plane \
data/sample_fcst/2005080700/wrfprs_ruc13_12.tm00_G212 \
plot.ps \
'name="TMP"; level="Z2"; set_attr_accum="37";' \
-v 4
...
DEBUG 4:      accum time: 370000
```
- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Review bugfix code change. No additional testing needed.

- [x] Do these changes include sufficient documentation and testing updates? **[Yes]**
Issue #1646 documents the bug and the fix.

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>
While many of the set_attr options are exercised in test/config/GridStatConfig_GRIB_set_attr, set_attr_accum is not. So it will cause no changes in the output.

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
