### PR TITLE
Feature 1991 vcnt

### DIFF
--- a/met/src/tools/core/grid_stat/grid_stat.cc
+++ b/met/src/tools/core/grid_stat/grid_stat.cc
@@ -85,8 +85,7 @@
 //                    output line types.
 //   034    05/10/16  Halley Gotway  Add grid weighting.
 //   035    05/20/16  Prestopnik J   Removed -version (now in command_line.cc)
-//   036    02/14/17  Win            MET-621 enhancement support- additional
-//                    nc_pairs_flag 'apply_mask'
+//   036    02/14/17  Win            MET#621 Add nc_pairs_flag.apply_mask
 //   037    05/15/17  Prestopnik P   Add shape for regrid, nbrhd and interp
 //   038    06/26/17  Halley Gotway  Add ECLV line type.
 //   039    08/18/17  Halley Gotway  Add fourier decomposition.
@@ -109,6 +108,7 @@
 //   051    03/28/21  Halley Gotway  Add mpr_column and mpr_thresh
 //                    filtering options.
 //   052    05/28/21  Halley Gotway  Add MCTS HSS_EC output.
+//   053    12/11/21  Halley Gotway  MET #1991 Fix VCNT output.
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -930,12 +930,13 @@ void process_scores() {
                do_cnt_sl1l2(conf_info.vx_opt[i], &pd);
             }
 
-            // Compute VL1L2 and VAL1L2 partial sums for UGRD,VGRD
+            // Compute VL1L2 and VAL1L2 partial sums for UGRD and VGRD
             if(!conf_info.vx_opt[i].fcst_info->is_prob()                         &&
                 conf_info.vx_opt[i].fcst_info->is_v_wind()                       &&
                 conf_info.vx_opt[i].fcst_info->uv_index() >= 0                   &&
                (conf_info.vx_opt[i].output_flag[i_vl1l2]  != STATOutputType_None ||
-                conf_info.vx_opt[i].output_flag[i_val1l2] != STATOutputType_None) ) {
+                conf_info.vx_opt[i].output_flag[i_val1l2] != STATOutputType_None ||
+                conf_info.vx_opt[i].output_flag[i_vcnt]   != STATOutputType_None)) {
 
                // Store the forecast variable name
                shc.set_fcst_var(ugrd_vgrd_abbr_str);
@@ -1006,7 +1007,6 @@ void process_scores() {
                   // Write out VL1L2
                   if(conf_info.vx_opt[i].output_flag[i_vl1l2] != STATOutputType_None &&
                      vl1l2_info[m].vcount > 0) {
-
                      write_vl1l2_row(shc, vl1l2_info[m],
                         conf_info.vx_opt[i].output_flag[i_vl1l2],
                         stat_at, i_stat_row,
@@ -1016,18 +1016,15 @@ void process_scores() {
                   // Write out VAL1L2
                   if(conf_info.vx_opt[i].output_flag[i_val1l2] != STATOutputType_None &&
                      vl1l2_info[m].vacount > 0) {
-
                      write_val1l2_row(shc, vl1l2_info[m],
                         conf_info.vx_opt[i].output_flag[i_val1l2],
                         stat_at, i_stat_row,
                         txt_at[i_val1l2], i_txt_row[i_val1l2]);
                   }
 
-
                   // Write out VCNT
                   if(conf_info.vx_opt[i].output_flag[i_vcnt] != STATOutputType_None &&
                      vl1l2_info[m].vcount > 0) {
-
                      write_vcnt_row(shc, vl1l2_info[m],
                         conf_info.vx_opt[i].output_flag[i_vcnt],
                         stat_at, i_stat_row,
@@ -1677,12 +1674,13 @@ void process_scores() {
                do_cnt_sl1l2(conf_info.vx_opt[i], &pd);
             }
 
-            // Compute VL1L2 and VAL1L2 partial sums for UGRD,VGRD
+            // Compute VL1L2 and VAL1L2 partial sums for UGRD and VGRD
             if(!conf_info.vx_opt[i].fcst_info->is_prob()                         &&
                 conf_info.vx_opt[i].fcst_info->is_v_wind()                       &&
                 conf_info.vx_opt[i].fcst_info->uv_index() >= 0                   &&
                (conf_info.vx_opt[i].output_flag[i_vl1l2]  != STATOutputType_None ||
-                conf_info.vx_opt[i].output_flag[i_val1l2] != STATOutputType_None) ) {
+                conf_info.vx_opt[i].output_flag[i_val1l2] != STATOutputType_None ||
+                conf_info.vx_opt[i].output_flag[i_vcnt]   != STATOutputType_None)) {
 
                // Store the forecast variable name
                shc.set_fcst_var(ugrd_vgrd_abbr_str);
@@ -1754,7 +1752,6 @@ void process_scores() {
                   // Write out VL1L2
                   if(conf_info.vx_opt[i].output_flag[i_vl1l2] != STATOutputType_None &&
                      vl1l2_info[m].vcount > 0) {
-
                      write_vl1l2_row(shc, vl1l2_info[m],
                         conf_info.vx_opt[i].output_flag[i_vl1l2],
                         stat_at, i_stat_row,
@@ -1764,12 +1761,21 @@ void process_scores() {
                   // Write out VAL1L2
                   if(conf_info.vx_opt[i].output_flag[i_val1l2] != STATOutputType_None &&
                      vl1l2_info[m].vacount > 0) {
-
                      write_val1l2_row(shc, vl1l2_info[m],
                         conf_info.vx_opt[i].output_flag[i_val1l2],
                         stat_at, i_stat_row,
                         txt_at[i_val1l2], i_txt_row[i_val1l2]);
                   }
+
+                  // Write out VCNT
+                  if(conf_info.vx_opt[i].output_flag[i_vcnt] != STATOutputType_None &&
+                     vl1l2_info[m].vcount > 0) {
+                     write_vcnt_row(shc, vl1l2_info[m],
+                        conf_info.vx_opt[i].output_flag[i_vcnt],
+                        stat_at, i_stat_row,
+                        txt_at[i_vcnt], i_txt_row[i_vcnt]);
+                  }
+
                } // end for m
 
                // Reset the forecast variable name

--- a/met/src/tools/core/point_stat/point_stat.cc
+++ b/met/src/tools/core/point_stat/point_stat.cc
@@ -98,6 +98,7 @@
 //   047    08/23/21  Seth Linden    Add ORANK line type for HiRA.
 //   048    09/13/21  Seth Linden    Changed obs_qty to obs_qty_inc.
 //                    Added code for obs_qty_exc.
+//   049    12/11/21  Halley Gotway  MET#1991 Fix VCNT output.
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -1055,12 +1056,13 @@ void process_scores() {
                   do_cnt_sl1l2(conf_info.vx_opt[i], pd_ptr);
                }
 
-               // Compute VL1L2 and VAL1L2 partial sums for UGRD,VGRD
+               // Compute VL1L2 and VAL1L2 partial sums for UGRD and VGRD
                if(!conf_info.vx_opt[i].vx_pd.fcst_info->is_prob() &&
                    conf_info.vx_opt[i].vx_pd.fcst_info->is_v_wind() &&
                    conf_info.vx_opt[i].vx_pd.fcst_info->uv_index() >= 0  &&
                   (conf_info.vx_opt[i].output_flag[i_vl1l2]  != STATOutputType_None ||
-                   conf_info.vx_opt[i].output_flag[i_val1l2] != STATOutputType_None) ) {
+                   conf_info.vx_opt[i].output_flag[i_val1l2] != STATOutputType_None ||
+                   conf_info.vx_opt[i].output_flag[i_vcnt]   != STATOutputType_None)) {
 
                   // Store the forecast variable name
                   shc.set_fcst_var(ugrd_vgrd_abbr_str);
@@ -1117,8 +1119,7 @@ void process_scores() {
                            txt_at[i_val1l2], i_txt_row[i_val1l2]);
                      }
 
-
-                    // Write out VCNT
+                     // Write out VCNT
                      if(conf_info.vx_opt[i].output_flag[i_vcnt] != STATOutputType_None &&
                         vl1l2_info[m].vcount > 0) {
                         write_vcnt_row(shc, vl1l2_info[m],
@@ -1126,7 +1127,6 @@ void process_scores() {
                            stat_at, i_stat_row,
                            txt_at[i_vcnt], i_txt_row[i_vcnt]);
                      }
-
 
                   } // end for m
 


### PR DESCRIPTION
## Expected Differences ##

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Manually ran the regression test to compare to the develop branch in:
   kiowa:/d1/projects/MET/MET_pull_requests/met-10.1.0/met-10.1.0_beta5/feature_1991

These changes add 4 new output lines to the existing unit test output. Please see below.

COMPARING grid_stat/grid_stat_GFS_FOURIER_240000L_20120410_000000V.stat
file1: MET-feature_1991_vcnt/test_output/grid_stat/grid_stat_GFS_FOURIER_240000L_20120410_000000V.stat
file2: MET-develop/test_output/grid_stat/grid_stat_GFS_FOURIER_240000L_20120410_000000V.stat
ERROR: differing number of rows 5 vs. 1 for row type VCNT between versions 10_1 vs. 10_1 

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Just review the code changes.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**

The Fourier decomposition [section](https://met.readthedocs.io/en/latest/Users_Guide/grid-stat.html?highlight=fourier#fourier-decomposition) does not explicitly list output line types. So there is no existing documentation to update.

- [x] Do these changes include sufficient testing updates? **[Yes]**

The existing unit tests demonstrate this functionality.

- [x] Will this PR result in changes to the test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

In kiowa:/d1/projects/MET/MET_pull_requests/met-10.1.0/met-10.1.0_beta5/feature_1991, there are 4 new VCNT output lines created by this feature branch. These changes are expected.

```
COMPARING grid_stat/grid_stat_GFS_FOURIER_240000L_20120410_000000V.stat
file1: MET-feature_1991_vcnt/test_output/grid_stat/grid_stat_GFS_FOURIER_240000L_20120410_000000V.stat
file2: MET-develop/test_output/grid_stat/grid_stat_GFS_FOURIER_240000L_20120410_000000V.stat
ERROR: differing number of rows 5 vs. 1 for row type VCNT between versions 10_1 vs. 10_1 
```

- [x] Please complete this pull request review by **[Tues 12/14/21]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Linked issues** with the original issue number.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
