### PR TITLE
Feature 1965 NB faile with time summary by ioda2nc

### DIFF
--- a/met/src/tools/other/ioda2nc/ioda2nc.cc
+++ b/met/src/tools/other/ioda2nc/ioda2nc.cc
@@ -964,7 +964,6 @@ void addObservation(const float *obs_arr, const ConcatString &hdr_typ,
    map<ConcatString,ConcatString> name_map = conf_info.getObsVarMap();
    string var_name = obs_var_names[var_index];
    string out_name = name_map[var_name];
-cout << "  DEBUG HS var_name: " <<  var_name << ", out_name: " << out_name << ", passing: " << (0<out_name.length() ? out_name : var_name) << "\n";
    Observation obs = Observation(hdr_typ.text(),
                                  hdr_sid.text(),
                                  hdr_vld,

--- a/met/src/tools/other/ioda2nc/ioda2nc.cc
+++ b/met/src/tools/other/ioda2nc/ioda2nc.cc
@@ -369,7 +369,7 @@ void process_ioda_file(int i_pb) {
    IntArray diff_file_times;
    int diff_file_time_count;
    StringArray variables_big_nlevels;
-   static const char *method_name = "process_ioda_file() ->";
+   static const char *method_name = "process_ioda_file() -> ";
    static const char *method_name_s = "process_ioda_file() ";
 
    bool apply_grid_mask = (conf_info.grid_mask.nx() > 0 &&
@@ -961,7 +961,10 @@ void addObservation(const float *obs_arr, const ConcatString &hdr_typ,
    else obs_qty.format("%d", nint(quality_mark));
 
    int var_index = obs_arr[1];
+   map<ConcatString,ConcatString> name_map = conf_info.getObsVarMap();
    string var_name = obs_var_names[var_index];
+   string out_name = name_map[var_name];
+cout << "  DEBUG HS var_name: " <<  var_name << ", out_name: " << out_name << ", passing: " << (0<out_name.length() ? out_name : var_name) << "\n";
    Observation obs = Observation(hdr_typ.text(),
                                  hdr_sid.text(),
                                  hdr_vld,
@@ -969,7 +972,7 @@ void addObservation(const float *obs_arr, const ConcatString &hdr_typ,
                                  obs_qty.text(),
                                  var_index,
                                  obs_arr[2], obs_arr[3], obs_arr[4],
-                                 var_name);
+                                 (0<out_name.length() ? out_name : var_name));
    obs.setHeaderIndex(obs_arr[0]);
    observations.push_back(obs);
    if(do_summary) summary_obs->addObservationObj(obs);


### PR DESCRIPTION
The NB was failed because of time summary variables were excluded.
This was introduced on fixing multiple inputs files (same input file with -iofile option).

obs_name_map = [
   { key = "wind_direction"; val = "WDIR"; },
   { key = "wind_speed";     val = "WIND"; }
];

Summary of the issues:

On processing the first ioda input file:
1. Read "wind_direction@ObsValue" variable and "wind_speed@ObsValue"
2. Renamed "wind_direction" and "wind_speed" to "WDIR" and "WIND" to the variable list
3. Passing the variable names, WDIR and WIND, to time summary processing
4. Read "WDIR@ObsValue" variable and "WIND@ObsValue" for the next IODA input because of step 2 --> fail to reading two variables.

The step 4 was fixed with previous PR, but it broke the step 2. The PR is to fix the step 2.


## Expected Differences ##

- [X] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

Run ioda2nc unit test and make sure the outputs are the same.
The unit test outptus are available at kiowa:/d1/personal/hsoh/git/pull_request/MET_feature_1965_ioda2nc_same_input2/unit_test_output//ioda2nc/

(base) hsoh@kiowa:/d1/personal/hsoh/git/pull_request/MET_feature_1965_ioda2nc_same_input2/met$ ll /d1/personal/hsoh/git/pull_request/MET_feature_1965_ioda2nc_same_input2/unit_test_output/ioda2nc/
-rw-r--r-- 1 hsoh 11373 28473 Jan 12 14:28 ioda.NC001007.2020031012.mask_sid.nc
-rw-r--r-- 1 hsoh 11373 29888 Jan 12 14:28 ioda.NC001007.2020031012.same_input.nc
-rw-r--r-- 1 hsoh 11373 41709 Jan 12 14:28 ioda.NC001007.2020031012.summary.nc
-rw-r--r-- 1 hsoh 11373 37736 Jan 12 14:28 odb_sonde_16019_all.nc
(note one more output)

(base) hsoh@kiowa:/d1/personal/hsoh/git/pull_request/MET_feature_1965_ioda2nc_same_input2/met$ ll /d1/projects/MET/MET_regression/develop/NB20220112/MET-develop-ref/test_output/ioda2nc/
-rw-rw-r-- 1 met_test rap 28473 Jan 12 01:46 ioda.NC001007.2020031012.mask_sid.nc
-rw-rw-r-- 1 met_test rap 41709 Jan 12 01:46 ioda.NC001007.2020031012.summary.nc
-rw-rw-r-- 1 met_test rap 37736 Jan 12 01:46 odb_sonde_16019_all.nc


- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Run ioda2nc unit test and make sure the outputs are the same

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**

- [x] Do these changes include sufficient testing updates? **[No]**

- [x] Will this PR result in changes to the test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

One more output ioda.NC001007.2020031012.same_input.nc

- [ ] Please complete this pull request review by **[Fill in date]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [ ] After submitting the PR, select **Linked issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
