### PR TITLE
Feature #2659 develop templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,14 +43,15 @@ Describe the steps to reproduce the behavior:
 - [ ] Select **scientist(s)** or **no scientist** required
 
 ### Labels ###
+- [ ] Review default **alert** labels
 - [ ] Select **component(s)**
 - [ ] Select **priority**
 - [ ] Select **requestor(s)**
 
-### Projects and Milestone ###
-- [ ] Select **Organization** level **Project** for support of the current coordinated release
-- [ ] Select **Repository** level **Project** for development toward the next official release or add **alert: NEED CYCLE ASSIGNMENT** label
+### Milestone and Projects ###
 - [ ] Select **Milestone** as the next bugfix version
+- [ ] Select **Coordinated METplus-X.Y Support** project for support of the current coordinated release
+- [ ] Select **MET-X.Y.Z Development** project for development toward the next official release
 
 ## Define Related Issue(s) ##
 Consider the impact to the other METplus components.
@@ -70,14 +71,14 @@ Branch name: `bugfix_<Issue Number>_main_<Version>_<Description>`
 Pull request: `bugfix <Issue Number> main_<Version> <Description>`
 - [ ] Define the pull request metadata, as permissions allow.
 Select: **Reviewer(s)** and **Development** issue
-Select: **Organization** level software support **Project** for the current coordinated release
 Select: **Milestone** as the next bugfix version
+Select: **Coordinated METplus-X.Y Support** project for support of the current coordinated release
 - [ ] Iterate until the reviewer(s) accept and merge your changes.
 - [ ] Delete your fork or branch.
 - [ ] Complete the steps above to fix the bug on the **develop** branch.
 Branch name:  `bugfix_<Issue Number>_develop_<Description>`
 Pull request: `bugfix <Issue Number> develop <Description>`
 Select: **Reviewer(s)** and **Development** issue
-Select: **Repository** level development cycle **Project** for the next official release
 Select: **Milestone** as the next official version
+Select: **MET-X.Y.Z Development** project for development toward the next official release
 - [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -33,13 +33,14 @@ Consider breaking the enhancement down into sub-issues.
 - [ ] Select **scientist(s)** or **no scientist** required
 
 ### Labels ###
+- [ ] Review default **alert** labels
 - [ ] Select **component(s)**
 - [ ] Select **priority**
 - [ ] Select **requestor(s)**
 
-### Projects and Milestone ###
-- [ ] Select **Repository** and/or **Organization** level **Project(s)** or add **alert: NEED CYCLE ASSIGNMENT** label
-- [ ] Select **Milestone** as the next official version or **Future Versions**
+### Milestone and Projects ###
+- [ ] Select **Milestone** as the next official version or **Backlog of Development Ideas**
+- [ ] For the next official version, select the **MET-X.Y.Z Development** project
 
 ## Define Related Issue(s) ##
 Consider the impact to the other METplus components.
@@ -58,9 +59,9 @@ Branch name: `feature_<Issue Number>_<Description>`
 - [ ] Submit a pull request to merge into **develop**.
 Pull request: `feature <Issue Number> <Description>`
 - [ ] Define the pull request metadata, as permissions allow.
-Select: **Reviewer(s)** and **Development** issues
-Select: **Repository** level development cycle **Project** for the next official release
+Select: **Reviewer(s)** and **Development** issue
 Select: **Milestone** as the next official version
+Select: **MET-X.Y.Z Development** project for development toward the next official release
 - [ ] Iterate until the reviewer(s) accept and merge your changes.
 - [ ] Delete your fork or branch.
 - [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/new_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/new_feature_request.md
@@ -37,13 +37,14 @@ Consider breaking the new feature down into sub-issues.
 - [ ] Select **scientist(s)** or **no scientist** required
 
 ### Labels ###
+- [ ] Review default **alert** labels
 - [ ] Select **component(s)**
 - [ ] Select **priority**
 - [ ] Select **requestor(s)**
 
-### Projects and Milestone ###
-- [ ] Select **Repository** and/or **Organization** level **Project(s)** or add **alert: NEED CYCLE ASSIGNMENT** label
-- [ ] Select **Milestone** as the next official version or **Future Versions**
+### Milestone and Projects ###
+- [ ] Select **Milestone** as the next official version or **Backlog of Development Ideas**
+- [ ] For the next official version, select the **MET-X.Y.Z Development** project
 
 ## Define Related Issue(s) ##
 Consider the impact to the other METplus components.
@@ -62,9 +63,9 @@ Branch name: `feature_<Issue Number>_<Description>`
 - [ ] Submit a pull request to merge into **develop**.
 Pull request: `feature <Issue Number> <Description>`
 - [ ] Define the pull request metadata, as permissions allow.
-Select: **Reviewer(s)** and **Development** issues
-Select: **Repository** level development cycle **Project** for the next official release
+Select: **Reviewer(s)** and **Development** issue
 Select: **Milestone** as the next official version
+Select: **MET-X.Y.Z Development** project for development toward the next official release
 - [ ] Iterate until the reviewer(s) accept and merge your changes.
 - [ ] Delete your fork or branch.
 - [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/sub-issue.md
+++ b/.github/ISSUE_TEMPLATE/sub-issue.md
@@ -23,10 +23,11 @@ This is a sub-issue of #*List the parent issue number here*.
 - [ ] Select **scientist(s)** or **no scientist** required
 
 ### Labels ###
+- [ ] Review default **alert** labels
 - [ ] Select **component(s)**
 - [ ] Select **priority**
 - [ ] Select **requestor(s)**
 
-### Projects and Milestone ###
-- [ ] Select **Repository** and/or **Organization** level **Project(s)** or add **alert: NEED CYCLE ASSIGNMENT** label
-- [ ] Select **Milestone** as the next official version or **Future Versions**
+### Milestone and Projects ###
+- [ ] Select **Milestone** as the next official version or **Backlog of Development Ideas**
+- [ ] For the next official version, select the **MET-X.Y.Z Development** project

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -33,13 +33,14 @@ Consider breaking the task down into sub-issues.
 - [ ] Select **scientist(s)** or **no scientist** required
 
 ### Labels ###
+- [ ] Review default **alert** labels
 - [ ] Select **component(s)**
 - [ ] Select **priority**
 - [ ] Select **requestor(s)**
 
-### Projects and Milestone ###
-- [ ] Select **Repository** and/or **Organization** level **Project(s)** or add **alert: NEED CYCLE ASSIGNMENT** label
-- [ ] Select **Milestone** as the next official version or **Future Versions**
+### Milestone and Projects ###
+- [ ] Select **Milestone** as the next official version or **Backlog of Development Ideas**
+- [ ] For the next official version, select the **MET-X.Y.Z Development** project
 
 ## Define Related Issue(s) ##
 Consider the impact to the other METplus components.
@@ -58,9 +59,9 @@ Branch name: `feature_<Issue Number>_<Description>`
 - [ ] Submit a pull request to merge into **develop**.
 Pull request: `feature <Issue Number> <Description>`
 - [ ] Define the pull request metadata, as permissions allow.
-Select: **Reviewer(s)** and **Development** issues
-Select: **Repository** level development cycle **Project** for the next official release
+Select: **Reviewer(s)** and **Development** issue
 Select: **Milestone** as the next official version
+Select: **MET-X.Y.Z Development** project for development toward the next official release
 - [ ] Iterate until the reviewer(s) accept and merge your changes.
 - [ ] Delete your fork or branch.
 - [ ] Close this issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,9 +27,9 @@ See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors
 - [ ] Complete the PR definition above.
 - [ ] Ensure the PR title matches the feature or bugfix branch name.
 - [ ] Define the PR metadata, as permissions allow.
-Select: **Reviewer(s)**
-Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
+Select: **Reviewer(s)** and **Development** issue
 Select: **Milestone** as the version that will include these changes
+Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **MET-X.Y.Z Development** project for official releases
 - [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
 - [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
 - [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.


### PR DESCRIPTION
Porting issue and pull request template updates over from `main_v11.1` into the `develop` branch.

Will proceed with the merge without review since @jprestop already reviewed these changes in PR #2660.