### PR TITLE
Bugfix #2412 main_v11.0 climo

### DIFF
--- a/internal/scripts/docker/build_met_docker.sh
+++ b/internal/scripts/docker/build_met_docker.sh
@@ -15,14 +15,14 @@ fi
 
 LOG_FILE=/met/MET-${MET_GIT_NAME}/make_install.log
 echo "Compiling MET ${MET_GIT_NAME} and writing log file ${LOG_FILE}"
-make install > ${LOG_FILE}
+make -j install > ${LOG_FILE}
 if [ $? != 0 ]; then
     exit 1
 fi
 
 LOG_FILE=/met/logs/MET-${MET_GIT_NAME}_make_test.log
 echo "Testing MET ${MET_GIT_NAME} and writing log file ${LOG_FILE}"
-make test > ${LOG_FILE} 2>&1
+make -j test > ${LOG_FILE} 2>&1
 if [ $? != 0 ]; then
     exit 1
 fi

--- a/src/basic/vx_cal/doyhms_to_unix.cc
+++ b/src/basic/vx_cal/doyhms_to_unix.cc
@@ -97,7 +97,22 @@ return ( s );
 
 }
 
+
 ////////////////////////////////////////////////////////////////////////
+
+int unix_to_sec_of_year(unixtime u) {
+
+int mon, day, yr, hr, min, sec;
+
+unix_to_mdyhms(u, mon, day, yr, hr, min, sec);
+
+return ( (int) mdyhms_to_unix(mon, day, 1970, hr, min, sec) );
+
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
 
 long unix_to_long_yyyymmddhh(unixtime u) {
 
@@ -111,5 +126,48 @@ yyyymmddhh = 1000000 * yr + 10000 * mon + 100 * day + hr;
 return ( yyyymmddhh );
 
 }
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+int sec_of_day_diff(unixtime ut1, unixtime ut2) {
+
+int sec_per_day = 60 * 60 * 24;
+
+int s1 = unix_to_sec_of_day(ut1);
+
+int s2 = unix_to_sec_of_day(ut2);
+
+int ds = s2 - s1;
+
+     if ( ds < -1 * sec_per_day/2 ) ds += sec_per_day;
+else if ( ds >      sec_per_day/2 ) ds -= sec_per_day;
+
+return ( ds );
+
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+int sec_of_year_diff(unixtime ut1, unixtime ut2) {
+
+int sec_per_year = 60 * 60 * 24 * 365;
+
+int s1 = unix_to_sec_of_year(ut1);
+
+int s2 = unix_to_sec_of_year(ut2);
+
+int ds = s2 - s1;
+
+     if ( ds < -1 * sec_per_year/2 ) ds += sec_per_year;
+else if ( ds >      sec_per_year/2 ) ds -= sec_per_year;
+
+return ( ds );
+
+}
+
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/basic/vx_cal/doyhms_to_unix.cc
+++ b/src/basic/vx_cal/doyhms_to_unix.cc
@@ -100,13 +100,18 @@ return ( s );
 
 ////////////////////////////////////////////////////////////////////////
 
-int unix_to_sec_of_year(unixtime u) {
+
+int unix_to_day_of_year(unixtime u) {
 
 int mon, day, yr, hr, min, sec;
 
 unix_to_mdyhms(u, mon, day, yr, hr, min, sec);
 
-return ( (int) mdyhms_to_unix(mon, day, 1970, hr, min, sec) );
+int sec_of_year = mdyhms_to_unix(mon, day, 1970, 0, 0, 0);
+
+int sec_per_day = 60 * 60 * 24;
+
+return ( sec_of_year / sec_per_day );
 
 }
 
@@ -139,12 +144,12 @@ int s1 = unix_to_sec_of_day(ut1);
 
 int s2 = unix_to_sec_of_day(ut2);
 
-int ds = s2 - s1;
+int dt = s2 - s1;
 
-     if ( ds < -1 * sec_per_day/2 ) ds += sec_per_day;
-else if ( ds >      sec_per_day/2 ) ds -= sec_per_day;
+     if ( dt < -1 * sec_per_day/2 ) dt += sec_per_day;
+else if ( dt >      sec_per_day/2 ) dt -= sec_per_day;
 
-return ( ds );
+return ( dt );
 
 }
 
@@ -152,20 +157,22 @@ return ( ds );
 ////////////////////////////////////////////////////////////////////////
 
 
-int sec_of_year_diff(unixtime ut1, unixtime ut2) {
+int day_of_year_diff(unixtime ut1, unixtime ut2) {
 
-int sec_per_year = 60 * 60 * 24 * 365;
 
-int s1 = unix_to_sec_of_year(ut1);
+int sec_per_day  = 60 * 60 * 24;
+int day_per_year = 365;
 
-int s2 = unix_to_sec_of_year(ut2);
+int d1 = unix_to_day_of_year(ut1);
 
-int ds = s2 - s1;
+int d2 = unix_to_day_of_year(ut2);
 
-     if ( ds < -1 * sec_per_year/2 ) ds += sec_per_year;
-else if ( ds >      sec_per_year/2 ) ds -= sec_per_year;
+int dt = d2 - d1;
 
-return ( ds );
+     if ( dt < -1 * day_per_year/2.0 ) dt += day_per_year;
+else if ( dt >      day_per_year/2.0 ) dt -= day_per_year;
+
+return ( dt );
 
 }
 

--- a/src/basic/vx_cal/vx_cal.h
+++ b/src/basic/vx_cal/vx_cal.h
@@ -81,6 +81,8 @@ extern  int       hms_to_sec      (int hour, int min, int sec);
 
 extern  int       unix_to_sec_of_day (unixtime u);
 
+extern  int       unix_to_sec_of_year (unixtime u);
+
 extern  long      unix_to_long_yyyymmddhh (unixtime u);
 
 // Parse time strings
@@ -123,6 +125,14 @@ extern  ConcatString HH(int hours);
 
 extern  int          timestring_to_sec(const char *);
 extern  ConcatString sec_to_timestring(int);
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+extern  int  sec_of_day_diff (unixtime ut1, unixtime ut2);
+
+extern  int  sec_of_year_diff (unixtime ut1, unixtime ut2);
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/basic/vx_cal/vx_cal.h
+++ b/src/basic/vx_cal/vx_cal.h
@@ -81,7 +81,7 @@ extern  int       hms_to_sec      (int hour, int min, int sec);
 
 extern  int       unix_to_sec_of_day (unixtime u);
 
-extern  int       unix_to_sec_of_year (unixtime u);
+extern  int       unix_to_day_of_year (unixtime u);
 
 extern  long      unix_to_long_yyyymmddhh (unixtime u);
 
@@ -132,7 +132,7 @@ extern  ConcatString sec_to_timestring(int);
 
 extern  int  sec_of_day_diff (unixtime ut1, unixtime ut2);
 
-extern  int  sec_of_year_diff (unixtime ut1, unixtime ut2);
+extern  int  day_of_year_diff (unixtime ut1, unixtime ut2);
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/basic/vx_util/interp_util.cc
+++ b/src/basic/vx_util/interp_util.cc
@@ -1287,7 +1287,7 @@ DataPlane valid_time_interp(const DataPlane &in1, const DataPlane &in2,
    // Range check the times
    if(dp1.valid() > to_ut || dp2.valid() < to_ut ||
       dp1.valid() == dp2.valid()) {
-      mlog << Error << "\time_interp() -> "
+      mlog << Error << "\ntime_interp() -> "
            << "the interpolation time " << unix_to_yyyymmdd_hhmmss(to_ut)
            << " must fall between the input times: "
            << unix_to_yyyymmdd_hhmmss(dp1.valid()) << " and "

--- a/src/basic/vx_util/interp_util.cc
+++ b/src/basic/vx_util/interp_util.cc
@@ -1280,13 +1280,15 @@ DataPlane valid_time_interp(const DataPlane &in1, const DataPlane &in2,
    double w1 = bad_data_double;
    double w2 = bad_data_double;
 
-   // Store min and max valid times.
+   // Store min and max valid times
    dp1 = (in1.valid() <= in2.valid() ? in1 : in2);
    dp2 = (in1.valid() >  in2.valid() ? in1 : in2);
 
+   // Check for matching valid times
+   if(dp1.valid() == dp2.valid()) return(dp1);
+
    // Range check the times
-   if(dp1.valid() > to_ut || dp2.valid() < to_ut ||
-      dp1.valid() == dp2.valid()) {
+   if(dp1.valid() > to_ut || dp2.valid() < to_ut) {
       mlog << Error << "\ntime_interp() -> "
            << "the interpolation time " << unix_to_yyyymmdd_hhmmss(to_ut)
            << " must fall between the input times: "

--- a/src/libcode/vx_statistics/read_climo.cc
+++ b/src/libcode/vx_statistics/read_climo.cc
@@ -191,34 +191,35 @@ void read_climo_file(const char *climo_file, GrdFileType ctype,
 
       // Check the hour time step
       if(!is_bad_data(hour_ts) && abs(dsec_of_day) >= hour_ts) {
-         mlog << Debug(3) << "Skipping the " << clm_ut_cs << " \""
-              << info->magic_str()
-              << "\" climatology field since the time offset ("
-              << abs(dsec_of_day) << " seconds) >= the \"" << conf_key_hour_interval
-              << "\" entry (" << hour_ts << " seconds) from file: "
+         mlog << Debug(3) << "Skipping " << clm_ut_cs << " \"" << info->magic_str()
+              << "\" climatology field with \"" << conf_key_hour_interval
+              << "\" offset (" << abs(dsec_of_day) / (double) sec_per_hour
+              << " >= " << hour_ts / (double) sec_per_hour << " hours) in file: "
               << climo_file << "\n";
          continue;
       }
 
       // Check the day time step
       if(!is_bad_data(day_ts) && abs(dsec_of_year) >= day_ts) {
-         mlog << Debug(3) << "Skipping the " << clm_ut_cs << " \""
-              << info->magic_str()
-              << "\" climatology field since the time offset ("
-              << abs(dsec_of_year) << " seconds) >= the \""
-              << conf_key_day_interval << "\" entry (" << day_ts
-              << " seconds) from file: " << climo_file << "\n";
+         mlog << Debug(3) << "Skipping " << clm_ut_cs << " \"" << info->magic_str()
+              << "\" climatology field with \"" << conf_key_day_interval
+              << "\" offset (" << abs(dsec_of_year) / (double) sec_per_day
+              << " >= " << day_ts / (double) sec_per_day << " days) in file: "
+              << climo_file << "\n";
          continue;
       }
 
       // Print log message for matching record
-      mlog << Debug(4) << "Found matching " << clm_ut_cs << " \""
-           << info->magic_str() << "\" climatology field in file \""
+      mlog << Debug(3) << "Matching " << clm_ut_cs << " \"" << info->magic_str()
+           << "\" climatology field with \"" << conf_key_hour_interval << "\" offset ("
+           << abs(dsec_of_day) / (double) sec_per_hour << " hours) and \""
+           << conf_key_day_interval << "\" offset ("
+           << abs(dsec_of_year) / (double) sec_per_day << " days) in file: "
            << climo_file << "\".\n"; 
 
       // Regrid, if needed
       if(!(mtddf->grid() == vx_grid)) {
-         mlog << Debug(2) << "Regridding the " << clm_ut_cs << " \""
+         mlog << Debug(2) << "Regridding " << clm_ut_cs << " \""
               << info->magic_str()
               << "\" climatology field to the verification grid.\n";
          dp = met_regrid(clm_dpa[i], mtddf->grid(), vx_grid,

--- a/src/libcode/vx_statistics/read_climo.cc
+++ b/src/libcode/vx_statistics/read_climo.cc
@@ -343,7 +343,7 @@ DataPlaneArray climo_time_interp(const DataPlaneArray &dpa, int day_ts,
 
          // For equality, do a single time interpolation.
          if(prv_hms == nxt_hms) {
-             ut = (vld_ut / sec_per_day) + prv_hms;
+             ut = (vld_ut / sec_per_day)*sec_per_day + prv_hms;
              interp_dpa.add(climo_hms_interp(
                                dpa, it->second, ut, mthd),
                                dpa.lower(it->second[0]),


### PR DESCRIPTION
## Expected Differences ##

These code changes are more substantial than I was hoping. However, I think the resulting logic and log messages are both more clear and intuitive. For each climo record being considered, the code now computes 2 time differences: the number of DAYS that differ and the number of HMS seconds that differ. These are both stored as a +/- time offset relative to the forecast valid time in seconds.

The day difference is checked against the `day_interval` config entry. And the hms difference is checked against the `hour_interval` config entry.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Tested a variety of different climo dates in `seneca:/d1/projects/MET/MET_pull_requests/met-11.0.1/issue_2242/test_climo` as the `met_test` user.

Test after Dec 15th:
```
./test_climo.sh 20201225_06
DEBUG 3: For forecast valid at 20201225_060000, found 2 climatology field(s) with valid time(s): 20201215_060000, 20210115_060000
DEBUG 3: Interpolating climatology fields at 20201215_060000 and 20210115_060000 to 20201225_060000 using the DW_MEAN interpolation method.
```
Test before Jan 15:
```
./test_climo.sh 20200105_03
DEBUG 3: For forecast valid at 20200105_030000, found 4 climatology field(s) with valid time(s): 20191215_000000, 20191215_060000, 20200115_000000, 20200115_060000
DEBUG 3: Interpolating climatology fields at 20191215_000000 and 20200115_000000 to 20200105_000000 using the DW_MEAN interpolation method.
DEBUG 3: Interpolating climatology fields at 20191215_060000 and 20200115_060000 to 20200105_060000 using the DW_MEAN interpolation method.
DEBUG 3: Interpolating climatology fields at 20200105_000000 and 20200105_060000 to 20200105_030000 using the DW_MEAN interpolation method.
```

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
- Review the logic of the code changes.
- Could test with more dates on seneca. Could also test with daily climo files rather than just these monthly ones.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**
I made no doc changes.

- [x] Do these changes include sufficient testing updates? **[No]**
I did not add tests for the main_v11.0 branch. However, I do plan to add them for these changes in the develop branch with a separate PR.

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Please complete this pull request review by **[Tues 1/24/23]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)**
Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
Select: **Milestone** as the version that will include these changes
- [x] After submitting the PR, select **Development** issue with the original issue number.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
