### PR TITLE
Feature 1918 climo_ens_member_id

### DIFF
--- a/met/docs/Users_Guide/gen-ens-prod.rst
+++ b/met/docs/Users_Guide/gen-ens-prod.rst
@@ -173,6 +173,18 @@ Each value in the array will replace the text **MET_ENS_MEMBER_ID**.
     ];
   }
 
+This replacement behavior can also be applied to climatology file name entry, in the 
+climo_mean and climo_stdev dictionaries.
+
+.. code-block:: none
+
+  climo_mean = {
+     file_name = ["/path/to/file/memberMET_ENS_MEMBER_ID-mean.nc"];
+     }
+     
+This substitution method can be helpful in creating standardized anomalies, where each
+ensemble member can have a specific mean and standard deviation file applied to it.
+
 **control_id** is a string that is substituted in the same way as the **ens_member_ids** values
 to read a control member. This value is only used when the **-ctrl** command line argument is
 used. The value should not be found in the **ens_member_ids** array.

--- a/met/docs/Users_Guide/gen-ens-prod.rst
+++ b/met/docs/Users_Guide/gen-ens-prod.rst
@@ -182,8 +182,8 @@ climo_mean and climo_stdev dictionaries.
      file_name = ["/path/to/file/memberMET_ENS_MEMBER_ID-mean.nc"];
      }
      
-This substitution method can be helpful in creating standardized anomalies, where each
-ensemble member can have a specific mean and standard deviation file applied to it.
+This substitution method can only be used if **ens_member_ids** has at least one entry 
+and the **normalize** option is set to **CLIMO_ANOM** or **CLIMO_STD_ANOM**.
 
 **control_id** is a string that is substituted in the same way as the **ens_member_ids** values
 to read a control member. This value is only used when the **-ctrl** command line argument is

--- a/met/src/libcode/vx_data2d/var_info.cc
+++ b/met/src/libcode/vx_data2d/var_info.cc
@@ -892,6 +892,12 @@ int EnsVarInfo::get_file_index(int index) {
 
 ////////////////////////////////////////////////////////////////////////
 
+ConcatString EnsVarInfo::get_ens_member_id(int index) {
+   return inputs[index].ens_member_id;
+}
+
+////////////////////////////////////////////////////////////////////////
+
 ConcatString raw_magic_str(Dictionary i_edict, GrdFileType file_type) {
    ConcatString magic_str;
 

--- a/met/src/libcode/vx_data2d/var_info.h
+++ b/met/src/libcode/vx_data2d/var_info.h
@@ -258,9 +258,10 @@ inline int          VarInfo::accum_attr()     const { return(SetAttrAccum);    }
 //
 
 struct InputInfo {
-   VarInfo * var_info;      // Variable information to read
-   int file_index;          // Index in file_list of file to read
-   StringArray * file_list; // Array of files (unallocated)
+   VarInfo * var_info;         // Variable information to read
+   int file_index;             // Index in file_list of file to read
+   StringArray * file_list;    // Array of files (unallocated)
+   ConcatString ens_member_id; // MET_ENS_MEMBER_ID string
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -292,6 +293,7 @@ class EnsVarInfo {
       VarInfo * get_var_info(int index=0);
       ConcatString get_file(int index=0);
       int get_file_index(int index=0);
+      ConcatString get_ens_member_id(int index=0);
 
       ConcatString nc_var_str;      // Ensemble variable name strings
       ThreshArray cat_ta;           // Ensemble categorical thresholds

--- a/met/src/libcode/vx_statistics/read_climo.cc
+++ b/met/src/libcode/vx_statistics/read_climo.cc
@@ -243,6 +243,12 @@ void read_climo_file(const char *climo_file, GrdFileType ctype,
          }
       }
 
+      // Print log message for matching record
+      mlog << Debug(4)
+           << "Found matching " << cur_ut_cs << " \""
+           << info->magic_str() << "\" climatology field in file \""
+           << climo_file << "\".\n"; 
+
       // Regrid, if needed
       if(!(mtddf->grid() == vx_grid)) {
          mlog << Debug(2)

--- a/met/src/tools/other/gen_ens_prod/gen_ens_prod.cc
+++ b/met/src/tools/other/gen_ens_prod/gen_ens_prod.cc
@@ -319,9 +319,9 @@ void process_ensemble() {
          // Skip bad data files
          if(!ens_file_vld[(*var_it)->get_file_index(i_ens)]) continue;
 
-         mlog << Debug(3) << "\n"
-              << "Reading field: "
-              << var_info->magic_str() << "\n";
+         mlog << Debug(3)
+              << "\nReading ensemble field \""
+              << var_info->magic_str() << "\".\n";
 
          // Read data and track the valid data count
          if(!get_data_plane(ens_file.c_str(), etype,
@@ -458,9 +458,17 @@ void get_climo_mean_stdev(GenEnsProdVarInfo *ens_info, int i_var,
       setenv(met_ens_member_id, ens_info->get_ens_member_id(i_ens).c_str(), 1);
    }
 
+   mlog << Debug(4)
+        << "Reading climatology mean data for ensemble field \""
+        << ens_info->get_var_info(i_ens)->magic_str() << "\".\n";
+
    cmn_dp = read_climo_data_plane(
                conf_info.conf.lookup_array(conf_key_climo_mean_field, false),
                i_var, ens_valid_ut, grid);
+
+   mlog << Debug(4)
+        << "Reading climatology standard deviation data for ensemble field \""
+        << ens_info->get_var_info(i_ens)->magic_str() << "\".\n";
 
    csd_dp = read_climo_data_plane(
                conf_info.conf.lookup_array(conf_key_climo_stdev_field, false),

--- a/met/src/tools/other/gen_ens_prod/gen_ens_prod.cc
+++ b/met/src/tools/other/gen_ens_prod/gen_ens_prod.cc
@@ -55,6 +55,8 @@ static void process_command_line(int, char **);
 static void process_grid(const Grid &);
 static void process_ensemble();
 
+static void get_climo_mean_stdev(GenEnsProdVarInfo *, int,
+                                 bool, int, DataPlane &, DataPlane &);
 static void get_ens_mean_stdev(GenEnsProdVarInfo *, DataPlane &, DataPlane &);
 static bool get_data_plane(const char *, GrdFileType, VarInfo *, DataPlane &);
 
@@ -272,7 +274,7 @@ void process_grid(const Grid &fcst_grid) {
 
 void process_ensemble() {
    int i_var, i_ens, n_ens_vld, n_ens_inputs;
-   bool need_reset;
+   bool need_reset, set_climo_ens_mem_id;
    DataPlane ens_dp, ctrl_dp;
    DataPlane cmn_dp, csd_dp;
    DataPlane emn_dp, esd_dp;
@@ -286,6 +288,13 @@ void process_ensemble() {
 
       // Need to reinitialize counts and sums for each ensemble field
       need_reset = true;
+
+      // When normalizing relative to climatology with MET_ENS_MEMBER_ID set,
+      // read climatology separately for each member
+      set_climo_ens_mem_id =
+         (conf_info.ens_member_ids.n() > 1) &&
+         ((*var_it)->normalize == NormalizeType_ClimoAnom ||
+          (*var_it)->normalize == NormalizeType_ClimoStdAnom);
 
       // Print out the normalization flag
       cs << cs_erase;
@@ -335,17 +344,13 @@ void process_ensemble() {
             clear_counts();
 
             // Read climatology data for this field
-            cmn_dp = read_climo_data_plane(
-                        conf_info.conf.lookup_array(conf_key_climo_mean_field, false),
-                        i_var, ens_valid_ut, grid);
-
-            csd_dp = read_climo_data_plane(
-                        conf_info.conf.lookup_array(conf_key_climo_stdev_field, false),
-                        i_var, ens_valid_ut, grid);
+            get_climo_mean_stdev((*var_it), i_var,
+                                 set_climo_ens_mem_id,
+                                 i_ens, cmn_dp, csd_dp);
 
             // Compute the ensemble summary data, if needed
             if((*var_it)->normalize == NormalizeType_FcstAnom ||
-               (*var_it)->normalize == NormalizeType_FcstStdAnom ) {
+               (*var_it)->normalize == NormalizeType_FcstStdAnom) {
                get_ens_mean_stdev((*var_it), emn_dp, esd_dp);
             }
             else {
@@ -371,6 +376,13 @@ void process_ensemble() {
                   exit(1);
                }
 
+               // Read climo data with MET_ENS_MEMBER_ID set
+               if(set_climo_ens_mem_id) {
+                  get_climo_mean_stdev((*var_it), i_var,
+                                       set_climo_ens_mem_id, i_ens,
+                                       cmn_dp, csd_dp);
+               }
+
                // Normalize, if requested
                if((*var_it)->normalize != NormalizeType_None) {
                   normalize_data(ctrl_dp, (*var_it)->normalize,
@@ -390,6 +402,13 @@ void process_ensemble() {
                  << var_info->magic_str() << "\".\n";
 
          } // end if need_reset
+
+         // Read climo data with MET_ENS_MEMBER_ID set
+         if(set_climo_ens_mem_id) {
+             get_climo_mean_stdev((*var_it), i_var,
+                                  set_climo_ens_mem_id, i_ens,
+                                  cmn_dp, csd_dp);
+         }
 
          // Normalize, if requested
          if((*var_it)->normalize != NormalizeType_None) {
@@ -411,7 +430,7 @@ void process_ensemble() {
       if(((double) n_ens_vld/n_ens_inputs) < conf_info.vld_ens_thresh) {
          mlog << Error << "\nprocess_ensemble() -> "
               << n_ens_vld << " of " << n_ens_inputs
-	      << " (" << (double)n_ens_vld/n_ens_inputs << ")"
+              << " (" << (double)n_ens_vld/n_ens_inputs << ")"
               << " fields found for \"" << (*var_it)->get_var_info()->magic_str()
               << "\" does not meet the threshold specified by \""
               << conf_key_ens_ens_thresh << "\" (" << conf_info.vld_ens_thresh
@@ -424,6 +443,33 @@ void process_ensemble() {
       write_ens_nc(*var_it, n_ens_vld, ens_dp, cmn_dp, csd_dp);
 
    } // end for var_it
+
+   return;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void get_climo_mean_stdev(GenEnsProdVarInfo *ens_info, int i_var,
+                          bool set_ens_mem_id, int i_ens,
+                          DataPlane &cmn_dp, DataPlane &csd_dp) {
+
+   // Set the MET_ENS_MEMBER_ID environment variable
+   if(set_ens_mem_id) {
+      setenv(met_ens_member_id, ens_info->get_ens_member_id(i_ens).c_str(), 1);
+   }
+
+   cmn_dp = read_climo_data_plane(
+               conf_info.conf.lookup_array(conf_key_climo_mean_field, false),
+               i_var, ens_valid_ut, grid);
+
+   csd_dp = read_climo_data_plane(
+               conf_info.conf.lookup_array(conf_key_climo_stdev_field, false),
+               i_var, ens_valid_ut, grid);
+
+   // Unset the MET_ENS_MEMBER_ID environment variable
+   if(set_ens_mem_id) {
+      unsetenv(met_ens_member_id);
+   }
 
    return;
 }

--- a/met/src/tools/other/gen_ens_prod/gen_ens_prod.h
+++ b/met/src/tools/other/gen_ens_prod/gen_ens_prod.h
@@ -14,7 +14,7 @@
 //
 //   Mod#   Date      Name            Description
 //   ----   ----      ----            -----------
-//   000    09/10/21  Halley Gotway   Initial version (MET #1904).
+//   000    09/10/21  Halley Gotway   MET #1904 Initial version.
 //
 ////////////////////////////////////////////////////////////////////////
 

--- a/met/src/tools/other/gen_ens_prod/gen_ens_prod_conf_info.cc
+++ b/met/src/tools/other/gen_ens_prod/gen_ens_prod_conf_info.cc
@@ -213,6 +213,7 @@ void GenEnsProdConfInfo::process_config(GrdFileType etype, StringArray * ens_fil
          input_info.var_info = next_var;
          input_info.file_index = 0;
          input_info.file_list = ens_files;
+         input_info.ens_member_id = ens_member_ids[j];
          ens_info->add_input(input_info);
 
          // Add InputInfo to ens info list for each ensemble file provided
@@ -221,6 +222,7 @@ void GenEnsProdConfInfo::process_config(GrdFileType etype, StringArray * ens_fil
             input_info.var_info = NULL;
             input_info.file_index = k;
             input_info.file_list = ens_files;
+            input_info.ens_member_id = ens_member_ids[j];
             ens_info->add_input(input_info);
          } // end for k
 

--- a/test/config/GenEnsProdConfig_climo_anom_ens_member_id
+++ b/test/config/GenEnsProdConfig_climo_anom_ens_member_id
@@ -1,0 +1,161 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Gen-Ens-Prod configuration file.
+//
+// For additional information, please see the MET User's Guide.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Output model name to be written
+//
+model = "CFSv2";
+
+//
+// Output description to be written
+// May be set separately in each "obs.field" entry
+//
+desc = "NA";
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Verification grid
+// May be set separately in each "field" entry
+//
+regrid = {
+   to_grid    = NONE;
+   method     = NEAREST;
+   width      = 1;
+   vld_thresh = 0.5;
+   shape      = SQUARE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// May be set separately in each "field" entry
+//
+censor_thresh = [];
+censor_val    = [];
+normalize     = CLIMO_STD_ANOM;
+cat_thresh    = [];
+nc_var_str    = "";
+
+//
+// Ensemble fields to be processed
+//
+ens = {
+   file_type = NETCDF_NCCF;
+   ens_thresh = 0.3;
+   vld_thresh = 0.3;
+
+   field = [
+      {
+         name       = "fcst";
+         level      = "(MET_ENS_MEMBER_ID,0,*,*)";
+         cat_thresh = [ <-0.43, >-0.43&&<=0.43, >0.43 ];
+      }
+   ];
+}
+
+//
+// IDs for ensemble members
+// Only set if processing a single file with all ensembles
+//
+ens_member_ids = ["0","1","2"];
+control_id = "";
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Neighborhood ensemble probabilities
+//
+nbrhd_prob = {
+   width      = [ 5 ];
+   shape      = CIRCLE;
+   vld_thresh = 0.0;
+}
+
+//
+// NMEP smoothing methods
+//
+nmep_smooth = {
+   vld_thresh      = 0.0;
+   shape           = CIRCLE;
+   gaussian_dx     = 81.27;
+   gaussian_radius = 120;
+   type = [
+      {
+         method = GAUSSIAN;
+         width  = 1;
+      }
+   ];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Climatology data
+//
+climo_mean = {
+
+   file_name = [ "${CLIMO_MEAN_FILE}" ];
+   field     = [
+      {
+         name  = "series_cnt_FBAR";
+         level = "(*,*)";
+      }
+   ];
+
+   regrid = {
+      method     = NEAREST;
+      width      = 1;
+      vld_thresh = 0.5;
+      shape      = SQUARE;
+   }
+
+   time_interp_method = DW_MEAN;
+   day_interval       = NA;
+   hour_interval      = NA;
+}
+
+climo_stdev = {
+
+   file_name = [ "${CLIMO_STDEV_FILE}" ];
+   field     = [
+      {
+         name  = "series_cnt_FSTDEV";
+         level = "(*,*)";
+      }
+   ];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Ensemble product output types
+// May be set separately in each "ens.field" entry
+//
+ensemble_flag = {
+   latlon    = TRUE;
+   mean      = TRUE;
+   stdev     = TRUE;
+   minus     = FALSE;
+   plus      = FALSE;
+   min       = FALSE;
+   max       = FALSE;
+   range     = FALSE;
+   vld_count = FALSE;
+   frequency = TRUE;
+   nep       = FALSE;
+   nmep      = FALSE;
+   climo     = FALSE;
+   climo_cdp = FALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+version = "V10.1.0";
+
+////////////////////////////////////////////////////////////////////////////////

--- a/test/config/GenEnsProdConfig_single_file_nc
+++ b/test/config/GenEnsProdConfig_single_file_nc
@@ -9,7 +9,7 @@
 //
 // Output model name to be written
 //
-model = "WRF";
+model = "CFSv2";
 
 //
 // Output description to be written

--- a/test/xml/unit_gen_ens_prod.xml
+++ b/test/xml/unit_gen_ens_prod.xml
@@ -157,5 +157,21 @@
     </output>
   </test>
 
+  <test name="gen_ens_prod_CLIMO_ANOM_ENS_MEMBER_ID">
+    <exec>&MET_BIN;/gen_ens_prod</exec>
+    <env>
+      <pair><name>CLIMO_MEAN_FILE</name>  <value>&DATA_DIR_MODEL;/CPC_NMME/memberMET_ENS_MEMBER_ID-climo.nc</value></pair>
+      <pair><name>CLIMO_STDEV_FILE</name> <value>&DATA_DIR_MODEL;/CPC_NMME/memberMET_ENS_MEMBER_ID-climo.nc</value></pair>
+    </env>
+    <param> \
+      -ens    &DATA_DIR_MODEL;/CPC_NMME/CFSv2.tmp2m.198201.fcst.nc \
+      -config &CONFIG_DIR;/GenEnsProdConfig_climo_anom_ens_member_id \
+      -out    &OUTPUT_DIR;/gen_ens_prod/gen_ens_prod_CLIMO_ANOM_ENS_MEMBER_ID.nc \
+      -v 2
+    </param>
+    <output>
+      <grid_nc>&OUTPUT_DIR;/gen_ens_prod/gen_ens_prod_CLIMO_ANOM_ENS_MEMBER_ID.nc</grid_nc>
+    </output>
+  </test>
 
 </met_test>


### PR DESCRIPTION
## Expected Differences ##

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Adapted a test from unit_gen_ens_prod.xml to test these changes:
```
gen_ens_prod \
-ens ${MET_TEST_INPUT}/model_data/CPC_NMME/CFSv2.tmp2m.198201.fcst.nc \
-config GenEnsProdConfig_single_file_nc_normalize_climo.txt \
-out gen_ens_prod_SINGLE_FILE_NC_NO_CTRL_NORMALIZE_CLIMO.nc  \
-v 10
```

With this config file:
[GenEnsProdConfig_single_file_nc_normalize_climo.txt](https://github.com/dtcenter/MET/files/8145101/GenEnsProdConfig_single_file_nc_normalize_climo.txt)

The resulting output file contains a mean field of all 0's. Just setting climo_mean = ens copies over the same field settings to the climo_mean dictionary. Running with normalize = CLIMO_ANOM subtracts ens field - climo_mean field. The fact that the result is all 0's demonstrates that MET_ENS_MEMBER_ID setting is properly being substituted for each ensemble member read.

Note that I did also consider whether this should be added to Ensemble-Stat. But I decided that no, it should not. This logic only applies when normalizing input gridded data relative to climatology data. And that feature is not yet supported in Ensemble-Stat.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Please test more on seneca using:
/d1/projects/MET/MET_pull_requests/met-10.1.0/met-10.1.0-beta6/feature_1918/MET-feature_1918_climo_ens_member_id_into_develop/met/bin/gen_ens_prod

Do more thorough testing with your actual use case data. Note that MET_ENS_MEMBER_ID *should* be able to be used in climo_mean.file_name as well, although I haven't explicitly tested that.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**
I made no updates to the documentation. Can you please take a look and update the docs as you see fit.

- [x] Do these changes include sufficient testing updates? **[No]**
I made no testing updates. Although once you get your METplus use case up and running, I'd recommend adding some small piece of it to the MET unit tests.

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Please complete this pull request review by **[Monday 2/28/22]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Linked issues** with the original issue number.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
