### PR TITLE
Bugfix 1886 develop grid_diag

### DIFF
--- a/met/internal_tests/libcode/vx_series_data/test_series_data.cc
+++ b/met/internal_tests/libcode/vx_series_data/test_series_data.cc
@@ -46,7 +46,7 @@ int main(int argc, char *argv[]) {
     double delta = (max - min) / nbin;
     double width = 10;
 
-    vector<int> pdf;
+    vector<long long> pdf;
 
     init_pdf(nbin, pdf);
 

--- a/met/src/libcode/vx_series_data/series_pdf.cc
+++ b/met/src/libcode/vx_series_data/series_pdf.cc
@@ -22,7 +22,7 @@
 
 void init_pdf(
     int n,
-    vector<int>& pdf) {
+    vector<long long>& pdf) {
 
     for(int k = 0; k < n; k++) {
         pdf.push_back(0);
@@ -35,7 +35,7 @@ void init_pdf(
     double min,
     double max,
     double delta,
-    vector<int>& pdf) {
+    vector<long long>& pdf) {
 
     int n = (max - min) / delta;
     for(int k = 0; k < n; k++) {
@@ -48,7 +48,7 @@ void init_pdf(
 void init_joint_pdf(
     int n_A,
     int n_B,
-    vector<int>& pdf) {
+    vector<long long>& pdf) {
 
     for(int k = 0; k < n_A * n_B; k++) {
         pdf.push_back(0);
@@ -60,7 +60,7 @@ void init_joint_pdf(
 void update_pdf(
     double min,
     double delta,
-    vector<int>& pdf,
+    vector<long long>& pdf,
     const DataPlane& dp,
     const MaskPlane& mp) {
 
@@ -86,7 +86,7 @@ void update_joint_pdf(
     double min_B,
     double delta_A,
     double delta_B,
-    vector<int>& pdf,
+    vector<long long>& pdf,
     const DataPlane& dp_A,
     const DataPlane& dp_B,
     const MaskPlane& mp) {
@@ -115,7 +115,7 @@ void update_joint_pdf(
 void print_pdf(
     double min,
     double delta,
-    const vector<int>& pdf) {
+    const vector<long long>& pdf) {
 
     for(int k = 0; k < pdf.size(); k++) {
         double bin_min = min + k * delta;
@@ -132,7 +132,7 @@ void write_nc_pdf(
     const VarInfo& info,
     double min,
     double delta,
-    const vector<int>& pdf) {
+    const vector<long long>& pdf) {
 
     vector<double> bin_min;
     vector<double> bin_max;

--- a/met/src/libcode/vx_series_data/series_pdf.h
+++ b/met/src/libcode/vx_series_data/series_pdf.h
@@ -30,7 +30,7 @@ using namespace netCDF;
 
 void init_pdf(
     int n,
-    vector<int>& pdf);
+    vector<long long>& pdf);
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -38,21 +38,21 @@ void init_pdf(
     double min,
     double max,
     double delta,
-    vector<int>& pdf);
+    vector<long long>& pdf);
 
 ////////////////////////////////////////////////////////////////////////
 
 void init_joint_pdf(
     int n_A,
     int n_B,
-    vector<int>& pdf);
+    vector<long long>& pdf);
 
 ////////////////////////////////////////////////////////////////////////
 
 void update_pdf(
     double min,
     double delta,
-    vector<int>& pdf,
+    vector<long long>& pdf,
     const DataPlane&,
     const MaskPlane&);
 
@@ -65,7 +65,7 @@ void update_joint_pdf(
     double min_B,
     double delta_A,
     double delta_B,
-    vector<int>& pdf,
+    vector<long long>& pdf,
     const DataPlane&,
     const DataPlane&,
     const MaskPlane&);
@@ -75,7 +75,7 @@ void update_joint_pdf(
 void print_pdf(
     double min,
     double delta,
-    const vector<int>& pdf);
+    const vector<long long>& pdf);
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -84,7 +84,7 @@ void write_nc_pdf(
     const VarInfo& info,
     double min,
     double delta,
-    const vector<int>& pdf);
+    const vector<long long>& pdf);
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/met/src/tools/other/grid_diag/grid_diag.cc
+++ b/met/src/tools/other/grid_diag/grid_diag.cc
@@ -17,6 +17,7 @@
 //   000    10/01/19  Fillmore        New
 //   001    07/28/20  Halley Gotway   Updates for #1391.
 //   002    03/04/21  Halley Gotway   Bugfix #1694.
+//   003    08/20/21  Halley Gotway   Bugfix #1886 for integer overflow.
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -426,7 +427,7 @@ void setup_histograms(void) {
 	      << "Initializing " << data_info->magic_str_attr()
 	      << " histogram with " << n_bins << " bins from "
 	      << min << " to " << max << ".\n";
-      histograms[i_var_str] = vector<int>();
+      histograms[i_var_str] = vector<long long>();
       init_pdf(n_bins, histograms[i_var_str]);
    } // for i_var
 }
@@ -456,7 +457,7 @@ void setup_joint_histograms(void) {
               << "Initializing " << data_info->magic_str_attr() << "_"
               << joint_info->magic_str_attr() << " joint histogram with "
               << n_bins << " x " << n_joint_bins << " bins.\n";
-         joint_histograms[ij_var_str] = vector<int>();
+         joint_histograms[ij_var_str] = vector<long long>();
 
          init_joint_pdf(n_bins, n_joint_bins,
                         joint_histograms[ij_var_str]);
@@ -568,7 +569,7 @@ void setup_nc_file(void) {
       ConcatString hist_name("hist_");
       hist_name.add(var_name);
       NcDim var_dim = data_var_dims[i_var];
-      NcVar hist_var = add_var(nc_out, hist_name, ncInt, var_dim,
+      NcVar hist_var = add_var(nc_out, hist_name, ncInt64, var_dim,
                                deflate_level);
       hist_vars.push_back(hist_var);
 
@@ -602,7 +603,7 @@ void setup_nc_file(void) {
          dims.push_back(var_dim);
          dims.push_back(joint_dim);
 
-         NcVar hist_var = add_var(nc_out, hist_name, ncInt, dims,
+         NcVar hist_var = add_var(nc_out, hist_name, ncInt64, dims,
                                   deflate_level);
          joint_hist_vars.push_back(hist_var);
 
@@ -620,7 +621,7 @@ void write_nc_var_int(const char *var_name, const char *long_name,
                       int n) {
 
    // Add the variable
-   NcVar var = add_var(nc_out, var_name, ncInt);
+   NcVar var = add_var(nc_out, var_name, ncInt64);
    add_att(&var, "long_name", long_name);
 
    if(!put_nc_data(&var, &n)) {
@@ -650,7 +651,7 @@ void write_histograms(void) {
       VarInfo *data_info = conf_info.data_info[i_var];
       NcVar hist_var = hist_vars[i_var];
 
-      int *hist = histograms[i_var_str].data();
+      long long *hist = histograms[i_var_str].data();
 
       hist_var.putVar(hist);
    }
@@ -676,7 +677,7 @@ void write_joint_histograms(void) {
                     << "VAR" << i_var << "_"
                     << "VAR" << j_var;
 
-         int *hist = joint_histograms[ij_var_str].data();
+         long long *hist = joint_histograms[ij_var_str].data();
 
          offsets.clear();
          counts.clear();

--- a/met/src/tools/other/grid_diag/grid_diag.cc
+++ b/met/src/tools/other/grid_diag/grid_diag.cc
@@ -218,6 +218,16 @@ void process_command_line(int argc, char **argv) {
    grid = parse_vx_grid(conf_info.data_info[0]->regrid(),
                         &data_grid, &data_grid);
 
+   // The regrid.to_grid option cannot be set to FCST or OBS
+   if(conf_info.data_info[0]->regrid().field == FieldType_Fcst ||
+      conf_info.data_info[0]->regrid().field == FieldType_Obs) {
+      mlog << Error << "\nprocess_command_line() -> "
+           << "the \"regrid.to_grid\" configuration option cannot be set to "
+           << "FCST or OBS!\nSpecify a named grid, grid specification string, "
+           << "or the path to a gridded data file instead.\n\n";
+      exit(1);
+   }
+
    // Process masking regions
    conf_info.process_masks(grid);
 }
@@ -474,9 +484,9 @@ void setup_nc_file(void) {
 	nc_out = open_ncfile(out_file.c_str(), true);
 
 	if(IS_INVALID_NC_P(nc_out)) {
-		mlog << Error << "\nsetup_nc_file() -> "
-			<< "trouble opening output NetCDF file "
-			<< out_file << "\n\n";
+      mlog << Error << "\nsetup_nc_file() -> "
+			  << "trouble opening output NetCDF file "
+			  << out_file << "\n\n";
 		exit(1);
 	}
 

--- a/met/src/tools/other/grid_diag/grid_diag.h
+++ b/met/src/tools/other/grid_diag/grid_diag.h
@@ -110,8 +110,8 @@ vector<double> var_mins;
 vector<double> var_maxs;
 
 // Variable histogram map
-map<ConcatString, vector<int> > histograms;
-map<ConcatString, vector<int> > joint_histograms;
+map<ConcatString, vector<long long> > histograms;
+map<ConcatString, vector<long long> > joint_histograms;
 map<ConcatString, vector<double> > bin_mins;
 map<ConcatString, vector<double> > bin_maxs;
 map<ConcatString, vector<double> > bin_mids;


### PR DESCRIPTION
## Pull Request Testing ##

Same changes as the bugfix for PR #1887. However, this also adds a check to make sure the user doesn't configure with regrid.to_grid = FCST or OBS:
```
ERROR  : 
ERROR  : process_command_line() -> the "regrid.to_grid" configuration option cannot be set to FCST or OBS!
ERROR  : Specify a named grid, grid specification string, or the path to a gridded data file instead.
ERROR  : 
```
Please refer to PR #1887 for details.

- [x] Please complete this pull request review by **[8/23/2021]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Linked issues** with the original issue number.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
