### PR TITLE
added logic to manually trigger a workflow via the GitHub…

### DIFF
--- a/.github/jobs/set_job_controls.sh
+++ b/.github/jobs/set_job_controls.sh
@@ -66,7 +66,13 @@ elif [ "${GITHUB_EVENT_NAME}" == "push" ]; then
     fi
     
   fi
-  
+
+elif [ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]; then
+
+    if [ "${force_tests}" == "true" ]; then
+        run_diff=true
+    fi
+
 fi
 
 # if updating truth or running diff, run unit tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,6 +23,13 @@ on:
     paths-ignore:
       - 'met/docs/**'
 
+  workflow_dispatch:
+    inputs:
+      force_tests:
+        description: 'Run the unit tests'
+        default: true
+        type: boolean
+
 env:
   DOCKERHUB_REPO: dtcenter/met-dev
 
@@ -39,6 +46,7 @@ jobs:
         run: .github/jobs/set_job_controls.sh
         env:
           commit_msg: ${{ github.event.head_commit.message }}
+          force_tests: ${{ github.event.inputs.force_tests }}
 
     outputs:
       run_compile: ${{ steps.job_status.outputs.run_compile }}


### PR DESCRIPTION
… Actions tab on the web and forcing the unit tests to run

These changes should allow the testing workflow to be triggered manually through the GitHub Actions tab. This will not be available until the changes are merged into the default branch (main_v10.1). On the testing workflow view, there should be a Run Workflow button where users can select the branch to run the workflow and a checkbox to run the unit tests or not. This should allow us to select our feature branch and run the unit test logic from here instead of making a minor change to include a keyword in a commit message to trigger this logic if we forget to add the keyword.

The testing workflow ran on this branch and I confirmed that the value from github.event.inputs.force_tests is an empty string when the workflow is not triggered manually. If the event is workflow_dispatch, the boolean value from the inputs should be set to the string 'true' according to the documentation. The check for the value in the set_job_controls.sh script should work as expected.