### PR TITLE
Feature 2215 ioda2nc message type

### DIFF
--- a/data/config/IODA2NCConfig_default
+++ b/data/config/IODA2NCConfig_default
@@ -88,8 +88,8 @@ obs_name_map = [];
 // Default mapping for Metadata.
 //
 metadata_map = [
-   { key = "message_type"; val = "msg_type"; },
-   { key = "station_id";   val = "report_identifier"; },
+   { key = "message_type"; val = "msg_type,station_ob"; },
+   { key = "station_id";   val = "station_id,report_identifier"; },
    { key = "pressure";     val = "air_pressure,pressure"; },
    { key = "height";       val = "height,height_above_mean_sea_level"; },
    { key = "elevation";    val = ""; }

--- a/docs/Users_Guide/reformat_point.rst
+++ b/docs/Users_Guide/reformat_point.rst
@@ -951,8 +951,8 @@ _____________________
 .. code-block:: none
 		
 		metadata_map = [
-		{ key = "message_type"; val = "msg_type"; },
-		{ key = "station_id";   val = "report_identifier"; },
+		{ key = "message_type"; val = "msg_type,station_ob"; },
+		{ key = "station_id";   val = "station_id,report_identifier"; },
 		{ key = "pressure";     val = "air_pressure,pressure"; },
 		{ key = "height";       val = "height,height_above_mean_sea_level"; },
 		{ key = "elevation";    val = ""; }

--- a/src/tools/other/ioda2nc/ioda2nc.cc
+++ b/src/tools/other/ioda2nc/ioda2nc.cc
@@ -411,10 +411,10 @@ void process_ioda_file(int i_pb) {
    get_var_names(f_in, &var_names);
    get_dim_names(f_in, &dim_names);
    for(idx=0; idx<var_names.n(); idx++) {
-      if(has_postfix(var_names[idx], "MetaData")) {
+      if(has_postfix(var_names[idx], "@MetaData")) {
          metadata_vars.add(var_names[idx].substr(0, var_names[idx].find('@')));
       }
-      if(has_postfix(var_names[idx], "ObsValue")) {
+      if(has_postfix(var_names[idx], "@ObsValue")) {
          obs_value_vars.add(var_names[idx].substr(0, var_names[idx].find('@')));
       }
    }

--- a/src/tools/other/ioda2nc/ioda2nc.cc
+++ b/src/tools/other/ioda2nc/ioda2nc.cc
@@ -102,7 +102,6 @@ static int compress_level = -1;
 ////////////////////////////////////////////////////////////////////////
 
 static IntArray filtered_times;
-//static map<ConcatString, StringArray> variableTypeMap;
 
 static bool do_summary;
 static bool save_summary_only = false;
@@ -505,10 +504,18 @@ void process_ioda_file(int i_pb) {
       hdr_msg_types = new char[nlocs*nstring];
       get_meta_data_strings(f_in, msg_type_name, hdr_msg_types);
    }
+   else {
+      mlog << Debug(1) << method_name
+           << "The metadata variable for message type does not exist!\n";
+   }
 
    if(has_station_id) {
       hdr_station_ids = new char[nlocs*nstring];
       get_meta_data_strings(f_in, station_id_name, hdr_station_ids);
+   }
+   else {
+      mlog << Debug(1) << method_name
+           << "The metadata variable for station ID does not exist!\n";
    }
 
    if(!get_nc_data(&in_hdr_lat_var, hdr_lat_arr, nlocs)) {
@@ -576,9 +583,9 @@ void process_ioda_file(int i_pb) {
       start_t = clock();
    }
 
-   log_message.add(" IODA messages");
+   log_message = " IODA messages";
    if(npbmsg != npbmsg_total) {
-      log_message << " (out of " << unixtime_to_string(npbmsg_total) << ")";
+      log_message << " (out of " << npbmsg_total << ")";
    }
    mlog << Debug(2) << "Processing " << npbmsg << log_message << "...\n";
 
@@ -658,7 +665,6 @@ void process_ioda_file(int i_pb) {
       }
 
       if(has_msg_type) {
-         int buf_len = sizeof(modified_hdr_typ);
          m_strncpy(hdr_typ, hdr_msg_types+(i_read*nstring), nstring, method_name_s, "hdr_typ");
          m_rstrip(hdr_typ, nstring);
 
@@ -669,20 +675,18 @@ void process_ioda_file(int i_pb) {
             rej_typ++;
             continue;
          }
-
-         if(0 < message_type_map.count((string)hdr_typ)) {
-            ConcatString mappedMessageType = message_type_map[(string)hdr_typ];
-            mlog << Debug(6) << "\n" << method_name
-                 << "Switching report type \"" << hdr_typ
-                 << "\" to message type \"" << mappedMessageType << "\".\n";
-            if(mappedMessageType.length() < HEADER_STR_LEN) buf_len = HEADER_STR_LEN;
-            m_strncpy(modified_hdr_typ, mappedMessageType.c_str(), buf_len,
-                      method_name_s, "modified_hdr_typ");
-         }
-         else {
-            m_strncpy(modified_hdr_typ, hdr_typ, buf_len, method_name_s, "modified_hdr_typ2");
-         }
-         modified_hdr_typ[buf_len-1] = 0;
+      }
+      else m_strncpy(hdr_typ, "NA", HEADER_STR_LEN,
+                     method_name_s, "missing_hdr_typ");
+      if(0 < message_type_map.count((string)hdr_typ)) {
+         int buf_len = sizeof(modified_hdr_typ);
+         ConcatString mappedMessageType = message_type_map[(string)hdr_typ];
+         mlog << Debug(6) << "\n" << method_name
+              << "Switching report type \"" << hdr_typ
+              << "\" to message type \"" << mappedMessageType << "\".\n";
+         if(mappedMessageType.length() < HEADER_STR_LEN) buf_len = HEADER_STR_LEN;
+         m_strncpy(modified_hdr_typ, mappedMessageType.c_str(), buf_len,
+                   method_name_s, "modified_hdr_typ");
       }
 
       if(has_station_id) {
@@ -768,7 +772,7 @@ void process_ioda_file(int i_pb) {
       }
 
       // Store the index to the header data
-      obs_arr[0] = (float) nc_point_obs.get_hdr_index();
+      obs_arr[0] = (float)nc_point_obs.get_hdr_index();
 
       n_hdr_obs = 0;
       for(idx=0; idx<v_obs_data.size(); idx++ ) {


### PR DESCRIPTION
- Added "station_ob" variable to message_type variable name list (metadata_map at config file)
- Added "station_id" variable to station_id variable name list  (metadata_map at config file)
  - Not include XXX@RecMetaData into the metadata variable list
  - "station_id@RecMetaData" variable with dimension (nrecs, nstring) is different from "station_id@MetaData" variable with different dimension (nlocs, nstring).
  - No additional variable is available and not know how to map station_id from "station_id@RecMetaData"
- If the message type metadata variable does not exist, set the message_type to "NA" instead of empty string "".  This gives an option which prevents from filtering out by message type with the following MET tools
  - The empty message_type can not be mapped to any other existing message types
  - By having message_type "NA", they can be mapped to other message type

## Expected Differences ##

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

Run unit test.
- the unit test "ioda2nc_var_all" will have the log message
```
DEBUG 1: process_ioda_file() -> The metadata variable for message type does not exist!
DEBUG 1: process_ioda_file() -> The metadata variable for station ID does not exist!
```

ioda2nc adds the message_type and station_id with seneca:/d1/personal/kalb/ioda/raob_all_v1_20201215T1200Z.nc4 with new IODA2NCCondig_default.
```
/d1/personal/hsoh/data/IODA_files/raob_all_v1_20201215T1200Z.nc4 out_raob_all_v1_20201215T1200Z_msg_type2.nc -config IODA2NCConfig_msg_type -obs_var air_temperature -v 4
```

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**

- [x] Do these changes include sufficient testing updates? **[No]**

- [x] Will this PR result in changes to the test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

The unit test "ioda2nc_var_all" does not have the message_type and station_id variables. The hdr_typ_table was "". It will be changed "NA" at ioda2nc/odb_sonde_16019_all.nc.

- [ ] Please complete this pull request review by **[Fill in date]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [ ] After submitting the PR, select **Linked issues** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
