### PR TITLE
Bugfix 1715 pb2nc seg fault with pbl

### DIFF
--- a/met/src/tools/other/pb2nc/pb2nc.cc
+++ b/met/src/tools/other/pb2nc/pb2nc.cc
@@ -2428,7 +2428,7 @@ void write_netcdf_hdr_data() {
 
    // Check for no messages retained
    if(dim_count <= 0) {
-      mlog << Error << method_name << " -> "
+      mlog << Error << "\n" << method_name << " -> "
            << "No PrepBufr messages retained.  Nothing to write.\n\n";
       // Delete the NetCDF file
       remove_temp_file(ncfile);
@@ -2950,14 +2950,13 @@ int combine_tqz_and_uv(map<float, float*> pqtzuv_map_tq,
 
       bool no_overlap = (tq_pres_max < uv_pres_min) || (tq_pres_min > uv_pres_max);
       mlog << Debug(6) << method_name << "TQZ pressures: " << tq_pres_max
-           << " to " << tq_pres_min << "   UV pressures: " << uv_pres_max
+           << " to " << tq_pres_min << "  UV pressures: " << uv_pres_max
            << " to " << uv_pres_min << (no_overlap ? "  no overlap!" : "  overlapping") << "\n";
       if( no_overlap ) {
-         mlog << Warning << method_name
-              << "Can not combine TQ and UV records because of no overlapping.\n";
-         mlog << Warning << "             TQZ record count: " << tq_count
-              << ", UV record count: " << uv_count
-              << "  common_levels: " << common_levels.n() << "\n";
+         mlog << Warning << "\n" << method_name
+              << "Can not combine TQ and UV records because of no overlapping."
+              << "  TQZ count: " << tq_count << ", UV count: " << uv_count
+              << "  common_levels: " << common_levels.n() << "\n\n";
          return pqtzuv_map_merged.size();
       }
 
@@ -3061,7 +3060,7 @@ float compute_pbl(map<float, float*> pqtzuv_map_tq,
       hgt_cnt = spfh_cnt = 0;
       for (it=pqtzuv_map_merged.begin(); it!=pqtzuv_map_merged.end(); ++it) {
          if (index < 0) {
-            mlog << Error << method_name  << "negative index: " << index << "\n";
+            mlog << Error << "\n" <<  method_name  << "negative index: " << index << "\n\n";
             break;
          }
 
@@ -3081,7 +3080,7 @@ float compute_pbl(map<float, float*> pqtzuv_map_tq,
          index--;
       }
       if (index != -1) {
-         mlog << Error << method_name  << "Missing some levels (" << index << ")\n";
+         mlog << Error << "\n" << method_name  << "Missing some levels (" << index << ")\n";
       }
 
       if (pbl_level > MAX_PBL_LEVEL) {
@@ -3166,10 +3165,10 @@ void insert_pbl(float *obs_arr, const float pbl_value, const int pbl_code,
    hdr_info << unix_to_yyyymmdd_hhmmss(hdr_vld_ut)
             << " " << hdr_typ << " " << hdr_sid;
    if (is_eq(pbl_value, bad_data_float)) {
-      mlog << Warning << "Failed to compute PBL " << hdr_info << "\n\n";
+      mlog << Warning << "\nFailed to compute PBL " << hdr_info << "\n\n";
    }
    else if (pbl_value < hdr_elv) {
-      mlog << Warning << "Not saved because the computed PBL (" << pbl_value
+      mlog << Warning << "\nNot saved because the computed PBL (" << pbl_value
            << ") is less than the station elevation (" << hdr_elv
            << "). " << hdr_info << "\n\n";
       obs_arr[4] = 0;
@@ -3183,7 +3182,7 @@ void insert_pbl(float *obs_arr, const float pbl_value, const int pbl_code,
            << "   lat: " << hdr_lat << ", lon: " << hdr_lon
            << ", elv: " << hdr_elv << " " << hdr_info << "\n\n";
       if (obs_arr[4] > MAX_PBL) {
-         mlog << Warning << " Computed PBL (" << obs_arr[4] << " from "
+         mlog << Warning << "\nComputed PBL (" << obs_arr[4] << " from "
               << pbl_value << ") is too high, Reset to " << MAX_PBL
               << "  " << hdr_info<< "\n\n";
          obs_arr[4] = MAX_PBL;
@@ -3254,10 +3253,10 @@ void interpolate_pqtzuv(float *prev_pqtzuv, float *cur_pqtzuv, float *next_pqtzu
    if ((nint(prev_pqtzuv[0]) == nint(cur_pqtzuv[0]))
        || (nint(next_pqtzuv[0]) == nint(cur_pqtzuv[0]))
        || (nint(prev_pqtzuv[0]) == nint(next_pqtzuv[0]))) {
-      mlog << Error << method_name 
+      mlog << Error << "\n" << method_name 
            << "  Can't interpolate because of same pressure levels. prev: "
            << prev_pqtzuv[0] << ", cur: " << cur_pqtzuv[0]
-           << ", next: " <<  prev_pqtzuv[0] << "\n";
+           << ", next: " <<  prev_pqtzuv[0] << "\n\n";
    }
    else {
       float p_ratio = (cur_pqtzuv[0] - prev_pqtzuv[0]) / (next_pqtzuv[0] - prev_pqtzuv[0]);

--- a/test/config/PB2NCConfig_pbl
+++ b/test/config/PB2NCConfig_pbl
@@ -1,0 +1,163 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// PB2NC configuration file.
+//
+// For additional information, see the MET_BASE/config/README file.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// PrepBufr message type
+//
+message_type = ["ONLYSF", "ADPUPA"];
+
+//
+// Mapping of message type group name to comma-separated list of values
+// Derive PRMSL only for SURFACE message types
+//
+message_type_group_map = [
+   { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET";               },
+   { key = "ANYAIR";  val = "AIRCAR,AIRCFT";                      },
+   { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      }
+];
+
+//
+// Mapping of input PrepBufr message types to output message types
+//
+message_type_map = [];
+
+//
+// PrepBufr station ID
+//
+station_id = [];
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Observation time window
+//
+obs_window = {
+   beg = -2700;
+   end =  2700;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Observation retention regions
+//
+mask = {
+   grid = "";
+   poly = "";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Observing location elevation
+//
+elevation_range = {
+   beg =  -1000;
+   end = 100000;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Observation types
+//
+pb_report_type  = [ 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287 ];
+
+in_report_type  = [];
+
+instrument_type = [];
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Vertical levels to retain
+//
+level_range = {
+   beg = 1;
+   end = 511;
+}
+
+level_category = [0, 1, 4, 5, 6];
+
+///////////////////////////////////////////////////////////////////////////////
+
+//
+// BUFR variable names to retain or derive.
+// Use obs_bufr_map to rename variables in the output.
+// If empty, process all available variables.
+//
+obs_bufr_var = ["TOB", "UOB", "VOB", "TOCC", "D_RH", "TDO", "PMO", "HOVI", "CEILING", "MXGS", "D_CAPE", "D_PBL"];
+//obs_bufr_var = ["TOB", "UOB", "VOB", "TOCC", "D_RH", "TDO", "PMO", "HOVI", "CEILING", "MXGS", "D_CAPE"];
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Mapping of input BUFR variable names to output variables names.
+// The default PREPBUFR map, obs_prepbufr_map, is appended to this map.
+//
+obs_bufr_map = [];
+
+//
+// Default mapping for PREPBUFR.  Replace input BUFR variable names with GRIB
+// abbreviations in the output.  This default map is appended to obs_bufr_map.
+// This should not typically be overridden.
+//
+obs_prefbufr_map = [
+   { key = "POB";     val = "PRES";  },
+   { key = "QOB";     val = "SPFH";  },
+   { key = "TOB";     val = "TMP";   },
+   { key = "UOB";     val = "UGRD";  },
+   { key = "VOB";     val = "VGRD";  },
+   { key = "D_DPT";   val = "DPT";   },
+   { key = "D_WDIR";  val = "WDIR";  },
+   { key = "D_WIND";  val = "WIND";  },
+   { key = "D_RH";    val = "RH";    },
+   { key = "D_MIXR";  val = "MIXR";  },
+   { key = "D_PBL";   val = "HPBL";  },
+   { key = "D_PRMSL"; val = "PRMSL"; },
+   { key = "D_CAPE";  val = "CAPE";  },
+   { key = "TDO";     val = "DPT";   },
+   { key = "PMO";     val = "PRMSL"; },
+   { key = "TOCC";    val = "TCDC";  },
+   { key = "HOVI";    val = "VIS";   },
+   { key = "CEILING"; val = "HGT";   },
+   { key = "MXGS";    val = "GUST";  }
+];
+
+////////////////////////////////////////////////////////////////////////////////
+
+quality_mark_thresh = 9;
+event_stack_flag    = TOP;
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Time periods for the summarization
+// obs_var (string array) is added and works like grib_code (int array)
+// when use_var_id is enabled and variable names are saved.
+//
+time_summary = {
+  flag = FALSE;
+  raw_data = FALSE;
+  beg = "000000";
+  end = "235959";
+  step = 300;
+  width = 600;
+  grib_code = [];
+  obs_var   = [ "TMP", "WDIR", "RH" ];
+  type = [ "min", "max", "range", "mean", "stdev", "median", "p80" ];
+  vld_freq = 0;
+  vld_thresh = 0.0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+tmp_dir = "/tmp";
+version = "V10.0";
+
+////////////////////////////////////////////////////////////////////////////////

--- a/test/config/PB2NCConfig_pbl
+++ b/test/config/PB2NCConfig_pbl
@@ -67,7 +67,7 @@ elevation_range = {
 //
 // Observation types
 //
-pb_report_type  = [ 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287 ];
+pb_report_type  = [];
 
 in_report_type  = [];
 
@@ -92,8 +92,7 @@ level_category = [0, 1, 4, 5, 6];
 // Use obs_bufr_map to rename variables in the output.
 // If empty, process all available variables.
 //
-obs_bufr_var = ["TOB", "UOB", "VOB", "TOCC", "D_RH", "TDO", "PMO", "HOVI", "CEILING", "MXGS", "D_CAPE", "D_PBL"];
-//obs_bufr_var = ["TOB", "UOB", "VOB", "TOCC", "D_RH", "TDO", "PMO", "HOVI", "CEILING", "MXGS", "D_CAPE"];
+obs_bufr_var = ["D_CAPE", "D_PBL"];
 ////////////////////////////////////////////////////////////////////////////////
 
 //

--- a/test/xml/unit_pb2nc.xml
+++ b/test/xml/unit_pb2nc.xml
@@ -141,12 +141,12 @@
     </env>
     <param> \
       &DATA_DIR_OBS;/prepbufr/nam.20210311.t00z.prepbufr.tm00 \
-      &OUTPUT_DIR;/pb2nc/nam.20210311.t00z.prepbufr.tm00.nc \
+      &OUTPUT_DIR;/pb2nc/nam.20210311.t00z.prepbufr.tm00.pbl.nc \
       &CONFIG_DIR;/PB2NCConfig_pbl \
       -v 1
     </param>
     <output>
-      <point_nc>&OUTPUT_DIR;/pb2nc/nam.20210311.t00z.prepbufr.tm00.nc</point_nc>
+      <point_nc>&OUTPUT_DIR;/pb2nc/nam.20210311.t00z.prepbufr.tm00.pbl.nc</point_nc>
     </output>
   </test>
 

--- a/test/xml/unit_pb2nc.xml
+++ b/test/xml/unit_pb2nc.xml
@@ -131,6 +131,25 @@
     </output>
   </test>
   
+  <test name="pb2nc_compute_pbl_cape">
+    <exec>&MET_BIN;/pb2nc</exec>
+    <env>
+      <pair><name>STATION_ID</name>          <value></value></pair>
+      <pair><name>MASK_GRID</name>           <value></value></pair>
+      <pair><name>MASK_POLY</name>           <value></value></pair>
+      <pair><name>QUALITY_MARK_THRESH</name> <value>2</value></pair>
+    </env>
+    <param> \
+      &DATA_DIR_OBS;/prepbufr/nam.20210311.t00z.prepbufr.tm00 \
+      &OUTPUT_DIR;/pb2nc/nam.20210311.t00z.prepbufr.tm00.nc \
+      &CONFIG_DIR;/PB2NCConfig_pbl \
+      -v 1
+    </param>
+    <output>
+      <point_nc>&OUTPUT_DIR;/pb2nc/nam.20210311.t00z.prepbufr.tm00.nc</point_nc>
+    </output>
+  </test>
+
   <test name="pb2nc_NDAS_var_all">
     <exec>&MET_BIN;/pb2nc</exec>
     <env>


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

The segmentation fault on computing PBL. It happened on cray machine (9.1.1 & 9.1.2). The problem happens when the TQ records and the UV records are overlapping to interpolate.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

```
/d1/personal/hsoh/git/bugfix/bugfix_1715_pb2nc_seg_fault_with_pbl/MET/met/bin/pb2nc /d1/personal/hsoh/data/MET-1715/nam.20210311.t00z.prepbufr.tm00 nam.20210311.t00z.prepbufr.tm00.pbl.nc /d1/personal/hsoh/data/MET-1715/PB2NCConfig_case_6_10 -v 6

log messages:
WARNING: combine_tqz_and_uv() Can not combine TQ and UV records because of no overlapping.
WARNING:              TQZ record count: 1, UV record count: 57  common_levels: 0
WARNING: Failed to compute PBL 20210311_000000 ADPUPA 72493
```
- [x] Do these changes include sufficient documentation and testing updates? **[No]**

- [x] Will this PR result in changes to the test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

Added an unit test and one more output: pb2nc/nam.20210311.t00z.prepbufr.tm00.pbl.nc

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
- [x] After submitting the PR, select **Linked Issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.


## Summary of Updating ##
- Check if TQ records and UV are overlapping and display log messages if no overlapping
- Use nint instead of int for pressure values
- Additional check at interpolate_by_pressure and interpolate_pqtzuv
- Added one unit test which compute PBL and CAPE
