### PR TITLE
Feature dtcenter/METplus-Internal#21  signal handling

### DIFF
--- a/src/basic/vx_util/main.cc
+++ b/src/basic/vx_util/main.cc
@@ -65,6 +65,7 @@ void do_pre_process(int argc, char *argv[]);
 void set_handlers();
 void set_user_id();
 void store_arguments(int argc, char **argv);
+void tidy_and_exit(int signal);
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -124,7 +125,6 @@ string get_current_time() {
 
 ////////////////////////////////////////////////////////////////////////
 
-/* not working at Docker
 // based on blog at http://www.alexonlinux.com/how-to-handle-sigsegv-but-also-generate-core-dump
 // NOTE:  that comments on the blog indicate the core file generated on red hat or on multi-threaded programs
 //        might contain unhelpful information.
@@ -134,22 +134,23 @@ void segv_handler(int signum) {
 
    getcwd(cwdbuffer,MET_BUF_SIZE+1);
 
-   fprintf(stderr, "FATAL ERROR (SEGFAULT): Process %d got signal %d @ local time = %s\n", getpid(), signum, timebuffer);
+   fprintf(stderr, "FATAL ERROR (SEGFAULT): Process %d got signal %d @ local time = %s\n", getpid(), signum, timebuffer.c_str());
    fprintf(stderr, "FATAL ERROR (SEGFAULT): Look for a core file in %s\n",cwdbuffer);
    fprintf(stderr, "FATAL ERROR (SEGFAULT): Process command line: %s\n",met_cmdline.c_str());
    signal(signum, SIG_DFL);
    kill(getpid(), signum);
 }
-*/
 
 ////////////////////////////////////////////////////////////////////////
-// Need signal handlers for SIGINT, SIGHUP, SIGTERM, SIGPIPE, and SIGSEGV
-//  PORTsignal(SIGPIPE, (PORTsigfunc)SIG_IGN);
-//  PORTsignal(SIGSEGV, segv_handler);
 
 void set_handlers() {
-
-  set_new_handler(oom);
+   set_new_handler(oom);
+   signal(SIGSEGV, segv_handler);
+   signal(SIGINT, tidy_and_exit);
+   signal(SIGTERM, tidy_and_exit);
+   signal(SIGABRT, tidy_and_exit);
+   signal(SIGFPE, tidy_and_exit);
+   signal(SIGILL, tidy_and_exit);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -173,6 +174,18 @@ void store_arguments(int argc, char **argv) {
 ////////////////////////////////////////////////////////////////////////
 
 void tidy_and_exit(int signal) {
+   printf("FATAL: ");
+   if(signal == SIGINT) {
+      printf("Received Signal Interrupt. ");
+   } else if(signal == SIGTERM){
+      printf("Received Signal Terminate. ");
+   } else if(signal == SIGABRT){
+      printf("Received Signal Abort. ");
+   } else if(signal == SIGFPE){
+      printf("Received Signal Floating-Point Exception. ");
+   } else if(signal == SIGILL){
+      printf("Received Signal Illegal Instruction. ");
+   }
    printf("Exiting %d\n", signal);
    exit(signal);
 }


### PR DESCRIPTION
## Expected Differences ##

- [X] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>

- [X] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>

## Pull Request Testing ##

- [X] Describe testing already performed for these changes:</br>

I made some changes to the code and ran some tests to verify that the [csignal types](https://cplusplus.com/reference/csignal/) were handled properly. I was not able to cause a SIGILL exception, which according to the [GNU docs](https://www.gnu.org/software/libc/manual/html_node/Program-Error-Signals.html) is:

> The name of this signal is derived from “illegal instruction”; it usually means your program is trying to execute garbage or a privileged instruction.

Here are the tests I performed:

* Added `int[foo]={23};delete foo;` to the main function, which caused SIGABRT:
> free(): invalid pointer
> FATAL: Received Signal Abort. Exiting 6

* Added `int foo = 3/0;` to the main function, which caused SIGFPE:
> FATAL: Received Signal Floating-Point Exception. Exiting 8

* Added `abort();` to the main function, which caused SIGABRT:
> FATAL: Received Signal Abort. Exiting 6

* Ran mtd, then pressed CTRL+C to kill the process, which caused SIGINT:
> FATAL: Received Signal Interrupt. Exiting 2

* Ran mtd, then ran `snuff mtd` in another window to kill the process, which caused SIGTERM:
> FATAL: Received Signal Terminate. Exiting 15

* Added `void (*foo)();foo();` to the main function, which caused a seg fault:
> FATAL ERROR (SEGFAULT): Process 24433 got signal 11 @ local time = 2022-11-03 20:29:40Z
> FATAL ERROR (SEGFAULT): Look for a core file in /d1/personal/mccabe/MET/src/tools/other/mode_time_domain
> FATAL ERROR (SEGFAULT): Process command line: /home/mccabe/MET/bin/mtd -v 2 -fcst /d1/personal/mccabe/out/stage/file_lists/20170510040000_mtd_fcst_APCP.txt -obs /d1/personal/mccabe/out/stage/file_lists/20170510040000_mtd_obs_P01M_NONE.txt -config /d1/personal/mccabe/METplus/parm/met_config/MTDConfig_wrapped -outdir /d1/personal/mccabe/out/model_applications/precipitation/MTD_fcstHRRR-TLE_obsMRMS/201705100300

The core file is a file named 'core' that is generated in the current pwd where the app is running. This was the directory I was in when I called METplus to run a use case. The core file will likely not be generated by default because the ulimit needs to be set for the core file. You can run `ulimit -a` to see the settings. The default core file size is 0, but running `ulimit -c unlimited` will set the size to unlimited. Then the seg fault will generate the core file that can be used with the debugger to get to the state of the app when the seg fault occurred so you can see where it occurred.

- [X] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

* Review the code changes
* Try running an app and try to recreate some of the signals to see if you get the correct results.
  * There is an mtd binary on seneca that can be used to test: /d1/projects/MET/MET_issues/feature_21i/mtd OR
  * From the feature branch, build/install the basic/vx_util library, then build an app

- [X] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [X] Do these changes include sufficient testing updates? **[Yes]**

- [X] Will this PR result in changes to the test suite? **[No]**</br>

- [X] Please complete this pull request review by **11/8/2022**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [X] Review the source issue metadata (required labels, projects, and milestone).
- [X] Complete the PR definition above.
- [X] Ensure the PR title matches the feature or bugfix branch name.
- [X] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Development** with the original issue number.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
