### PR TITLE
Feature 1657 bounds attribute

### DIFF
--- a/met/src/basic/vx_cal/is_leap_year.cc
+++ b/met/src/basic/vx_cal/is_leap_year.cc
@@ -93,14 +93,18 @@ void increase_one_month(int &year, int &month) {
 unixtime add_to_unixtime(unixtime base_unixtime,
     int sec_per_unit, double time_value, bool no_leap) {
   unixtime ut;
-  
+  unixtime time_value_ut = (int)time_value;
+  double time_fraction = time_value - time_value_ut;
   if (!no_leap || sec_per_unit != 86400) {
-    ut = (unixtime)(base_unixtime + sec_per_unit * time_value);
+    bool use_ut = true;
+    if (abs(1.0 - time_fraction) < TIME_EPSILON) time_value_ut += 1;
+    else if (time_fraction > TIME_EPSILON) use_ut = false;
+    if (use_ut) ut = (unixtime)(base_unixtime + sec_per_unit * time_value_ut);
+    else ut = (unixtime)(base_unixtime + sec_per_unit * time_value);
   }
   else {
     int day_offset;
     int month, day, year, hour, minute, second;
-    double time_fraction = time_value - (int)time_value;
     
     unix_to_mdyhms(base_unixtime, month, day, year, hour, minute, second);
     day_offset = day + (int)time_value;
@@ -119,7 +123,8 @@ unixtime add_to_unixtime(unixtime base_unixtime,
     day = day_offset;
     if (day == 0) day = 1;
     ut = mdyhms_to_unix(month, day, year, hour, minute, second);
-    ut += (time_fraction * sec_per_unit);
+    if (time_fraction > (1-TIME_EPSILON) ) ut += sec_per_unit;
+    else if (time_fraction > TIME_EPSILON) ut += (time_fraction * sec_per_unit);
     mlog << Debug(5) << "add_to_unixtime() -> "
          << unix_to_yyyymmdd_hhmmss(base_unixtime)
          << " plus " << time_value << " days = "

--- a/met/src/basic/vx_cal/is_leap_year.cc
+++ b/met/src/basic/vx_cal/is_leap_year.cc
@@ -93,11 +93,11 @@ void increase_one_month(int &year, int &month) {
 unixtime add_to_unixtime(unixtime base_unixtime,
     int sec_per_unit, double time_value, bool no_leap) {
   unixtime ut;
-  unixtime time_value_ut = (int)time_value;
+  unixtime time_value_ut = (unixtime)time_value;
   double time_fraction = time_value - time_value_ut;
   if (!no_leap || sec_per_unit != 86400) {
     bool use_ut = true;
-    if (abs(1.0 - time_fraction) < TIME_EPSILON) time_value_ut += 1;
+    if ((1.0 - time_fraction) < TIME_EPSILON) time_value_ut += 1;
     else if (time_fraction > TIME_EPSILON) use_ut = false;
     if (use_ut) ut = (unixtime)(base_unixtime + sec_per_unit * time_value_ut);
     else ut = (unixtime)(base_unixtime + sec_per_unit * time_value);

--- a/met/src/basic/vx_cal/vx_cal.h
+++ b/met/src/basic/vx_cal/vx_cal.h
@@ -171,6 +171,7 @@ static const int Friday    = 5;
 static const int Saturday  = 6;
 static const int Sunday    = 7;
 
+static const double TIME_EPSILON = 0.001;
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/met/src/libcode/vx_data2d_nccf/nccf_file.h
+++ b/met/src/libcode/vx_data2d_nccf/nccf_file.h
@@ -82,6 +82,7 @@ class NcCfFile {
       TimeArray ValidTime;
 
       unixtime  InitTime;
+      unixtime  AccumTime;
 
       int       lead_time () const;   //  seconds
 


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

CF allows to set bounds attribute. MET override the time data (for accumulation) from the associated bounds variable (by "bounds" attribute) instead of the time variable.
Found the 1 second off (valid time: 20190601_145959 should be valid time: 20190601_150000) by the precision error during testing. It's fixed

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

The test input file is located at dakota:/d1/projects/MET/MET_test_data/unit_test/model_data/nccf/gpm_2019060103_2019060203.nc

The command to test:
```
regrid_data_plane /d1/projects/MET/MET_test_data/unit_test/model_data/nccf/gpm_2019060103_2019060203.nc G211 gpm_2019060103_2019060203_precipitation.nc -field 'name="precipitation_amount"; level="(*,*)";' -v 4
```

- [x] Do these changes include sufficient documentation and testing updates? **[No]**

- [x] Will this PR result in changes to the test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

The bug was fixed, so time of hh:59:59 or hh:00:01 will be fixed to hh:00:00 or (hh+1):00:01. I'm not sure if unit tests have this case.

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.


Command to test:
```
regrid_data_plane /d1/projects/MET/MET_test_data/unit_test/model_data/nccf/gpm_2019060103_2019060203.nc G211 gpm_2019060103_2019060203_precipitation.nc -field 'name="precipitation_amount"; level="(*,*)";' -v 4
```

Before:
```
DEBUG 4: Data plane information:
DEBUG 4:       plane min: 0
DEBUG 4:       plane max: 247.173
DEBUG 4:      valid time: 20190601_145959
DEBUG 4:       lead time: 000000
DEBUG 4:       init time: 20190601_145959
DEBUG 4:      accum time: 000000

        float precipitation_amount(lat, lon) ;
                precipitation_amount:init_time = "20190601_145959" ;
                precipitation_amount:init_time_ut = "1559401199" ;
                precipitation_amount:valid_time = "20190601_145959" ;
                precipitation_amount:valid_time_ut = "1559401199" ;

```

After (valid time, init time, & accum time are changed)
```
DEBUG 3: NcCfFile::open() -> read time from the bounds variable "time_bnds"
...
DEBUG 4: Data plane information:
DEBUG 4:       plane min: 0
DEBUG 4:       plane max: 247.173
DEBUG 4:      valid time: 20190602_030000
DEBUG 4:       lead time: 000000
DEBUG 4:       init time: 20190602_030000
DEBUG 4:      accum time: 240000

        float precipitation_amount(lat, lon) ;
                precipitation_amount:init_time = "20190602_030000" ;
                precipitation_amount:init_time_ut = "1559444400" ;
                precipitation_amount:valid_time = "20190602_030000" ;
                precipitation_amount:valid_time_ut = "1559444400" ;
                precipitation_amount:accum_time = "240000" ;
                precipitation_amount:accum_time_sec = 86400 ;

```