### PR TITLE
added logic to manually trigger a workflow via the GitHub… (develop)

### DIFF
--- a/.github/jobs/set_job_controls.sh
+++ b/.github/jobs/set_job_controls.sh
@@ -66,7 +66,13 @@ elif [ "${GITHUB_EVENT_NAME}" == "push" ]; then
     fi
     
   fi
-  
+
+elif [ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]; then
+
+    if [ "${force_tests}" == "true" ]; then
+        run_diff=true
+    fi
+
 fi
 
 # if updating truth or running diff, run unit tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,6 +23,13 @@ on:
     paths-ignore:
       - 'met/docs/**'
 
+  workflow_dispatch:
+    inputs:
+      force_tests:
+        description: 'Run the unit tests'
+        default: true
+        type: boolean
+
 env:
   DOCKERHUB_REPO: dtcenter/met-dev
 
@@ -39,6 +46,7 @@ jobs:
         run: .github/jobs/set_job_controls.sh
         env:
           commit_msg: ${{ github.event.head_commit.message }}
+          force_tests: ${{ github.event.inputs.force_tests }}
 
     outputs:
       run_compile: ${{ steps.job_status.outputs.run_compile }}

--- a/met/README
+++ b/met/README
@@ -188,7 +188,7 @@ sub-directory, or the MET Online Tutorial:
 
 - If all tools are enabled and the build is successful, the "<prefix>/bin"
   directory (where <prefix> is the prefix you specified on your configure
-  command line) will contain 36 executables:
+  command line) will contain the following executables:
    - ascii2nc
    - ensemble_stat
    - gen_ens_prod
@@ -200,6 +200,7 @@ sub-directory, or the MET Online Tutorial:
    - grid_diag
    - gsid2mpr
    - gsidens2orank
+   - ioda2nc
    - lidar2nc
    - madis2nc
    - mode


### PR DESCRIPTION
… Actions tab on the web and forcing the unit tests to run.

Same changes as PR #2107 into main_v10.1 so that manual trigger of workflow will work for branches that are created off of develop. I tested and ensured that the expected behavior occurs for triggering manually.

I noticed a small change to a README file that appears to not have made it back into the develop branch, so this PR will include that change.