### PR TITLE
Bugfix 1715 pb2nc seg fault with pbl 91

### DIFF
--- a/met/src/tools/other/pb2nc/pb2nc.cc
+++ b/met/src/tools/other/pb2nc/pb2nc.cc
@@ -2960,14 +2960,13 @@ int combine_tqz_and_uv(map<float, float*> pqtzuv_map_tq,
 
       bool no_overlap = (tq_pres_max < uv_pres_min) || (tq_pres_min > uv_pres_max);
       mlog << Debug(6) << method_name << "TQZ pressures: " << tq_pres_max
-           << " to " << tq_pres_min << "   UV pressures: " << uv_pres_max
+           << " to " << tq_pres_min << "  UV pressures: " << uv_pres_max
            << " to " << uv_pres_min << (no_overlap ? "  no overlap!" : "  overlapping") << "\n";
       if( no_overlap ) {
-         mlog << Warning << method_name
-              << "Can not combine TQ and UV records because of no overlapping.\n";
-         mlog << Warning << "             TQZ record count: " << tq_count
-              << ", UV record count: " << uv_count
-              << "  common_levels: " << common_levels.n() << "\n";
+         mlog << Warning << "\n" << method_name
+              << "Can not combine TQ and UV records because of no overlapping"
+              << "  TQZ count: " << tq_count << ", UV count: " << uv_count
+              << "  common_levels: " << common_levels.n() << "\n\n";
          return pqtzuv_map_merged.size();
       }
 
@@ -3177,10 +3176,10 @@ void insert_pbl(float *obs_arr, const float pbl_value, const int pbl_code,
    hdr_info << unix_to_yyyymmdd_hhmmss(hdr_vld_ut)
             << " " << hdr_typ << " " << hdr_sid;
    if (is_eq(pbl_value, bad_data_float)) {
-      mlog << Warning << "Failed to compute PBL " << hdr_info << "\n\n";
+      mlog << Warning << "\nFailed to compute PBL " << hdr_info << "\n\n";
    }
    else if (pbl_value < hdr_elv) {
-      mlog << Warning << "Not saved because the computed PBL (" << pbl_value
+      mlog << Warning << "\nNot saved because the computed PBL (" << pbl_value
            << ") is less than the station elevation (" << hdr_elv
            << "). " << hdr_info << "\n\n";
       obs_arr[4] = 0;
@@ -3194,7 +3193,7 @@ void insert_pbl(float *obs_arr, const float pbl_value, const int pbl_code,
            << "   lat: " << hdr_lat << ", lon: " << hdr_lon
            << ", elv: " << hdr_elv << " " << hdr_info << "\n\n";
       if (obs_arr[4] > MAX_PBL) {
-         mlog << Warning << " Computed PBL (" << obs_arr[4] << " from "
+         mlog << Warning << "\nComputed PBL (" << obs_arr[4] << " from "
               << pbl_value << ") is too high, Reset to " << MAX_PBL
               << "  " << hdr_info<< "\n\n";
          obs_arr[4] = MAX_PBL;

--- a/met/src/tools/other/pb2nc/pb2nc.cc
+++ b/met/src/tools/other/pb2nc/pb2nc.cc
@@ -3230,7 +3230,7 @@ int interpolate_by_pressure(int length, float *pres_data, float *var_data) {
                     << var_data[idx_start] << " and " << var_data[idx_end] << "\n";
                float data_diff = var_data[idx_end] - var_data[idx_start];
                for (idx2 = idx_start+1; idx2<idx_end; idx2++) {
-                  if (is_eq(pres_data[idx_end], pres_data[idx_start])) {
+                  if (!is_eq(pres_data[idx_end], pres_data[idx_start])) {
                      float pres_ratio = (pres_data[idx2] - pres_data[idx_start])
                            / (pres_data[idx_end] - pres_data[idx_start]);
                      var_data[idx2] = var_data[idx_start] + (data_diff * pres_ratio);
@@ -3266,9 +3266,9 @@ void interpolate_pqtzuv(float *prev_pqtzuv, float *cur_pqtzuv, float *next_pqtzu
        || (nint(next_pqtzuv[0]) == nint(cur_pqtzuv[0]))
        || (nint(prev_pqtzuv[0]) == nint(next_pqtzuv[0]))) {
       mlog << Error << method_name 
-              << "  Can't interpolate because of same pressure levels. prev: "
-              << prev_pqtzuv[0] << ", cur: " << cur_pqtzuv[0]
-              << ", next: " <<  prev_pqtzuv[0] << "\n";
+           << "  Can't interpolate because of same pressure levels. prev: "
+           << prev_pqtzuv[0] << ", cur: " << cur_pqtzuv[0]
+           << ", next: " <<  prev_pqtzuv[0] << "\n";
    }
    else {
       float p_ratio = (cur_pqtzuv[0] - prev_pqtzuv[0]) / (next_pqtzuv[0] - prev_pqtzuv[0]);

--- a/met/src/tools/other/pb2nc/pb2nc.cc
+++ b/met/src/tools/other/pb2nc/pb2nc.cc
@@ -2437,7 +2437,7 @@ void write_netcdf_hdr_data() {
 
    // Check for no messages retained
    if(dim_count <= 0) {
-      mlog << Error << method_name << " -> "
+      mlog << Error << "\n" << method_name << " -> "
            << "No PrepBufr messages retained.  Nothing to write.\n\n";
       // Delete the NetCDF file
       remove_temp_file(ncfile);
@@ -3071,7 +3071,7 @@ float compute_pbl(map<float, float*> pqtzuv_map_tq,
       hgt_cnt = spfh_cnt = 0;
       for (it=pqtzuv_map_merged.begin(); it!=pqtzuv_map_merged.end(); ++it) {
          if (index < 0) {
-            mlog << Error << method_name  << "negative index: " << index << "\n";
+            mlog << Error << "\n" << method_name  << "negative index: " << index << "\n\n";
             break;
          }
 
@@ -3091,7 +3091,7 @@ float compute_pbl(map<float, float*> pqtzuv_map_tq,
          index--;
       }
       if (index != -1) {
-         mlog << Error << method_name  << "Missing some levels (" << index << ")\n";
+         mlog << Error << "\n" << method_name  << "Missing some levels (" << index << ")\n\n";
       }
 
       if (pbl_level > MAX_PBL_LEVEL) {
@@ -3264,7 +3264,7 @@ void interpolate_pqtzuv(float *prev_pqtzuv, float *cur_pqtzuv, float *next_pqtzu
    if ((nint(prev_pqtzuv[0]) == nint(cur_pqtzuv[0]))
        || (nint(next_pqtzuv[0]) == nint(cur_pqtzuv[0]))
        || (nint(prev_pqtzuv[0]) == nint(next_pqtzuv[0]))) {
-      mlog << Error << method_name 
+      mlog << Error << "\n" << method_name 
            << "  Can't interpolate because of same pressure levels. prev: "
            << prev_pqtzuv[0] << ", cur: " << cur_pqtzuv[0]
            << ", next: " <<  prev_pqtzuv[0] << "\n";


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

The segmentation fault on computing PBL. It happened on cray machine (9.1.1 & 9.1.2). The problem happens when the TQ records and the UV records are overlapping to interpolate.

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

```
/d1/personal/hsoh/git/bugfix/bugfix_1715_pb2nc_seg_fault_with_pbl_91/MET/met/bin/pb2nc /d1/personal/hsoh/data/MET-1715/nam.20210311.t00z.prepbufr.tm00 nam.20210311.t00z.prepbufr.tm00.pbl.nc /d1/personal/hsoh/data/MET-1715/PB2NCConfig_case_6 -v 6

log messages:
WARNING: combine_tqz_and_uv() Can not combine TQ and UV records because of no overlapping.
WARNING:              TQZ record count: 1, UV record count: 57  common_levels: 0
WARNING: Failed to compute PBL 20210311_000000 ADPUPA 72493
```

- [x] Do these changes include sufficient documentation and testing updates? **[No]**

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.


## Summary of Updating ##
- Check if TQ records and UV are overlapping and display log messages if no overlapping
- Use nint instead of int for pressure values
- Additional check at interpolate_by_pressure and interpolate_pqtzuv