### PR TITLE
Bugfix 1817 point2grid latlon to laton

### DIFF
--- a/met/src/basic/vx_util/data_plane.cc
+++ b/met/src/basic/vx_util/data_plane.cc
@@ -410,7 +410,7 @@ return;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-int DataPlane::two_to_one(int x, int y) const {
+int DataPlane::two_to_one(int x, int y, bool to_north) const {
    int n;
 
    if((x < 0) || (x >= Nx) || (y < 0) || (y >= Ny)) {
@@ -420,7 +420,7 @@ int DataPlane::two_to_one(int x, int y) const {
       exit(1);
    }
 
-   n = y*Nx + x;   //  don't change this!  lots of downstream code depends on this!
+   n = (to_north ? y : (Ny-1-y))*Nx + x;    //  don't change this!  lots of downstream code depends on this!
 
    return(n);
 }

--- a/met/src/basic/vx_util/data_plane.h
+++ b/met/src/basic/vx_util/data_plane.h
@@ -109,7 +109,7 @@ class DataPlane {
 
       void replace_bad_data(const double value);
 
-      int  two_to_one(int x, int y) const;
+      int  two_to_one(int x, int y, bool to_north=true) const;
       void one_to_two(int n, int &x, int &y) const;
 
       bool s_is_on(int x, int y) const;


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

The problem was caused the input NetCDF has latitude from north to south. The "units" attribute at the latitude variable is not correct. The problem still happens if the "units" attribute is corrected. The problem was computing the offset from x-index and y-index (two-to_one() method).

./point2grid /d1/personal/hsoh/data/Binyu/wrong_latitude_units/VOLCAT_HIMAWARI-8_FLDK_s2020296_050000_v300250_VCB_w167_FLDK_b2020295_204000_g001_pc.nc "latlon 200 200 45 153 0.1 0.1" bezy_2020296_0500_regrided.nc -field 'name="ash_mass_loading"; level="(0,,)";'

OR

/d1/personal/hsoh/git/bugfixes/bugfix_1817_point2grid_latlon_to_laton/MET/met/bin/point2grid /d1/personal/hsoh/data/Binyu/wrong_latitude_units/VOLCAT_HIMAWARI-8_FLDK_s2020296_050000_v300250_VCB_w167_FLDK_b2020295_204000_g001_pc.nc "latlon 200 200 45 153 0.1 0.1" bezy_2020296_0500_regrided.nc -field 'name="ash_mass_loading"; level="(0,,)";'

./plot_data_plane bezy_2020296_0500_regrided.nc test.ps 'name="ash_mass_loading"; level="(,)";'

Note: The plot by ncview for the input NetCDF (VOLCAT_HIMAWARI-8_FLDK_s2020296_050000_v300250_VCB_w167_FLDK_b2020295_204000_g001_pc.nc) and the output netCDF (bezy_2020296_0500_regrided.nc) are not similar. You have to check the lat/lon by moving the mouse at the ncview

   - The ncview of input NetCDF: the latitude is north to south (latitude decreases with ncview from bottom left)
      - Clicking "Inv P" botton will flip vertically (latitude increases with ncview from bottom left)
      - It's rotated about 45 degrees
         -  how to know: check latitude/longitude changes by moving the mouse vertically/horizontally).
   - The ncview of output NetCDF by point2grid: the latitude is south to north


- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

It was a bug. No additional documentation.
Old MET supports regrid_data_Plane on this input. MET 10.0 beta 4 or later does not allow because the input is not evenly spaced horizontally/vertically.

- [x] Do these changes include sufficient testing updates? **[Yes]**

- [x] Will this PR result in changes to the test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

The unit test "point2grid_2D_time" has the latitude north to south. SO the output should be updated by this change.

<MET_UNIT_TEST_OUT>/point2grid/point2grid_2D_time_west_bering_sea.nc will have different content

- [x] Please complete this pull request review by **[6/22/2021]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Linked issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
