### PR TITLE
Feature #2278 qm_docs

### DIFF
--- a/docs/Users_Guide/reformat_point.rst
+++ b/docs/Users_Guide/reformat_point.rst
@@ -243,7 +243,7 @@ The example **obs_bufr_var** setting above retains observations of QOB, TOB, ZOB
 • **D_MLCAPE** for mixed layer convective available potential energy (from POB, QOB, and TOB)
 
 
-In BUFR, lower quality mark values indicate higher quality observations. The quality marks for derived observations are computed as the maximum of the quality marks for its components. For example, **D_DPT** derived from **POB** with quality mark 1 and **QOB** with quality mark 2 is assigned a quality mark value of 2. **D_DBL**, **D_CAPE**, and **D_MLCAPE** are derived using data from multiple vertical levels. However, their quality marks are computed as the maximum of their components only at the first vertical level.
+In BUFR, lower quality mark values indicate higher quality observations. The quality marks for derived observations are computed as the maximum of the quality marks for its components. For example, **D_DPT** derived from **POB** with quality mark 1 and **QOB** with quality mark 2 is assigned a quality mark value of 2. **D_PBL**, **D_CAPE**, and **D_MLCAPE** are derived using data from multiple vertical levels. Their quality marks are computed as the maximum of their components over all vertical levels.
 
 _____________________
 

--- a/docs/Users_Guide/reformat_point.rst
+++ b/docs/Users_Guide/reformat_point.rst
@@ -219,7 +219,31 @@ _____________________
   obs_bufr_var = [ 'QOB', 'TOB', 'ZOB', 'UOB', 'VOB' ];
 
 
-Each PrepBUFR message will likely contain multiple observation variables. The **obs_bufr_var** variable is used to specify which observation variables should be retained or derived. The variable name comes from BUFR file which includes BUFR table. The following BUFR names may be retained: QOB, TOB, ZOB, UOB, and VOB for specific humidity, temperature, height, and the u and v components of winds. The following BUFR names may be derived: D_DPT, D_WIND, D_RH, D_MIXR, D_PRMSL, D_PBL, D_CAPE, and D_MLCAPE for dew point, wind speed, relative humidity, mixing ratio, pressure reduced to MSL, planetary boundary layer height, convective available potential energy, and mixed layer convective available potential energy. This configuration replaces **obs_grib_code**. If the list is empty, all BUFR variables are retained.
+Each PrepBUFR message will likely contain multiple observation variables. The **obs_bufr_var** variable is used to specify which observation variables should be retained or derived. The observation variable names are retrieved from the BUFR table embedded within the file. Users can run PB2NC with the **-index** command line argument to list out the variable names present in the file, and those names can be listed in this setting. If the list is empty, all BUFR variables present in the file are retained. This setting replaces the deprecated **obs_grib_code**.
+
+
+The example **obs_bufr_var** setting above retains observations of QOB, TOB, ZOB, UOB, and VOB for specific humidity, temperature, height, and the u and v components of winds. Observations of those types are reported at the corresponding POB pressure level. In addition, PB2NC can derive the several other variables from these observations. By convention, all observations that are derivable are named with a **D_** prefix:
+
+• **D_DPT** for dew point (from POB and QOB)
+
+• **D_WDIR** for wind speed (from UOB and VOB)
+
+• **D_WIND** for wind speed (from UOB and VOB)
+
+• **D_RH** for relative humidity (from POB, QOB, and TOB)
+
+• **D_MIXR** for mixing ratio (from QOB)
+
+• **D_PRMSL** for pressure reduced to mean sea level (from POB, TOB, and ZOB)
+
+• **D_PBL** for planetary boundary layer height (from POB, QOB, TOB, ZOB, UOB, and VOB)
+
+• **D_CAPE** for convective available potential energy (from POB, QOB, and TOB)
+
+• **D_MLCAPE** for mixed layer convective available potential energy (from POB, QOB, and TOB)
+
+
+In BUFR data, lower quality mark values indicate higher quality observations. The quality marks for derived observations are computed as the maximum of the quality marks for its components. For example, **D_DPT** derived from **POB** with quality mark 1 and **QOB** with quality mark 2 is assigned a quality mark value of 2. **D_DBL**, **D_CAPE**, and **D_MLCAPE** are derived using data from multiple vertical levels. However, their quality marks are computed as the maximum of their components only at the first vertical level.
 
 _____________________
 
@@ -301,6 +325,9 @@ The summaries will only be calculated for the observations specified in the **gr
 
 
 The **vld_freq** and **vld_thresh** entries specify the required ratio of valid data for an output time summary value to be computed. This option is only applied when these entries are set to non-zero values. The **vld_freq** entry specifies the expected frequency of observations in seconds. The width of the time window is divided by this frequency to compute the expected number of observations for the time window. The actual number of valid observations is divided by the expected number to compute the ratio of valid data. An output time summary value will only be written if that ratio is greater than or equal to the **vld_thresh** entry. Detailed information about which observations are excluded is provided at debug level 4.
+
+
+The quality mark for time summaries is always reported by PB2NC as bad data. Time summaries are computed by several MET point pre-processing tools using common library code. While BUFR quality marks are integers, the quality flags for other point data formats (MADIS NetCDF, for example) are stored as strings. MET does not currently contain logic to determine which quality flag strings are better or worse. Note however that any point observation whose quality mark does not meet the **quality_mark_thresh** criteria is not used in the computation of time summaries.
 
 .. _pb2nc output:
 

--- a/docs/Users_Guide/reformat_point.rst
+++ b/docs/Users_Guide/reformat_point.rst
@@ -226,7 +226,7 @@ The example **obs_bufr_var** setting above retains observations of QOB, TOB, ZOB
 
 • **D_DPT** for dew point (from POB and QOB)
 
-• **D_WDIR** for wind speed (from UOB and VOB)
+• **D_WDIR** for wind direction (from UOB and VOB)
 
 • **D_WIND** for wind speed (from UOB and VOB)
 

--- a/docs/Users_Guide/reformat_point.rst
+++ b/docs/Users_Guide/reformat_point.rst
@@ -222,7 +222,7 @@ _____________________
 Each PrepBUFR message will likely contain multiple observation variables. The **obs_bufr_var** variable is used to specify which observation variables should be retained or derived. The observation variable names are retrieved from the BUFR table embedded within the file. Users can run PB2NC with the **-index** command line argument to list out the variable names present in the file, and those names can be listed in this setting. If the list is empty, all BUFR variables present in the file are retained. This setting replaces the deprecated **obs_grib_code**.
 
 
-The example **obs_bufr_var** setting above retains observations of QOB, TOB, ZOB, UOB, and VOB for specific humidity, temperature, height, and the u and v components of winds. Observations of those types are reported at the corresponding POB pressure level. In addition, PB2NC can derive the several other variables from these observations. By convention, all observations that are derivable are named with a **D_** prefix:
+The example **obs_bufr_var** setting above retains observations of QOB, TOB, ZOB, UOB, and VOB for specific humidity, temperature, height, and the u and v components of winds. Observations of those types are reported at the corresponding POB pressure level. In addition, PB2NC can derive several other variables from these observations. By convention, all observations that are derivable are named with a **D_** prefix:
 
 • **D_DPT** for dew point (from POB and QOB)
 
@@ -243,7 +243,7 @@ The example **obs_bufr_var** setting above retains observations of QOB, TOB, ZOB
 • **D_MLCAPE** for mixed layer convective available potential energy (from POB, QOB, and TOB)
 
 
-In BUFR data, lower quality mark values indicate higher quality observations. The quality marks for derived observations are computed as the maximum of the quality marks for its components. For example, **D_DPT** derived from **POB** with quality mark 1 and **QOB** with quality mark 2 is assigned a quality mark value of 2. **D_DBL**, **D_CAPE**, and **D_MLCAPE** are derived using data from multiple vertical levels. However, their quality marks are computed as the maximum of their components only at the first vertical level.
+In BUFR, lower quality mark values indicate higher quality observations. The quality marks for derived observations are computed as the maximum of the quality marks for its components. For example, **D_DPT** derived from **POB** with quality mark 1 and **QOB** with quality mark 2 is assigned a quality mark value of 2. **D_DBL**, **D_CAPE**, and **D_MLCAPE** are derived using data from multiple vertical levels. However, their quality marks are computed as the maximum of their components only at the first vertical level.
 
 _____________________
 

--- a/scripts/utility/print_pointnc2ascii.py
+++ b/scripts/utility/print_pointnc2ascii.py
@@ -84,7 +84,8 @@ class met_nc_point_obs():
             obs_val = [ f'{i:.0f}' for i in self.obs_val ]
         else:
             obs_precision = self.get_precision(self.obs_val)
-            obs_val = [ f'{i:.1f}' if abs((i*10)-int(i*10)) < 0.000001 else
+            obs_val = [ 'NA'       if np.ma.is_masked(i) else
+                        f'{i:.1f}' if abs((i*10)-int(i*10)) < 0.000001 else
                         f'{i:.1f}' if abs((i*10)-int(i*10)) > 0.999998 else
                         f'{i:.2f}' if abs((i*100)-int(i*100)) < 0.000001 else
                         f'{i:.2f}' if abs((i*100)-int(i*100)) > 0.999998 else

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -1345,17 +1345,21 @@ void process_pbfile(int i_pb) {
          }
       }
 
+      // Initialize for CAPE and PBL
       if (cal_cape || cal_mlcape) {
          cape_level = 0;
+         cape_qm = bad_data_float;
       }
 
       do_pbl = cal_pbl && 0 == strcmp("ADPUPA", hdr_typ);
       if (do_pbl) {
          pbl_level = 0;
+         pbl_qm = bad_data_float;
       }
 
       // Search through the vertical levels
       for(lv=0, n_hdr_obs = 0; lv<buf_nlev; lv++) {
+
          // If the observation vertical level is not within the
          // specified valid range, continue to the next vertical
          // level

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -1505,12 +1505,17 @@ void process_pbfile(int i_pb) {
                      if (cape_level < MAX_CAPE_LEVEL) cape_data_temp[cape_level] = obs_arr[4];
                      cape_member_cnt++;
                   }
-                  if (is_cape_input && (cape_level == 0)) {
+
+                  // Track of the maximum quality mark for CAPE components
+                  if (is_cape_input && (cape_level == 0) &&
+                     (is_bad_data(cape_qm) || quality_mark > cape_qm) {
                      cape_qm = quality_mark;
                   }
                }
 
-               if (do_pbl && (pbl_level == 0)) {
+               // Track the maximum quality mark for PBL components
+               if (do_pbl && (pbl_level == 0) &&
+                  (is_bad_data(pbl_qm) || quality_mark > pbl_qm) {
                   pbl_qm = quality_mark;
                }
             }

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -1003,6 +1003,7 @@ void process_pbfile(int i_pb) {
    float cape_qm = bad_data_float;
 
    // To compute PBL
+   int pbl_level = 0;
    int pbl_code = -1;
    float pbl_p, pbl_h;
    float pbl_qm = bad_data_float;
@@ -1351,6 +1352,9 @@ void process_pbfile(int i_pb) {
       }
 
       do_pbl = cal_pbl && 0 == strcmp("ADPUPA", hdr_typ);
+      if (do_pbl) {
+         pbl_level = 0;
+      }
 
       // Search through the vertical levels
       for(lv=0, n_hdr_obs = 0; lv<buf_nlev; lv++) {
@@ -1889,6 +1893,7 @@ void process_pbfile(int i_pb) {
       }
 
       if (do_pbl) {
+         pbl_level = 0;
          is_same_header = (prev_hdr_vld_ut == hdr_vld_ut)
                && is_eq(prev_hdr_lat, hdr_lat)
                && is_eq(prev_hdr_lon, hdr_lon)

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -1507,15 +1507,13 @@ void process_pbfile(int i_pb) {
                   }
 
                   // Track of the maximum quality mark for CAPE components
-                  if (is_cape_input && (cape_level == 0) &&
-                     (is_bad_data(cape_qm) || quality_mark > cape_qm)) {
+                  if (is_cape_input && (is_bad_data(cape_qm) || quality_mark > cape_qm)) {
                      cape_qm = quality_mark;
                   }
                }
 
                // Track the maximum quality mark for PBL components
-               if (do_pbl && (pbl_level == 0) &&
-                  (is_bad_data(pbl_qm) || quality_mark > pbl_qm)) {
+               if (do_pbl && (is_bad_data(pbl_qm) || quality_mark > pbl_qm)) {
                   pbl_qm = quality_mark;
                }
             }

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -1003,7 +1003,6 @@ void process_pbfile(int i_pb) {
    float cape_qm = bad_data_float;
 
    // To compute PBL
-   int pbl_level = 0;
    int pbl_code = -1;
    float pbl_p, pbl_h;
    float pbl_qm = bad_data_float;
@@ -1352,10 +1351,6 @@ void process_pbfile(int i_pb) {
       }
 
       do_pbl = cal_pbl && 0 == strcmp("ADPUPA", hdr_typ);
-      if (do_pbl) {
-         pbl_level = 0;
-         pbl_qm = bad_data_float;
-      }
 
       // Search through the vertical levels
       for(lv=0, n_hdr_obs = 0; lv<buf_nlev; lv++) {
@@ -1894,7 +1889,6 @@ void process_pbfile(int i_pb) {
       }
 
       if (do_pbl) {
-         pbl_level = 0;
          is_same_header = (prev_hdr_vld_ut == hdr_vld_ut)
                && is_eq(prev_hdr_lat, hdr_lat)
                && is_eq(prev_hdr_lon, hdr_lon)
@@ -1915,6 +1909,7 @@ void process_pbfile(int i_pb) {
             pqtzuv_list.clear();
             pqtzuv_map_tq.clear();
             pqtzuv_map_uv.clear();
+            pbl_qm = bad_data_float;
          }
          //is_same_header = false;
          prev_hdr_vld_ut = hdr_vld_ut;

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -1509,7 +1509,7 @@ void process_pbfile(int i_pb) {
                      cape_member_cnt++;
                   }
 
-                  // Track of the maximum quality mark for CAPE components
+                  // Track the maximum quality mark for CAPE components
                   if (is_cape_input && (is_bad_data(cape_qm) || quality_mark > cape_qm)) {
                      cape_qm = quality_mark;
                   }

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -1508,14 +1508,14 @@ void process_pbfile(int i_pb) {
 
                   // Track of the maximum quality mark for CAPE components
                   if (is_cape_input && (cape_level == 0) &&
-                     (is_bad_data(cape_qm) || quality_mark > cape_qm) {
+                     (is_bad_data(cape_qm) || quality_mark > cape_qm)) {
                      cape_qm = quality_mark;
                   }
                }
 
                // Track the maximum quality mark for PBL components
                if (do_pbl && (pbl_level == 0) &&
-                  (is_bad_data(pbl_qm) || quality_mark > pbl_qm) {
+                  (is_bad_data(pbl_qm) || quality_mark > pbl_qm)) {
                   pbl_qm = quality_mark;
                }
             }


### PR DESCRIPTION
## Expected Differences ##

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Ran a full regression test in this [GHA run](https://github.com/dtcenter/MET/actions/runs/3586711534) and note that one difference is flagged.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

  - @hsoh-u please review the actual code change to keep track of the max quality flag for PBL and CAPE. And can you confirm that we *SHOULD* only be computing them from the first level? Is there a reason we don't compute the maximum quality flag over all levels used? Please also note the tweak to the python print utility.
  - @PerryShafran-NOAA these changes would modify the quality flag values for PBL and CAPE from a value of 2 to 8 or 9 (see below) since thats the maximum quality value of their components. Is this good? Or will it cause trouble for your verification of CAPE/PBL?
  - @TaraJensen please review the documentation changes included in the PR (or reassign to another scientist to review). You can see them rendered via RTD starting after [this table](https://met--2364.org.readthedocs.build/en/2364/Users_Guide/reformat_point.html#id5).

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [x] Do these changes include sufficient testing updates? **[Yes]**
No changes needed.

- [x] Will this PR result in changes to the test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>
This changes one output file:
```
COMPARING pb2nc_indy/nam.20210311.t00z.prepbufr.tm00.pbl.nc
ERROR: NetCDF headers differ:
12c12
< 	nobs_qty = 1 ;
---
> 	nobs_qty = 2 ;
```
I dumped these to ascii and confirmed that the only changes are in the `qty` column.
All that that previously had a value of '2' are now '8' or '9'.

- [x] Please complete this pull request review by **[Mon 12/5/22]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Development** with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
