### PR TITLE
Feature #2801 warnings

### DIFF
--- a/data/config/ConfigConstants
+++ b/data/config/ConfigConstants
@@ -7,6 +7,9 @@
 // Warning message results in tool exiting.
 exit_on_warning = FALSE;
 
+// Allowable offset in seconds to silence time difference warning messages
+time_offset_warning = 0;
+
 // NetCDF Compression per variable (0 to 9, 0: disable compression)
 // This will be overridden by the environment variable MET_NC_COMPRESS and the
 // command line argument.

--- a/docs/Users_Guide/config_options.rst
+++ b/docs/Users_Guide/config_options.rst
@@ -505,7 +505,7 @@ If set to true and a MET tool encounters a warning, it will immediately exit
 with bad status after writing the warning message.
 
 .. code-block:: none
-		
+
   exit_on_warning = FALSE;
 
 time_offset_warning
@@ -521,7 +521,7 @@ difference is less than or equal to this setting, a debug log message is
 written instead of a warning.
 
 .. code-block:: none
-		
+
   time_offset_warning = 0;
 
 nc_compression
@@ -543,7 +543,7 @@ WARNING: Selecting a high compression level may slow down the reading and
 writing of NetCDF files within MET significantly.
 
 .. code-block:: none
-		
+
   nc_compression = 0;
 
 output_precision
@@ -555,7 +555,7 @@ files. Setting this option in the config file of one of the tools will
 override the default value set in ConfigConstants.
 
 .. code-block:: none
-		
+
   output_precision = 5;
 
 .. _config_tmp_dir:
@@ -570,7 +570,7 @@ Some tools override the temporary directory by the command line argument
 "-tmp_dir <diretory_name>".
 
 .. code-block:: none
-		
+
   tmp_dir = "/tmp";
 
 A description of the use of temporary files in MET can be found in
@@ -589,7 +589,7 @@ logic should be applied. If not defined, the default values listed below are
 used.
 
 .. code-block:: none
-		
+
   mesage_type_group_map = [
      { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET";               },
      { key = "ANYAIR";  val = "AIRCAR,AIRCFT";                      },
@@ -608,7 +608,7 @@ is also supported in PBN2NC as a way of renaming input PREPBUFR message
 types.
 
 .. code-block:: none
-		
+
   message_type_map = [
      { key = "FM-12 SYNOP";  val = "ADPSFC"; },
      { key = "FM-13 SHIP";   val = "SFCSHP"; },
@@ -631,7 +631,7 @@ whitespace) to distinguish between their output.
 e.g. model = "GFS";
 
 .. code-block:: none
-		
+
   model = "FCST";
 
 desc
@@ -647,7 +647,7 @@ between their output.
 e.g. desc = "QC_9";
 
 .. code-block:: none
-		
+
   desc = "NA";
 
 obtype
@@ -662,7 +662,7 @@ observation message type value is written to the OBTYPE column. Otherwise,
 the configuration file obtype value is written.
 
 .. code-block:: none
-		
+
   obtype = "ANALYS";
 
 .. _regrid:
@@ -764,7 +764,7 @@ using the following entries:
   Settings defined at higher levels of config file context are not applied. 
 
 .. code-block:: none
-		
+
   regrid = {
      to_grid         = NONE;
      method          = NEAREST;
@@ -803,7 +803,7 @@ to be verified. This dictionary may include the following entries:
     Grid-Stat or Point-Stat tools as follows:
 
     .. code-block:: none
-    
+
       fcst = {
          field = [ { name  = "APCP_24_A24_ENS_FREQ_gt0.0";
                      level = "(*,*)";
@@ -887,7 +887,7 @@ to be verified. This dictionary may include the following entries:
     Examples of user-defined data censoring operations include:
 
     .. code-block:: none
-		    
+
       censor_thresh = [ >12000 ];
       censor_val    = [  12000 ];
 
@@ -961,7 +961,7 @@ to be verified. This dictionary may include the following entries:
   For example:
 
   .. code-block:: none
-		    
+
     fcst = {
        file_type = GRIB1;         GRIB version 1
        file_type = GRIB2;         GRIB version 2
@@ -1181,7 +1181,7 @@ File-format specific settings for the "field" entry:
         For example:
 
          .. code-block:: none
-        
+
            field = [
              { name = "read_ascii_numpy.py data/python/fcst.txt FCST"; }
            ];
@@ -1203,16 +1203,15 @@ File-format specific settings for the "field" entry:
         For example:
 
         .. code-block:: none
-			 
-	  file_type = PYTHON_NUMPY;
+
+          file_type = PYTHON_NUMPY;
           field     = [
             { name = "read_ascii_numpy.py MET_PYTHON_INPUT_ARG FCST"; }
           ];
 
-	  
-	  
+
 .. code-block:: none
-		
+
   fcst = {
      censor_thresh = [];
      censor_val    = [];
@@ -1246,13 +1245,13 @@ in a non-trivial way. The length of the "obs.field" array must match the
 length of the "fcst.field" array.  For example:
 
 .. code-block:: none
-		
+
         obs = fcst;
 
 or
 
 .. code-block:: none
-		
+
    fcst = {
      censor_thresh = [];
      censor_val    = [];
@@ -1306,7 +1305,7 @@ or
   than one "message_type" entry is desired within the config file. For example:
 
   .. code-block:: none
-     
+
      fcst = {
          censor_thresh = [];
          censor_val    = [];
@@ -1356,7 +1355,7 @@ or
    are included or excluded for each verification task.
 
 .. code-block:: none
-		
+
   obs = fcst;
 
 climo_mean
@@ -1399,7 +1398,7 @@ of several entires defining the climatology file names and fields to be used.
   entries "match_month", "match_day", and "time_step".
 
 .. code-block:: none
-		
+
   climo_mean = {
   
      file_name = [ "/path/to/climatological/mean/files" ];
@@ -1441,7 +1440,7 @@ rather than means. In the example below, this dictionary is set by copying
 over the "climo_mean" setting and then updating the "file_name" entry.
 
 .. code-block:: none
-		
+
   climo_stdev = climo_mean;
   climo_stdev = {
      file_name = [ "/path/to/climatological/standard/deviation/files" ];
@@ -1479,7 +1478,7 @@ climatological bins. The array must begin with 0.0 and end with 1.0.
 For example:
 
 .. code-block:: none
-		
+
   cdf_bins = [ 0.0, 0.10, 0.25, 0.75, 0.90, 1.0 ];
 
 When "cdf_bins" is set to an integer, it defines the number of bins to be
@@ -1488,7 +1487,7 @@ centered on 0.5. An odd number of bins can be centered or uncentered while
 an even number of bins can only be  uncentered. For example:
 
 .. code-block:: none
-		
+
   4 uncentered bins (cdf_bins = 4; center_bins = FALSE;) yields:
     0.0, 0.25, 0.50, 0.75, 1.0
   5 uncentered bins (cdf_bins = 5; center_bins = FALSE;) yields:
@@ -1506,7 +1505,7 @@ Setting the number of bins to 1 effectively disables this logic by grouping
 all pairs into a single climatological bin.
 
 .. code-block:: none
-		
+
   climo_cdf = {
      cdf_bins    = 11;    or an array of floats
      center_bins = TRUE;  or FALSE
@@ -1567,7 +1566,7 @@ in the Wavelet-Stat and MODE tools:
  * "BOTH" to mask both fields with missing data from the other
 
 .. code-block:: none
-		
+
   mask_missing_flag = BOTH;
 
 
@@ -1582,7 +1581,7 @@ In PB2NC, the reference time is the PREPBUFR files center time. In
 Point-Stat and Ensemble-Stat, the reference time is the forecast valid time.
 
 .. code-block:: none
-		
+
   obs_window = {
      beg = -5400;
      end =  5400;
@@ -1696,7 +1695,7 @@ domain. If the nearest grid point is inside the mask, that point observation
 is included in the mask.
 
 .. code-block:: none
-		
+
   mask = {
      grid    = [ "FULL" ];
      poly    = [ "MET_BASE/poly/LMV.poly",
@@ -1724,7 +1723,7 @@ value. Therefore, an alpha value of 0.05 corresponds to a 95% confidence
 interval.
 
 .. code-block:: none
-		
+
   ci_alpha = [ 0.05, 0.10 ];
 
 .. _config_boot:
@@ -1783,7 +1782,7 @@ should be used for computing bootstrap confidence intervals:
   computing platform.
 
 .. code-block:: none
-		
+
   boot = {
      interval = PCTILE;
      rep_prop = 1.0;
@@ -1852,7 +1851,7 @@ This dictionary may include the following entries:
     
     * DW_MEAN     for the distance-weighted average value
       where weight = distance^-2
-		
+
     * LS_FIT      for a least-squares fit
     
     * BILIN       for bilinear interpolation (width = 2)
@@ -1888,12 +1887,12 @@ This dictionary may include the following entries:
     permutations of their values are applied.
 
 .. code-block:: none
-		
+
   interp = {
      field      = BOTH;
      vld_thresh = 1.0;
      shape      = SQUARE;
-  
+
      type = [
         {
            method = [ NEAREST ];
@@ -1921,7 +1920,7 @@ threshold which defines land (threshold is true) and water (threshold is false).
 The "land_mask.flag" entry may be set separately in each "obs.field" entry.
 
 .. code-block:: none
-		
+
   land_mask = {
      flag      = FALSE;
      file_name = [];
@@ -1950,7 +1949,7 @@ the verification domain.
 The "topo_mask.flag" entry may be set separately in each "obs.field" entry.
 
 .. code-block:: none
-		
+
   topo_mask = {
      flag               = FALSE;
      file_name          = [];
@@ -2003,7 +2002,7 @@ This dictionary may include the following entries:
   the obs.cat_thresh thresholds will be used instead.
 
 .. code-block:: none
-		
+
   hira = {
       flag            = FALSE;
      width           = [ 2, 3, 4, 5 ];
@@ -2028,7 +2027,7 @@ output line type from the MET tools. Each line type may be set to one of:
   "_type.txt" file, a more readable ASCII file sorted by line type.
 
 .. code-block:: none
-		
+
   output_flag = {
      fho    = NONE;  Forecast, Hit, Observation Rates
      ctc    = NONE;  Contingency Table Counts
@@ -2080,7 +2079,7 @@ the output of all the different fields). A value of false means no
 netcdf output will be generated.
 
 .. code-block:: none
-		
+
   nc_pairs_flag = {
      latlon       = TRUE;
      raw          = TRUE;
@@ -2112,7 +2111,7 @@ For example:
 |
  
 .. code-block:: none
-		
+
   nc_pairs_var_name = "";
 
 nc_pairs_var_suffix
@@ -2135,7 +2134,7 @@ NOTE: This option was previously named "nc_pairs_var_str", which is
 now deprecated.
 
 .. code-block:: none
-		
+
   nc_pairs_var_suffix = "";
 
 ps_plot_flag
@@ -2146,7 +2145,7 @@ indicating whether a PostScript plot should be generated summarizing
 the verification.
 
 .. code-block:: none
-		
+
   ps_plot_flag = TRUE;
 
 grid_weight_flag
@@ -2170,7 +2169,7 @@ The weights are ultimately computed as the weight at each grid point divided
 by the sum of the weights for the current masking region.
 
 .. code-block:: none
-		
+
   grid_weight_flag = NONE;
 
 hss_ec_value
@@ -2188,7 +2187,7 @@ If set, it must greater than or equal to 0.0 and less than 1.0. A value of
 0.0 produces an HSS_EC statistic equal to the Accuracy statistic.
 
 .. code-block:: none
-		
+
   hss_ec_value = NA;
 
 rank_corr_flag
@@ -2200,7 +2199,7 @@ be computed. Computing them over large datasets is computationally
 intensive and slows down the runtime significantly.
 
 .. code-block:: none
-		
+
   rank_corr_flag = FALSE;
 
 duplicate_flag
@@ -2222,7 +2221,7 @@ about where duplicates were detected and which observations were used
 in those cases.
 
 .. code-block:: none
-		
+
   duplicate_flag = NONE;
 
 obs_summary
@@ -2257,7 +2256,7 @@ about where duplicates were detected and which observations were used
 in those cases.
 
 .. code-block:: none
-		
+
   obs_summary = NONE;
 
 
@@ -2267,13 +2266,13 @@ obs_perc_value
 Percentile value to use when obs_summary = PERC
 
 .. code-block:: none
-		
+
   obs_perc_value = 50;
 
   
 obs_quality_inc
 ---------------
-		
+
 The "obs_quality_inc" entry specifies the quality flag values that are to be
 retained and used for verification. An empty list signifies that all
 point observations should be used, regardless of their quality flag value.
@@ -2283,13 +2282,13 @@ an array of strings, even if the values themselves are numeric.
 Note "obs_quality_inc" replaces the older option "obs_quality".
 
 .. code-block:: none
-		
+
   obs_quality_inc = [ "1", "2", "3", "9" ];
 
   
 obs_quality_exc
 ---------------
-		
+
 The "obs_quality_exc" entry specifies the quality flag values that are to be
 ignored and not used for verification. An empty list signifies that all
 point observations should be used, regardless of their quality flag value.
@@ -2298,7 +2297,7 @@ observations. The quality flag values to ignore should be specified as
 an array of strings, even if the values themselves are numeric.
 
 .. code-block:: none
-		
+
   obs_quality_exc = [ "1", "2", "3", "9" ];
 
   
@@ -2311,7 +2310,7 @@ should be set to the installed *share/met* directory so the MET tools can
 locate the static data files they need at run time.
 
 .. code-block:: none
-		
+
   met_data_dir = "MET_BASE";
 
 many_plots
@@ -2334,7 +2333,7 @@ forecast field:
   for this plot.
 
 .. code-block:: none
-		
+
   fcst_raw_plot = {
      color_table   = "MET_BASE/colortables/met_default.ctable";
      plot_min      = 0.0;
@@ -2356,7 +2355,7 @@ to modify the output file name and avoid naming conflicts for multiple runs
 of the same tool.
 
 .. code-block:: none
-		
+
   output_prefix  = "";
 
 version
@@ -2367,7 +2366,7 @@ The configuration file version number should match the version number of
 the MET code being run. This value should generally not be modified.
 
 .. code-block:: none
-		
+
   version = "VN.N";
 
 time_summary
@@ -2385,7 +2384,7 @@ ending time offsets in seconds.
 For example:
 
 .. code-block:: none
-		
+
    beg = "00";
    end = "235959";
    step = 300;
@@ -2403,7 +2402,7 @@ uncentered time intervals. The following example requests observations for
 one hour prior:
 
 .. code-block:: none
-		
+
   width = { beg = -3600; end = 0; }
 
 The summaries will only be calculated for the specified GRIB codes
@@ -2437,7 +2436,7 @@ They are inclusive (union). All variables are included if both options
 are empty. Note: grib_code 11 is equivalent to obs_var "TMP".
 
 .. code-block:: none
-		
+
   time_summary = {
     flag = FALSE;
     beg = "000000";
@@ -2485,7 +2484,7 @@ entries. This dictionary may include the following entries:
   ensemble field.
 
 .. code-block:: none
-		
+
   ens = {
      censor_thresh = [];
      censor_val    = [];
@@ -2516,7 +2515,7 @@ combination of the categorical threshold (cat_thresh) and neighborhood width
 specified.
 
 .. code-block:: none
-		
+
   nbrhd_prob = {
      width      = [ 5 ];
      shape      = CIRCLE;
@@ -2536,7 +2535,7 @@ combination of the categorical threshold (cat_thresh), neighborhood width
 (nbrhd_prob.width), and smoothing method (nmep_smooth.type) specified.
 
 .. code-block:: none
-		
+
   nmep_smooth = {
      vld_thresh      = 0.0;
      shape           = CIRCLE;
@@ -2587,7 +2586,7 @@ which ensemble products should be generated:
   rank NetCDF output file.
 
 .. code-block:: none
-		
+
   ensemble_flag = {
     latlon     = TRUE;
      mean      = TRUE;
@@ -2631,7 +2630,7 @@ computation of the ranked probability score.  If left empty, but climatology
 data is provided, the climo_cdf thresholds will be used instead.
 
 .. code-block:: none
-		
+
   fcst = {
      message_type       = [ "ADPUPA" ];
      ens_ssvar_bin_size = 1;
@@ -2661,7 +2660,7 @@ unique.
 e.g. nc_var_str = "MIN";
 
 .. code-block:: none
-		
+
   nc_var_str = "";
 
 obs_thresh
@@ -2675,7 +2674,7 @@ Verification output will be computed separately for each threshold specified.
 This option may be set separately for each obs.field entry.
 
 .. code-block:: none
-		
+
   obs_thresh = [ NA ];
 
 skip_const
@@ -2689,7 +2688,7 @@ false, constant points are included and the observation rank is chosen at
 random.
 
 .. code-block:: none
-		
+
   skip_const = FALSE;
 
 obs_error
@@ -2739,7 +2738,7 @@ type, instrument type, station ID, range of heights, range of pressure
 levels, and range of values.
 
 .. code-block:: none
-		
+
   obs_error = {
      flag             = FALSE;   TRUE or FALSE
      dist_type        = NONE;    Distribution type
@@ -2757,7 +2756,7 @@ See: `Random Number Generator Performance <https://www.gnu.org/software/gsl/doc/
 used for random assignment of ranks when they are tied.
 
 .. code-block:: none
-		
+
   rng = {
      type = "mt19937";
      seed = "";
@@ -2790,7 +2789,7 @@ This toggle indicates whether forecast or observed lines should be used for
 analysis.
 
 .. code-block:: none
-		
+
   fcst      = FALSE;
   obs       = FALSE;
 
@@ -2798,7 +2797,7 @@ This toggle indicates whether single object or object pair lines should be
 used.
 
 .. code-block:: none
-		
+
   single    = FALSE;
   pair      = FALSE;
 
@@ -2806,7 +2805,7 @@ This toggle indicates whether simple object or object cluster object lines
 should be used.
 
 .. code-block:: none
-		
+
   simple    = FALSE;
   cluster   = FALSE;
 
@@ -2814,7 +2813,7 @@ This toggle indicates whether matched or unmatched object lines should be
 used.
 
 .. code-block:: none
-		
+
   matched   = FALSE;
   unmatched = FALSE;
 
@@ -3117,7 +3116,7 @@ thresholds must match. For N radii and M thresholds, NxM configurations of
 MODE will be run.
 
 .. code-block:: none
-		
+
   quilt = false;
 
 fcst, obs
@@ -3134,7 +3133,7 @@ The object definition settings for MODE are contained within the "fcst" and
   Multiple convolution radii may be specified as an array. For example:
 
   .. code-block:: none
-		  
+
     conv_radius = [ 5, 10, 15 ];
 
 * The "conv_thresh" entry specifies the convolution threshold used to
@@ -3142,7 +3141,7 @@ The object definition settings for MODE are contained within the "fcst" and
   Multiple convolution thresholds may be specified as an array. For example:
 
   .. code-block:: none
-		  
+
     conv_thresh = [ >=5.0, >=10.0, >=15.0 ];
 
 * The "vld_thresh" entry is described above.
@@ -3172,7 +3171,7 @@ The object definition settings for MODE are contained within the "fcst" and
   Multiple merge thresholds may be specified as an array. For example:
 
   .. code-block:: none
-		  
+
     merge_thresh = [ >=1.0, >=2.0, >=3.0 ];
 
 * The "merge_flag" entry specifies the merging methods to be applied:
@@ -3187,7 +3186,7 @@ The object definition settings for MODE are contained within the "fcst" and
    * "BOTH" for both the double-threshold and engine merging methods
 
 .. code-block:: none
-		
+
   fcst = {
      field = {
         name  = "APCP";
@@ -3215,7 +3214,7 @@ setting the appropriately will help ensure that appropriate default values
 are used for these variables.
 
 .. code-block:: none
-		
+
   grid_res = 4;
 
 match_flag
@@ -3234,7 +3233,7 @@ The "match_flag" entry specifies the matching method to be applied:
 * "NO_MERGE" for matching with no additional merging in either field
 
 .. code-block:: none
-		
+
   match_flag = MERGE_BOTH;
 
 max_centroid_dist
@@ -3246,7 +3245,7 @@ Setting this to a reasonable value speeds up the runtime enabling MODE to
 skip unreasonable object comparisons.
 
 .. code-block:: none
-		
+
   max_centroid_dist = 800.0/grid_res;
 
 weight
@@ -3259,7 +3258,7 @@ total interest value is computed, the weighted sum is normalized by the
 sum of the weights listed.
 
 .. code-block:: none
-		
+
   weight = {
      centroid_dist    = 2.0;
      boundary_dist    = 4.0;
@@ -3274,7 +3273,7 @@ sum of the weights listed.
 
 interest_function
 ^^^^^^^^^^^^^^^^^
-		
+
 The set of interest function variables listed define which values are of
 interest for each pairwise attribute measured. The interest functions may be
 defined as a piecewise linear function or as an algebraic expression. A
@@ -3283,7 +3282,7 @@ graph. An algebraic function may be defined in terms of several built-in
 mathematical functions.
 
 .. code-block:: none
-		
+
   interest_function = {
   
      centroid_dist = (
@@ -3337,7 +3336,7 @@ threshold is applied to the total interest values computed for each pair of
 objects and is used in determining matches.
 
 .. code-block:: none
-		
+
   total_interest_thresh = 0.7;
 
 print_interest_thresh
@@ -3352,7 +3351,7 @@ be written as long as the distance between the object centroids is less than
 the max_centroid_dist variable.
 
 .. code-block:: none
-		
+
   print_interest_thresh = 0.0;
 
 plot_valid_flag
@@ -3364,7 +3363,7 @@ indicates the entire domain should be plotted; FALSE indicates only the
 region containing valid data after masking should be plotted.
 
 .. code-block:: none
-		
+
   plot_valid_flag = FALSE;
 
 plot_gcarc_flag
@@ -3375,7 +3374,7 @@ polylines should be plotted using great circle arcs as opposed to straight
 lines in the grid.
 
 .. code-block:: none
-		
+
   plot_gcarc_flag = FALSE;
 
 ct_stats_flag
@@ -3385,7 +3384,7 @@ The ct_stats_flag can be set to TRUE or FALSE to produce additional output,
 in the form of contingency table counts and statistics.
 
 .. code-block:: none
-		
+
   ct_stats_flag = TRUE;
 
 shift_right
@@ -3400,7 +3399,7 @@ This option provides a very specialized case of automated regridding. The
 much more flexible "regrid" option may be used instead.
 
 .. code-block:: none
-		
+
   shift_right = 0;
 
 PB2NCConfig_default
@@ -3483,7 +3482,7 @@ For example:
 `Current Table A Entries in PREPBUFR mnemonic table <http://www.emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_1.htm>`_
 
 .. code-block:: none
-		
+
   message_type = [];
 
 station_id
@@ -3497,7 +3496,7 @@ stations should be retained.
 For example:  station_id = [ "KDEN" ];
 
 .. code-block:: none
-		
+
   station_id = [];
 
 elevation_range
@@ -3508,7 +3507,7 @@ entries specifying the range of observing locations elevations to be
 retained.
 
 .. code-block:: none
-		
+
   elevation_range = {
      beg =  -1000;
      end = 100000;
@@ -3532,7 +3531,7 @@ For example:
 |
 
 .. code-block:: none
-		
+
   pb_report_type  = [];
 
 in_report_type
@@ -3552,7 +3551,7 @@ For example:
 |
 
 .. code-block:: none
-		
+
   in_report_type = [];
 
 instrument_type
@@ -3562,7 +3561,7 @@ The "instrument_type" entry is an array of instrument types to be retained.
 An empty list indicates that all should be retained.
 
 .. code-block:: none
-		
+
   instrument_type = [];
 
 level_range
@@ -3572,7 +3571,7 @@ The "level_range" entry is a dictionary which contains "beg" and "end"
 entries specifying the range of vertical levels (1 to 255) to be retained.
 
 .. code-block:: none
-		
+
   level_range = {
      beg = 1;
      end = 255;
@@ -3612,7 +3611,7 @@ An empty list indicates that all should be retained.
 See: `Current Table A Entries in PREPBUFR mnemonic table <http://www.emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_1.htm>`_
 
 .. code-block:: none
-		
+
   level_category = [];
 
 obs_bufr_var
@@ -3633,7 +3632,7 @@ command line option to see the list of available observation variables.
 |
 
 .. code-block:: none
-		
+
   obs_bufr_var = [ "QOB", "TOB", "ZOB", "UOB", "VOB" ];
 
 obs_bufr_map
@@ -3645,7 +3644,7 @@ Users may choose to rename BUFR variables to match the naming convention
 of the forecast the observation is used to verify.
 
 .. code-block:: none
-		
+
   obs_bufr_map = [];
 
 obs_prepbufr_map
@@ -3658,7 +3657,7 @@ backward-compatibility for earlier versions of MET which wrote GRIB
 abbreviations to the output.
 
 .. code-block:: none
-		
+
   obs_prepbufr_map = [
      { key = "POB";     val = "PRES";  },
      { key = "QOB";     val = "SPFH";  },
@@ -3685,7 +3684,7 @@ GREATER THAN this threshold will be discarded.
 See `Code table for observation quality markers <http://www.emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_7.htm>`_
 
 .. code-block:: none
-		
+
   quality_mark_thresh = 2;
 
 event_stack_flag
@@ -3696,7 +3695,7 @@ specify whether observations should be drawn from the top of the event
 stack (most quality controlled) or the bottom of the event stack (most raw).
 
 .. code-block:: none
-		
+
   event_stack_flag = TOP;
 
 SeriesAnalysisConfig_default
@@ -3713,7 +3712,7 @@ If set less than or equal to 0, it is automatically reset to the number
 of grid points, and they are all processed concurrently.
 
 .. code-block:: none
-		
+
   block_size = 1024;
 
 vld_thresh
@@ -3726,7 +3725,7 @@ setting requires all data in the series to be valid.
 
 
 .. code-block:: none
-		
+
   vld_thresh = 1.0;
 
 output_stats
@@ -3738,7 +3737,7 @@ it is recommended to process a few output types at a time, especially if the
 grid is large.
 
 .. code-block:: none
-		
+
   output_stats = {
      fho    = [];
      ctc    = [];
@@ -3832,7 +3831,7 @@ Where "job_name" is set to one of the following:
   Optional Args:
 
   .. code-block:: none
-		  
+
     -by column_name to specify case information
     -out_alpha to override default alpha value of 0.05
     -derive to derive statistics on the fly
@@ -3846,7 +3845,7 @@ Where "job_name" is set to one of the following:
   types may be aggregated:
 
   .. code-block:: none
-		  
+
     -line_type FHO, CTC, MCTC,
                SL1L2, SAL1L2, VL1L2, VAL1L2,
                PCT, NBRCNT, NBRCTC, GRAD,
@@ -3864,7 +3863,7 @@ Where "job_name" is set to one of the following:
   combinations of "-line_type" and "-out_line_type" are listed below.
 
   .. code-block:: none
-		  
+
     -line_type FHO, CTC,      -out_line_type CTS, ECLV
     -line_type MCTC           -out_line_type MCTS
     -line_type SL1L2, SAL1L2, -out_line_type CNT
@@ -3886,7 +3885,7 @@ Where "job_name" is set to one of the following:
   Additional Required Args for -line_type MPR:
 
   .. code-block:: none
-		  
+
     -out_thresh or -out_fcst_thresh and -out_obs_thresh
      When -out_line_type FHO, CTC, CTS, MCTC, MCTS,
                          PCT, PSTD, PJC, PRC
@@ -3894,7 +3893,7 @@ Where "job_name" is set to one of the following:
   Additional Optional Args for -line_type MPR:
 
   .. code-block:: none
-		  
+
     -mask_grid, -mask_poly, -mask_sid
     -out_thresh or -out_fcst_thresh and -out_obs_thresh
     -out_cnt_logic
@@ -3906,14 +3905,14 @@ Where "job_name" is set to one of the following:
   Additional Optional Arg for:
 
   .. code-block:: none
-		  
+
     -line_type ORANK -out_line_type PHIST, SSVAR ...
     -out_bin_size
 	    
   Additional Optional Args for:
 
   .. code-block:: none
-		  
+
     -out_line_type ECLV ...
     -out_eclv_points
 
@@ -3957,7 +3956,7 @@ Where "job_name" is set to one of the following:
   For lead times of 12, 24, 36, and 48 hours, it contains RMSE for:
 
   .. code-block:: none
-		  
+
     - Wind Speed at the surface(b), 850(a), 400(a), 250(a) mb
     - Dew point Temperature at the surface(b), 850(b), 700(b), 400(b) mB
     - Temperature at the surface(b), 400(a) mB
@@ -3982,7 +3981,7 @@ Where "job_name" is set to one of the following:
   Required Args:
 
   .. code-block:: none
-		  
+
     -ramp_thresh (-ramp_thresh_fcst or -ramp_thresh_obs)
        For DYDT, threshold for the amount of change required to
        define an event.
@@ -3993,7 +3992,7 @@ Where "job_name" is set to one of the following:
   Optional Args:
 
   .. code-block:: none
-		  
+
     -ramp_type str
        Overrides the default ramp definition algorithm to be used.
        May be set to DYDT (default) or SWING for the swinging door
@@ -4026,7 +4025,7 @@ Where "job_name" is set to one of the following:
   union:
 
   .. code-block:: none
-		  
+
     "-model            name"
     "-fcst_lead        HHMMSS"
     "-obs_lead         HHMMSS"
@@ -4069,7 +4068,7 @@ Where "job_name" is set to one of the following:
   performed on their intersection:
 
   .. code-block:: none
-		  
+
     "-column_min     col_name value"     e.g. -column_min BASER 0.02
     "-column_max     col_name value"
     "-column_eq      col_name value"
@@ -4094,7 +4093,7 @@ Where "job_name" is set to one of the following:
     "-mask_sid        file|list" see description of "sid" entry above
 
   .. code-block:: none
-		  
+
     "-out_line_type   name"
     "-out_thresh      value" sets both -out_fcst_thresh and -out_obs_thresh
     "-out_fcst_thresh value" multiple for multi-category contingency tables
@@ -4119,7 +4118,7 @@ Where "job_name" is set to one of the following:
                              entry
 
   .. code-block:: none
-		  
+
     "-out_alpha       value"
 
   .. code-block:: none
@@ -4139,7 +4138,7 @@ Where "job_name" is set to one of the following:
   For aggregate and aggregate_stat job types:
 
   .. code-block:: none
-		    
+
     "-out_stat        path"   to write a .stat output file for the job
                               including the .stat header columns. Multiple
                               values for each header column are written as
@@ -4154,7 +4153,7 @@ Where "job_name" is set to one of the following:
   of the output .stat output file:
 
   .. code-block:: none
-		  
+
     -job aggregate_stat -line_type MPR -out_line_type CNT \
     -by OBS_SID -set_hdr VX_MASK OBS_SID -stat_out out.stat
     When using mulitple "-by" options, use "CASE" to reference the full string:
@@ -4162,7 +4161,7 @@ Where "job_name" is set to one of the following:
 
 
 .. code-block:: none
-		
+
   jobs = [
      "-job filter         -line_type SL1L2 -vx_mask DTC165 \
       -dump_row  job_filter_SL1L2.stat",
@@ -4208,7 +4207,7 @@ statistic name. Statistics using the default arithemtic mean method do not
 need to be listed.
 
 .. code-block:: none
-		
+
   wmo_sqrt_stats   = [];
   wmo_fisher_stats = [];
 
@@ -4218,7 +4217,7 @@ table counts or partial sums. The VIF is used to adjust the normal
 confidence intervals computed for the aggregated statistics.
 
 .. code-block:: none
-		
+
   vif_flag = FALSE;
 
 WaveletStatConfig_default
@@ -4237,7 +4236,7 @@ Wavelet-Stat into dyadic (2^n x 2^n) tiles:
 * "PAD" to pad the input data out to the nearest integer power of 2.
 
 .. code-block:: none
-		
+
   grid_decomp_flag = AUTO;
 
 tile
@@ -4254,7 +4253,7 @@ in Wavelet-Stat when the "grid_decomp_flag" is set to "TILE":
   coordinates of the tile.
 
 .. code-block:: none
-		
+
   tile = {
      width = 0;
      location = [
@@ -4295,7 +4294,7 @@ wavelet decomposition should be performed:
     204, 206, 208, 301, 303, 305, 307, 309)
 
 .. code-block:: none
-		
+
   wavelet = {
      type   = HAAR;
      member = 2;
@@ -4329,7 +4328,7 @@ Supply the NetCDF output information.  For example:
    level         = "SFC";
 
 .. code-block:: none
-		
+
   variable_name = "";
   units         = "";
   long_name     = "";
@@ -4352,7 +4351,7 @@ The swap_endian option indicates whether the endian-ness of the data should
 be swapped after reading.
 
 .. code-block:: none
-		
+
   swap_endian = TRUE;
 
 write_pixel_age
@@ -4363,5 +4362,5 @@ command line to the output file. This option writes the pixel age data,
 in minutes, to the output file instead.
 
 .. code-block:: none
-		
+
   write_pixel_age = FALSE;

--- a/docs/Users_Guide/config_options.rst
+++ b/docs/Users_Guide/config_options.rst
@@ -508,6 +508,22 @@ with bad status after writing the warning message.
 		
   exit_on_warning = FALSE;
 
+time_offset_warning
+-------------------
+
+The "time_offset_warning" entry in ConfigConstants defines an allowable
+offset in seconds to silence time differences warning messages. Several
+MET tools check the timestamps of the datasets being compared and print a
+warning message if they differ. Increasing this option from its default
+value of 0 seconds enables datasets that are close in time to be compared
+without triggering a warning. If the absolute value of a non-zero time
+difference is less than or equal to this setting, a debug log message is
+written instead of a warning.
+
+.. code-block:: none
+		
+  time_offset_warning = 0;
+
 nc_compression
 --------------
 

--- a/src/basic/vx_config/config_constants.h
+++ b/src/basic/vx_config/config_constants.h
@@ -525,9 +525,11 @@ static const char config_map_data_filename[] = "MET_BASE/config/ConfigMapData";
 // Parameter key names common to multiple tools
 //
 
-static const char conf_key_exit_on_warning[]   = "exit_on_warning";
-static const char conf_key_nc_compression[]    = "nc_compression";
-static const char conf_key_output_precision[]  = "output_precision";
+static const char conf_key_exit_on_warning[]     = "exit_on_warning";
+static const char conf_key_time_offset_warning[] = "time_offset_warning";
+static const char conf_key_nc_compression[]      = "nc_compression";
+static const char conf_key_output_precision[]    = "output_precision";
+
 static const char conf_key_version[]           = "version";
 static const char conf_key_model[]             = "model";
 static const char conf_key_desc[]              = "desc";

--- a/src/basic/vx_config/config_file.cc
+++ b/src/basic/vx_config/config_file.cc
@@ -257,25 +257,8 @@ return;
 
 ////////////////////////////////////////////////////////////////////////
 
-
-ConcatString MetConfig::get_tmp_dir()
-{
-   ConcatString tmp_dir;
-
-   // Use the MET_TMP_DIR environment variable, if set.
-   if(!get_env("MET_TMP_DIR", tmp_dir)) {
-      const DictionaryEntry * _e = lookup(conf_key_tmp_dir);
-      if ( LastLookupStatus ) tmp_dir = _e->string_value();
-      else                    tmp_dir = default_tmp_dir;
-   }
-
-   return tmp_dir;
-}
-
-
-////////////////////////////////////////////////////////////////////////
-
 int MetConfig::nc_compression()
+
 {
    ConcatString cs;
    int n = 0;
@@ -303,6 +286,41 @@ int n = lookup_int(conf_key_output_precision, false);
 if ( !LastLookupStatus )  n = default_precision;
 
 return n;
+
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+ConcatString MetConfig::get_tmp_dir()
+
+{
+   ConcatString tmp_dir;
+
+   // Use the MET_TMP_DIR environment variable, if set.
+   if(!get_env("MET_TMP_DIR", tmp_dir)) {
+      const DictionaryEntry * _e = lookup(conf_key_tmp_dir);
+      if ( LastLookupStatus ) tmp_dir = _e->string_value();
+      else                    tmp_dir = default_tmp_dir;
+   }
+
+   return tmp_dir;
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+bool MetConfig::time_offset_warning(int offset)
+
+{
+
+int allowable_offset = lookup_int(conf_key_time_offset_warning, false);
+
+if (!LastLookupStatus )  allowable_offset = 0;
+
+return ( abs(offset) > allowable_offset );
 
 }
 

--- a/src/basic/vx_config/config_file.h
+++ b/src/basic/vx_config/config_file.h
@@ -78,6 +78,8 @@ class MetConfig : public Dictionary {
       
       ConcatString get_tmp_dir();
 
+      bool time_offset_warning(int);
+
       StringArray filename() const;
 
       bool debug() const;

--- a/src/tools/core/grid_stat/grid_stat.cc
+++ b/src/tools/core/grid_stat/grid_stat.cc
@@ -111,6 +111,7 @@
 //   053    12/11/21  Halley Gotway  MET #1991 Fix VCNT output.
 //   054    07/06/22  Howard Soh     METplus-Internal #19 Rename main to met_main
 //   055    10/03/22  Prestopnik     MET #2227 Remove using namespace netCDF from header files
+//   056    01/29/24  Halley Gotway  MET #2801 Configure time difference warnings
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -769,9 +770,9 @@ void process_scores() {
 
          mlog << Warning << "\nprocess_scores() -> "
               << "Forecast and observation accumulation times "
-              << "do not match " << sec_to_hhmmss(fcst_dp.accum())
+              << "do not match (" << sec_to_hhmmss(fcst_dp.accum())
               << " != " << sec_to_hhmmss(obs_dp.accum())
-              << " for " << conf_info.vx_opt[i].fcst_info->magic_str()
+              << ") for " << conf_info.vx_opt[i].fcst_info->magic_str()
               << " versus " << conf_info.vx_opt[i].obs_info->magic_str()
               << ".\n\n";
       }

--- a/src/tools/core/grid_stat/grid_stat.cc
+++ b/src/tools/core/grid_stat/grid_stat.cc
@@ -745,12 +745,21 @@ void process_scores() {
       // Check that the valid times match
       if(fcst_dp.valid() != obs_dp.valid()) {
 
-         mlog << Warning << "\nprocess_scores() -> "
-              << "Forecast and observation valid times do not match "
-              << unix_to_yyyymmdd_hhmmss(fcst_dp.valid()) << " != "
-              << unix_to_yyyymmdd_hhmmss(obs_dp.valid()) << " for "
-              << conf_info.vx_opt[i].fcst_info->magic_str() << " versus "
-              << conf_info.vx_opt[i].obs_info->magic_str() << ".\n\n";
+         cs << cs_erase
+            << "Forecast and observation valid times do not match ("
+            << unix_to_yyyymmdd_hhmmss(fcst_dp.valid()) << " != "
+            << unix_to_yyyymmdd_hhmmss(obs_dp.valid()) << ") for "
+            << conf_info.vx_opt[i].fcst_info->magic_str() << " versus "
+            << conf_info.vx_opt[i].obs_info->magic_str() << ".";
+
+         if(conf_info.conf.time_offset_warning(
+               (int) (fcst_dp.valid() - obs_dp.valid()))) {
+            mlog << Warning << "\nprocess_scores() -> "
+                 << cs << "\n\n";
+         }
+         else {
+            mlog << Debug(3) << cs << "\n";
+         }
       }
 
       // Check that the accumulation intervals match

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -482,28 +482,37 @@ void ModeExecutive::setup_fcst_obs_data_traditional()
 
    if ( engine.conf_info.Obs->var_info->p_flag() ) rescale_probability(Obs_sd.data);
 
-   // Print a warning if the valid times do not match
+   // Check that the valid times match
 
    if(Fcst_sd.data.valid() != Obs_sd.data.valid()) {
 
-      mlog << Warning << "\nModeExecutive::setup_fcst_obs_data_traditional() -> "
-           << "Forecast and observation valid times do not match "
-           << unix_to_yyyymmdd_hhmmss(Fcst_sd.data.valid()) << " != "
-           << unix_to_yyyymmdd_hhmmss(Obs_sd.data.valid()) << " for "
-           << engine.conf_info.Fcst->var_info->magic_str() << " versus "
-           << engine.conf_info.Obs->var_info->magic_str() << ".\n\n";
+      ConcatString cs;
+      cs << "Forecast and observation valid times do not match ("
+         << unix_to_yyyymmdd_hhmmss(Fcst_sd.data.valid()) << " != "
+         << unix_to_yyyymmdd_hhmmss(Obs_sd.data.valid()) << ") for "
+         << engine.conf_info.Fcst->var_info->magic_str() << " versus "
+         << engine.conf_info.Obs->var_info->magic_str() << ".\n";
+
+      if(engine.conf_info.conf.time_offset_warning(
+           (int) (Fcst_sd.data.valid() - Obs_sd.data.valid()))) {
+         mlog << Warning << "\nModeExecutive::setup_fcst_obs_data_traditional() ->"
+              << cs << "\n\n";
+      }
+      else {
+         mlog << Debug(3) << cs << "\n";
+      }
    }
 
-   // Print a warning if the accumulation intervals do not match
+   // Check that the accumulation intervals match
 
    if(engine.conf_info.Fcst->var_info->level().type() == LevelType_Accum &&
       engine.conf_info.Obs->var_info->level().type()  == LevelType_Accum &&
-      Fcst_sd.data.accum()                       != Obs_sd.data.accum()) {
+      Fcst_sd.data.accum()                            != Obs_sd.data.accum()) {
 
       mlog << Warning << "\nModeExecutive::setup_fcst_obs_data_traditional() -> "
-           << "Forecast and observation accumulation times do not match "
-           << sec_to_hhmmss(Fcst_sd.data.valid()) << " != "
-           << sec_to_hhmmss(Obs_sd.data.valid()) << " for "
+           << "Forecast and observation accumulation times do not match ("
+           << sec_to_hhmmss(Fcst_sd.data.accum()) << " != "
+           << sec_to_hhmmss(Obs_sd.data.accum()) << ") for "
            << engine.conf_info.Fcst->var_info->magic_str() << " versus "
            << engine.conf_info.Obs->var_info->magic_str() << ".\n\n";
    }
@@ -792,26 +801,37 @@ void ModeExecutive::setup_fcst_obs_data_multivar_intensities(const MultiVarData 
 
    // Rescale probabilites from [0, 100] to [0, 1] also not neede in the second pass
 
-   // Print a warning if the valid times do not match
+   // Check that the valid times match
+
    if(Fcst_sd.data.valid() != Obs_sd.data.valid()) {
 
-       mlog << Warning << "\nModeExecutive::setup_fcst_obs_data_multivar_intensities() -> "
-            << "Forecast and observation valid times do not match "
-            << unix_to_yyyymmdd_hhmmss(Fcst_sd.data.valid()) << " != "
-            << unix_to_yyyymmdd_hhmmss(Obs_sd.data.valid()) << " for "
-            << engine.conf_info.Fcst->var_info->magic_str() << " versus "
-            << engine.conf_info.Obs->var_info->magic_str() << ".\n\n";
-    }
+      ConcatString cs;
+      cs << "Forecast and observation valid times do not match ("
+         << unix_to_yyyymmdd_hhmmss(Fcst_sd.data.valid()) << " != "
+         << unix_to_yyyymmdd_hhmmss(Obs_sd.data.valid()) << ") for "
+         << engine.conf_info.Fcst->var_info->magic_str() << " versus "
+         << engine.conf_info.Obs->var_info->magic_str() << ".\n";
 
-   // Print a warning if the accumulation intervals do not match
+      if(engine.conf_info.conf.time_offset_warning(
+           (int) (Fcst_sd.data.valid() - Obs_sd.data.valid()))) {
+         mlog << Warning << "\nModeExecutive::setup_fcst_obs_data_multivar_intensities() ->"
+              << cs << "\n\n";
+      }
+      else {
+         mlog << Debug(3) << cs << "\n";
+      }
+   }
+
+   // Check that the accumulation intervals match
+
    if(engine.conf_info.Fcst->var_info->level().type() == LevelType_Accum &&
       engine.conf_info.Obs->var_info->level().type()  == LevelType_Accum &&
-      Fcst_sd.data.accum()                       != Obs_sd.data.accum()) {
+      Fcst_sd.data.accum()                            != Obs_sd.data.accum()) {
 
        mlog << Warning << "\nModeExecutive::setup_fcst_obs_data_multivar_intensities() -> "
-           << "Forecast and observation accumulation times do not match "
-           << sec_to_hhmmss(Fcst_sd.data.valid()) << " != "
-           << sec_to_hhmmss(Obs_sd.data.valid()) << " for "
+           << "Forecast and observation accumulation times do not match ("
+           << sec_to_hhmmss(Fcst_sd.data.accum()) << " != "
+           << sec_to_hhmmss(Obs_sd.data.accum()) << ") for "
            << engine.conf_info.Fcst->var_info->magic_str() << " versus "
            << engine.conf_info.Obs->var_info->magic_str() << ".\n\n";
    }
@@ -891,26 +911,37 @@ void ModeExecutive::setup_fcst_obs_data_multivar_super(ShapeData &f_super, Shape
 
    // Rescale probabilites from [0, 100] to [0, 1] also not neede in the second pass
 
-   // Print a warning if the valid times do not match
+   // Check that the valid times match
+
    if(Fcst_sd.data.valid() != Obs_sd.data.valid()) {
 
-      mlog << Warning << "\nModeExecutive::setup_fcst_obs_data_multivar_super() -> "
-           << "Forecast and observation valid times do not match "
-           << unix_to_yyyymmdd_hhmmss(Fcst_sd.data.valid()) << " != "
-           << unix_to_yyyymmdd_hhmmss(Obs_sd.data.valid()) << " for "
-           << engine.conf_info.Fcst->var_info->magic_str() << " versus "
-           << engine.conf_info.Obs->var_info->magic_str() << ".\n\n";
+      ConcatString cs;
+      cs << "Forecast and observation valid times do not match ("
+         << unix_to_yyyymmdd_hhmmss(Fcst_sd.data.valid()) << " != "
+         << unix_to_yyyymmdd_hhmmss(Obs_sd.data.valid()) << ") for "
+         << engine.conf_info.Fcst->var_info->magic_str() << " versus "
+         << engine.conf_info.Obs->var_info->magic_str() << ".\n";
+
+      if(engine.conf_info.conf.time_offset_warning(
+           (int) (Fcst_sd.data.valid() != Obs_sd.data.valid()))) {
+         mlog << Warning << "\nModeExecutive::setup_fcst_obs_data_multivar_super() ->"
+              << cs << "\n\n";
+      }
+      else {
+         mlog << Debug(3) << cs << "\n";
+      }
    }
 
-   // Print a warning if the accumulation intervals do not match
+   // Check that the accumulation intervals match
+
    if(engine.conf_info.Fcst->var_info->level().type() == LevelType_Accum &&
       engine.conf_info.Obs->var_info->level().type()  == LevelType_Accum &&
-      Fcst_sd.data.accum()                       != Obs_sd.data.accum()) {
+      Fcst_sd.data.accum()                            != Obs_sd.data.accum()) {
 
       mlog << Warning << "\nModeExecutive::setup_fcst_obs_data_multivar_super() -> "
-           << "Forecast and observation accumulation times do not match "
-           << sec_to_hhmmss(Fcst_sd.data.valid()) << " != "
-           << sec_to_hhmmss(Obs_sd.data.valid()) << " for "
+           << "Forecast and observation accumulation times do not match ("
+           << sec_to_hhmmss(Fcst_sd.data.accum()) << " != "
+           << sec_to_hhmmss(Obs_sd.data.accum()) << ") for "
            << engine.conf_info.Fcst->var_info->magic_str() << " versus "
            << engine.conf_info.Obs->var_info->magic_str() << ".\n\n";
    }

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -491,7 +491,7 @@ void ModeExecutive::setup_fcst_obs_data_traditional()
          << unix_to_yyyymmdd_hhmmss(Fcst_sd.data.valid()) << " != "
          << unix_to_yyyymmdd_hhmmss(Obs_sd.data.valid()) << ") for "
          << engine.conf_info.Fcst->var_info->magic_str() << " versus "
-         << engine.conf_info.Obs->var_info->magic_str() << ".\n";
+         << engine.conf_info.Obs->var_info->magic_str() << ".";
 
       if(engine.conf_info.conf.time_offset_warning(
            (int) (Fcst_sd.data.valid() - Obs_sd.data.valid()))) {
@@ -810,7 +810,7 @@ void ModeExecutive::setup_fcst_obs_data_multivar_intensities(const MultiVarData 
          << unix_to_yyyymmdd_hhmmss(Fcst_sd.data.valid()) << " != "
          << unix_to_yyyymmdd_hhmmss(Obs_sd.data.valid()) << ") for "
          << engine.conf_info.Fcst->var_info->magic_str() << " versus "
-         << engine.conf_info.Obs->var_info->magic_str() << ".\n";
+         << engine.conf_info.Obs->var_info->magic_str() << ".";
 
       if(engine.conf_info.conf.time_offset_warning(
            (int) (Fcst_sd.data.valid() - Obs_sd.data.valid()))) {
@@ -920,7 +920,7 @@ void ModeExecutive::setup_fcst_obs_data_multivar_super(ShapeData &f_super, Shape
          << unix_to_yyyymmdd_hhmmss(Fcst_sd.data.valid()) << " != "
          << unix_to_yyyymmdd_hhmmss(Obs_sd.data.valid()) << ") for "
          << engine.conf_info.Fcst->var_info->magic_str() << " versus "
-         << engine.conf_info.Obs->var_info->magic_str() << ".\n";
+         << engine.conf_info.Obs->var_info->magic_str() << ".";
 
       if(engine.conf_info.conf.time_offset_warning(
            (int) (Fcst_sd.data.valid() != Obs_sd.data.valid()))) {

--- a/src/tools/core/pcp_combine/pcp_combine.cc
+++ b/src/tools/core/pcp_combine/pcp_combine.cc
@@ -879,7 +879,7 @@ void do_sub_command() {
          << "The initialization times do not match ("
          << unix_to_yyyymmdd_hhmmss(plus.init()) << " != "
          << unix_to_yyyymmdd_hhmmss(minus.init())
-         << ") for subtraction. Using the first value.\n";
+         << ") for subtraction. Using the first value.";
 
       if(config.time_offset_warning(
             (int) (plus.init() - minus.init()))) {

--- a/src/tools/core/pcp_combine/pcp_combine.cc
+++ b/src/tools/core/pcp_combine/pcp_combine.cc
@@ -77,6 +77,7 @@
 //                    the -pcpdir option.
 //   024    07/06/22  Howard Soh     METplus-Internal #19 Rename main to met_main
 //   025    09/29/22  Prestopnik     MET #2227 Remove namespace netCDF from header files
+//   026    01/29/24  Halley Gotway  MET #2801 Configure time difference warnings
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -869,15 +870,25 @@ void do_sub_command() {
    nc_valid_time = plus.valid();
 
    //
-   // Output initialization time
-   // Warning if init_time1 != init_time2.
+   // Check that the initialization times match
    //
    if(plus.init() != minus.init()) {
-      mlog << Warning << "\ndo_sub_command() -> "
-           << "the initialization times do not match ("
-           << unix_to_yyyymmdd_hhmmss(plus.init()) <<  " != "
-           << unix_to_yyyymmdd_hhmmss(minus.init())
-           << ") for subtraction.  Using the first value.\n\n";
+
+      ConcatString cs;
+      cs << cs_erase
+         << "The initialization times do not match ("
+         << unix_to_yyyymmdd_hhmmss(plus.init()) << " != "
+         << unix_to_yyyymmdd_hhmmss(minus.init())
+         << ") for subtraction. Using the first value.\n";
+
+      if(config.time_offset_warning(
+            (int) (plus.init() - minus.init()))) {
+         mlog << Warning << "\ndo_sub_command() -> "
+               << cs << "\n\n";
+      }
+      else {
+         mlog << Debug(3) << cs << "\n";
+      }
    }
    nc_init_time = plus.init();
 

--- a/src/tools/core/series_analysis/series_analysis.cc
+++ b/src/tools/core/series_analysis/series_analysis.cc
@@ -34,6 +34,7 @@
 //   013    05/25/22  Halley Gotway  MET #2147 Add CTS HSS_EC output.
 //   014    07/06/22  Howard Soh     METplus-Internal #19 Rename main to met_main
 //   015    10/03/22  Presotpnik     MET #2227 Remove namespace netCDF from header files
+//   016    01/29/24  Halley Gotway  MET #2801 Configure time difference warnings
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -543,12 +544,23 @@ void get_series_data(int i_series,
    if(fcst_dp.valid() != (unixtime) 0 &&
       obs_dp.valid()  != (unixtime) 0 &&
       fcst_dp.valid() != obs_dp.valid()) {
-      mlog << Warning << "\nget_series_data() -> "
-           << "Forecast and observation valid times do not match "
-           << unix_to_yyyymmdd_hhmmss(fcst_dp.valid()) << " != "
-           << unix_to_yyyymmdd_hhmmss(obs_dp.valid()) << " for "
-           << fcst_info->magic_str() << " versus "
-           << obs_info->magic_str() << ".\n\n";
+
+      ConcatString cs;
+      cs << cs_erase
+         << "Forecast and observation valid times do not match ("
+         << unix_to_yyyymmdd_hhmmss(fcst_dp.valid()) << " != "
+         << unix_to_yyyymmdd_hhmmss(obs_dp.valid()) << ") for "
+         << fcst_info->magic_str() << " versus "
+         << obs_info->magic_str() << ".";
+
+      if(conf_info.conf.time_offset_warning(
+            (int) (fcst_dp.valid() - obs_dp.valid()))) {
+         mlog << Warning << "\nget_series_data() -> "
+              << cs << "\n\n";
+      }
+      else {
+         mlog << Debug(3) << cs << "\n";
+      }
    }
 
    return;

--- a/src/tools/core/wavelet_stat/wavelet_stat.cc
+++ b/src/tools/core/wavelet_stat/wavelet_stat.cc
@@ -39,6 +39,7 @@
 //   014    07/09/21  Linden          MET #1746 Skip thresholding.
 //   015    07/06/22  Howard Soh      METplus-Internal #19 Rename main to met_main
 //   016    10/03/22  Prestopnik      MET #2227 Remove using namespace netCDF from header files
+//   017    01/29/24  Halley Gotway  MET #2801 Configure time difference warnings
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -338,24 +339,34 @@ void process_scores() {
       // Check that the valid times match
       if(fcst_dp.valid() != obs_dp.valid()) {
 
-         mlog << Warning << "\nprocess_scores() -> "
-              << "Forecast and observation valid times do not match "
-              << unix_to_yyyymmdd_hhmmss(fcst_dp.valid()) << " != " <<
-              unix_to_yyyymmdd_hhmmss(obs_dp.valid()) << " for "
-              << conf_info.fcst_info[i]->magic_str() << " versus "
-              << conf_info.obs_info[i]->magic_str() << ".\n";
+         ConcatString cs;
+         cs << cs_erase
+            << "Forecast and observation valid times do not match ("
+            << unix_to_yyyymmdd_hhmmss(fcst_dp.valid()) << " != "
+            << unix_to_yyyymmdd_hhmmss(obs_dp.valid()) << ") for "
+            << conf_info.fcst_info[i]->magic_str() << " versus "
+            << conf_info.obs_info[i]->magic_str() << ".";
+
+         if(conf_info.conf.time_offset_warning(
+               (int) (fcst_dp.valid() - obs_dp.valid()))) {
+            mlog << Warning << "\nprocess_scores() -> "
+                 << cs << "\n\n";
+         }
+         else {
+            mlog << Debug(3) << cs << "\n";
+         }
       }
 
       // Check that the accumulation intervals match
       if(conf_info.fcst_info[i]->level().type() == LevelType_Accum &&
          conf_info.obs_info[i]->level().type()  == LevelType_Accum &&
-         fcst_dp.accum()       != obs_dp.accum()) {
+         fcst_dp.accum()                        != obs_dp.accum()) {
 
          mlog << Warning << "\nprocess_scores() -> "
               << "Forecast and observation accumulation times "
-              << "do not match " << sec_to_hhmmss(fcst_dp.accum())
+              << "do not match (" << sec_to_hhmmss(fcst_dp.accum())
               << " != " << sec_to_hhmmss(obs_dp.accum())
-              << " for " << conf_info.fcst_info[i]->magic_str() << " versus "
+              << ") for " << conf_info.fcst_info[i]->magic_str() << " versus "
               << conf_info.obs_info[i]->magic_str() << ".\n";
       }
 

--- a/src/tools/other/wwmca_tool/nc_output.cc
+++ b/src/tools/other/wwmca_tool/nc_output.cc
@@ -56,7 +56,7 @@ void WwmcaRegridder::do_output(const char * output_filename)
    int accum_time, x, y;
    float f;
    double v;
-   ConcatString s;
+   ConcatString s, cs;
    const int Nx = ToGrid->nx();
    const int Ny = ToGrid->ny();
 
@@ -129,16 +129,23 @@ void WwmcaRegridder::do_output(const char * output_filename)
    
       if ( cp_nh->valid() != (unixtime) 0 &&
            cp_nh->valid() != valid_time )  {
-   
-         mlog << Warning << "\nWwmcaRegridder::do_output(const char * output_filename) -> "
-              << "the config file valid time ("
-              << unix_to_yyyymmdd_hhmmss(valid_time)
-              << ") and data file valid time ("
-              << unix_to_yyyymmdd_hhmmss(cp_nh->valid())
-              << ") do not match, using config file time.\n\n";
-   
+
+         cs << cs_erase
+            << "the config file valid time ("
+            << unix_to_yyyymmdd_hhmmss(valid_time)
+            << ") and data file valid time ("
+            << unix_to_yyyymmdd_hhmmss(cp_nh->valid())
+            << ") do not match, using config file time.";
+
+         if(Config->time_offset_warning(
+               (int) (cp_nh->valid() != valid_time))) {
+            mlog << Warning << "\nWwmcaRegridder::do_output(const char * output_filename) -> "
+                 << cs << "\n\n";
+         }
+         else {
+            mlog << Debug(3) << cs << "\n";
+         }
       }
-   
    }
    else  {
       valid_time = cp_nh->valid();
@@ -164,16 +171,23 @@ void WwmcaRegridder::do_output(const char * output_filename)
    
       if ( cp_nh->init() != (unixtime) 0 &&
            cp_nh->init() != init_time )  {
-   
-         mlog << Warning << "\nWwmcaRegridder::do_output(const char * output_filename) -> "
-              << "the config file initialization time ("
-              << unix_to_yyyymmdd_hhmmss(init_time)
-              << ") and data file initialization time ("
-              << unix_to_yyyymmdd_hhmmss(cp_nh->init())
-              << ") do not match, using config file time.\n\n";
-   
+
+         cs << cs_erase
+            << "the config file initialization time ("
+            << unix_to_yyyymmdd_hhmmss(init_time)
+            << ") and data file initialization time ("
+            << unix_to_yyyymmdd_hhmmss(cp_nh->init())
+            << ") do not match, using config file time.";
+
+         if(Config->time_offset_warning(
+               (int) (cp_nh->init() != init_time))) {
+            mlog << Warning << "\nWwmcaRegridder::do_output(const char * output_filename) -> "
+                 << cs << "\n\n";
+         }
+         else {
+            mlog << Debug(3) << cs << "\n";
+         }
       }
-   
    }
    else  {
       init_time = cp_nh->init();


### PR DESCRIPTION
## Expected Differences ##

This PR adds a new config file option named `time_offset_warning` to make configurable the writing of warning messages for relatively small time differences. The base `MetConfig` class is enhanced to parse its value and check it against the initialization and valid time differences.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[Yes]**</br>
If **yes**, please describe:</br>
While `time_offset_warning` is added in `ConfigConstants`, it can be specified within any MET configuration file to set it. The default setting of 0 seconds maintains the existing functionality of printing a warning message any difference in time in the gridded inputs.

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Compiled this feature branch in `seneca:/d1/projects/MET/MET_pull_requests/met-12.0.0/beta3/MET-feature_2801_warnings`. Manually ran tests to trigger the following warning and debug messages:

<details>
<summary>Setup</summary>
cd /d1/projects/MET/MET_pull_requests/met-12.0.0/beta3/MET-feature_2801_warnings
runas met_test
</details>

<details>
<summary>1. PCP-Combine</summary>
bin/pcp_combine -subtract data/sample_fcst/2005080700/wrfprs_ruc13_03.tm00_G212 data/sample_fcst/2005080712/wrfprs_ruc13_00.tm00_G212 diff.nc -field 'name="TMP"; level="Z2";' -v 3 -log run_pcp_combine_warning.log

WARNING: do_sub_command() -> The initialization times do not match (20050807_000000 != 20050807_120000) for subtraction. Using the first value.

bin/pcp_combine -subtract data/sample_fcst/2005080700/wrfprs_ruc13_03.tm00_G212 data/sample_fcst/2005080712/wrfprs_ruc13_00.tm00_G212 diff.nc -field 'name="TMP"; level="Z2"; time_offset_warning=12*60*60;' -v 3 -log run_pcp_combine_debug.log

DEBUG 3: The initialization times do not match (20050807_000000 != 20050807_120000) for subtraction. Using the first value.
</details>

<details>
<summary>2. Grid-Stat</summary>
export TEST_OUT_DIR=out
bin/grid_stat data/sample_fcst/2005080700/wrfprs_ruc13_03.tm00_G212 data/sample_fcst/2005080712/wrfprs_ruc13_00.tm00_G212 scripts/config/GridStatConfig_all -outdir out -log run_gs_warning.log -v 3

WARNING: process_scores() -> Forecast and observation valid times do not match (20050807_030000 != 20050807_120000) for TMP/Z2 versus TMP/Z2.

echo 'time_offset_warning = 12*60*60;' >>  scripts/config/GridStatConfig_all
bin/grid_stat data/sample_fcst/2005080700/wrfprs_ruc13_03.tm00_G212 data/sample_fcst/2005080712/wrfprs_ruc13_00.tm00_G212 scripts/config/GridStatConfig_all -outdir out -log run_gs_debug.log -v 3

WARNING: process_scores() -> Forecast and observation valid times do not match (20050807_030000 != 20050807_120000) for TMP/Z2 versus TMP/Z2.
</details>

<details>
<summary>3. MODE</summary>

bin/mode data/sample_fcst/2005080700/wrfprs_ruc13_03.tm00_G212 data/sample_fcst/2005080712/wrfprs_ruc13_00.tm00_G212 scripts/config/MODEConfig_RH -outdir out/mode -v 3 -log run_mode_warning.log

echo 'time_offset_warning = 12*60*60;' >> scripts/config/MODEConfig_RH
bin/mode data/sample_fcst/2005080700/wrfprs_ruc13_03.tm00_G212 data/sample_fcst/2005080712/wrfprs_ruc13_00.tm00_G212 scripts/config/MODEConfig_RH -outdir out/mode -v 3 -log run_mode_debug.log

DEBUG 3: Forecast and observation valid times do not match (20050807_030000 != 20050807_120000) for RH/P500 versus RH/P500.
</details>

Did not directly test these. Please proceed with code review.

4. Wavelet-Stat
5. Series-Analysis
6. WWMCA-Regrid

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Please browse the code changes, review the wording of the User's Guide updates, and browse the log files generated on seneca in /d1/projects/MET/MET_pull_requests/met-12.0.0/beta3/MET-feature_2801_warnings and note the difference between the warning and debug log files:
```
ls run_*_warning.log run_*_debug.log
```

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [x] Do these changes include sufficient testing updates? **[Yes]**
Our existing tests don't validate the log messages that are printed. So I didn't add any new tests.

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Please complete this pull request review by **[Tues 1/30/24]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **MET-X.Y.Z Development** project for official releases
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
