### PR TITLE
Feature #2870 removing_MISSING_warning

### DIFF
--- a/internal/test_unit/xml/unit_gen_ens_prod.xml
+++ b/internal/test_unit/xml/unit_gen_ens_prod.xml
@@ -26,7 +26,7 @@
   <test name="gen_ens_prod_NO_CTRL">
     <exec>echo "&DATA_DIR_MODEL;/grib1/arw-fer-gep1/arw-fer-gep1_2012040912_F024.grib \
                 &DATA_DIR_MODEL;/grib1/arw-sch-gep2/arw-sch-gep2_2012040912_F024.grib \
-                &DATA_DIR_MODEL;/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
+                MISSING \
                 &DATA_DIR_MODEL;/grib1/nmm-fer-gep4/nmm-fer-gep4_2012040912_F024.grib \
                 &DATA_DIR_MODEL;/grib1/arw-fer-gep5/arw-fer-gep5_2012040912_F024.grib \
                 &DATA_DIR_MODEL;/grib1/arw-sch-gep6/arw-sch-gep6_2012040912_F024.grib \
@@ -42,7 +42,7 @@
       -ens    &OUTPUT_DIR;/gen_ens_prod/input_file_list \
       -config &CONFIG_DIR;/GenEnsProdConfig \
       -out    &OUTPUT_DIR;/gen_ens_prod/gen_ens_prod_NO_CTRL_20120410_120000V.nc \
-      -v 2 
+      -v 3 
     </param>
     <output>
       <grid_nc>&OUTPUT_DIR;/gen_ens_prod/gen_ens_prod_NO_CTRL_20120410_120000V.nc</grid_nc>
@@ -52,7 +52,7 @@
   <test name="gen_ens_prod_WITH_CTRL">
     <exec>echo "&DATA_DIR_MODEL;/grib1/arw-fer-gep1/arw-fer-gep1_2012040912_F024.grib \
                 &DATA_DIR_MODEL;/grib1/arw-sch-gep2/arw-sch-gep2_2012040912_F024.grib \
-                &DATA_DIR_MODEL;/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
+                MISSING/&DATA_DIR_MODEL;/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
                 &DATA_DIR_MODEL;/grib1/nmm-fer-gep4/nmm-fer-gep4_2012040912_F024.grib \
                 &DATA_DIR_MODEL;/grib1/arw-fer-gep5/arw-fer-gep5_2012040912_F024.grib \
                 &DATA_DIR_MODEL;/grib1/arw-sch-gep6/arw-sch-gep6_2012040912_F024.grib \
@@ -69,7 +69,7 @@
       -ctrl   &DATA_DIR_MODEL;/grib1/arw-tom-gep0/arw-tom-gep0_2012040912_F024.grib \
       -config &CONFIG_DIR;/GenEnsProdConfig \
       -out    &OUTPUT_DIR;/gen_ens_prod/gen_ens_prod_WITH_CTRL_20120410_120000V.nc \
-      -v 2
+      -v 3 
     </param>
     <output>
       <grid_nc>&OUTPUT_DIR;/gen_ens_prod/gen_ens_prod_WITH_CTRL_20120410_120000V.nc</grid_nc>
@@ -162,7 +162,7 @@
       -ctrl   &DATA_DIR_MODEL;/grib1/arw-tom-gep0/arw-tom-gep0_2012040912_F024.grib \
       -config &CONFIG_DIR;/GenEnsProdConfig_normalize \
       -out    &OUTPUT_DIR;/gen_ens_prod/gen_ens_prod_NORMALIZE.nc \
-      -v 2
+      -v 3 
     </param>
     <output>
       <grid_nc>&OUTPUT_DIR;/gen_ens_prod/gen_ens_prod_NORMALIZE.nc</grid_nc>

--- a/src/libcode/vx_data2d_factory/parse_file_list.cc
+++ b/src/libcode/vx_data2d_factory/parse_file_list.cc
@@ -37,6 +37,7 @@ using namespace std;
 
 static const char python_str    [] = "python";
 static const char file_list_str [] = "file_list";
+static const char missing_str   [] = "MISSING";
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -197,6 +198,70 @@ if ( check_files_exist )  {
 f_in.close();
 
 return a;
+
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+GrdFileType parse_file_list_type(const StringArray& file_list)
+
+{
+
+GrdFileType ftype = FileType_None;
+
+for ( int i=0; i<file_list.n(); i++ )  {
+
+   //
+   //  skip missing files
+   //
+
+   if( !file_exists(file_list[i].c_str()) ) continue;
+
+   //
+   //  get the current file type
+   //
+
+   ftype = grd_file_type(file_list[i].c_str());
+
+   if ( ftype != FileType_None ) break;
+
+}
+
+return ftype;
+
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+void log_missing_file(const char *method_name,
+                      const char *desc_str,
+                      const string &file_name)
+
+{
+
+ConcatString cs;
+ConcatString missing_cs(missing_str);
+
+cs << method_name << "cannot open "
+   << desc_str << ": " << file_name;
+
+   //
+   //  Write a warning message for missing files or
+   //  a debug message for the MISSING keyword
+   //
+
+if ( file_name.find(missing_cs, 0) == 0 )  {
+   mlog << Debug(3) << cs << "\n";
+}
+else {
+   mlog << Warning << "\n" << cs << "\n\n";
+}
+
+return;
 
 }
 

--- a/src/libcode/vx_data2d_factory/parse_file_list.h
+++ b/src/libcode/vx_data2d_factory/parse_file_list.h
@@ -18,6 +18,7 @@
 ////////////////////////////////////////////////////////////////////////
 
 
+#include "vx_config.h"
 #include "vx_log.h"
 
 
@@ -27,6 +28,12 @@
 extern StringArray parse_file_list(const StringArray&);
 
 extern StringArray parse_ascii_file_list(const char * path);
+
+extern GrdFileType parse_file_list_type(const StringArray&);
+
+extern void log_missing_file(const char *method_name,
+                             const char *desc_str,
+                             const std::string &file_name);
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/ensemble_stat/ensemble_stat.cc
+++ b/src/tools/core/ensemble_stat/ensemble_stat.cc
@@ -72,6 +72,7 @@
 //   040    10/03/22  Prestopnik     MET #2227 Remove using namespace netCDF from
 //                                   header files
 //   041    04/16/24  Halley Gotway  MET #2786 Compute RPS from climo bin probs.
+//   042    04/29/24  Halley Gotway  MET #2870 Ignore MISSING keyword.
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -205,8 +206,6 @@ void process_command_line(int argc, char **argv) {
    int i;
    CommandLine cline;
    ConcatString default_config_file;
-   Met2dDataFile *ens_mtddf = (Met2dDataFile *) nullptr;
-   Met2dDataFile *obs_mtddf = (Met2dDataFile *) nullptr;
    const char *method_name = "process_command_line() -> ";
 
    // Set default output directory
@@ -360,31 +359,19 @@ void process_command_line(int argc, char **argv) {
 
    // Get the ensemble file type from config, if present
    etype = parse_conf_file_type(conf_info.conf.lookup_dictionary(conf_key_fcst));
-   if(FileType_UGrid == etype) {
-      mlog << Error << "\n" << program_name << " -> filetype "
-           << grdfiletype_to_string(etype) << " from the configuration is not supported\n\n";
 
-      exit(1);
+   // Get the ensemble file type from the files
+   if(etype == FileType_None) {
+      etype = parse_file_list_type(ens_file_list);
    }
 
-   // Read the first input ensemble file
-   if(!(ens_mtddf = mtddf_factory.new_met_2d_data_file(ens_file_list[0].c_str(), etype))) {
+   // UGrid not supported
+   if(etype == FileType_UGrid) {
       mlog << Error << "\n" << method_name
-           << "trouble reading ensemble file \""
-           << ens_file_list[0] << "\"\n\n";
+           << grdfiletype_to_string(etype)
+           << " ensemble files are not supported\n\n";
       exit(1);
    }
-
-   // Store the input ensemble file type
-   etype = ens_mtddf->file_type();
-   if(FileType_UGrid == etype) {
-      mlog << Error << "\n" << program_name << " -> The filetype "
-           << grdfiletype_to_string(etype) << " (" << ens_file_list[0]
-           << ") is not supported\n\n";
-
-      exit(1);
-   }
-
 
    // Observation files are required
    if(!grid_obs_flag && !point_obs_flag) {
@@ -405,28 +392,17 @@ void process_command_line(int argc, char **argv) {
 
       // Get the observation file type from config, if present
       otype = parse_conf_file_type(conf_info.conf.lookup_dictionary(conf_key_obs));
-      if(FileType_UGrid == otype) {
-         mlog << Error << "\n" << program_name << " -> filetype "
-              << grdfiletype_to_string(otype) << " from the configuration is not supported\n\n";
-      
-         exit(1);
+
+      // Get the observation file type from the files
+      if(otype == FileType_None) {
+         otype = parse_file_list_type(grid_obs_file_list);
       }
 
-      // Read the first gridded observation file
-      if(!(obs_mtddf = mtddf_factory.new_met_2d_data_file(grid_obs_file_list[0].c_str(), otype))) {
+      // UGrid not supported
+      if(otype == FileType_UGrid) {
          mlog << Error << "\n" << method_name
-              << "trouble reading gridded observation file \""
-              << grid_obs_file_list[0] << "\"\n\n";
-         exit(1);
-      }
-
-      // Store the gridded observation file type
-      otype = obs_mtddf->file_type();
-      if(FileType_UGrid == otype) {
-         mlog << Error << "\n" << program_name << " -> The filetype "
-              << grdfiletype_to_string(etype) << " (" << grid_obs_file_list[0]
-              << ") is not supported\n\n";
-      
+              << grdfiletype_to_string(otype)
+              << " gridded observation files are not supported\n\n";
          exit(1);
       }
    }
@@ -475,9 +451,7 @@ void process_command_line(int argc, char **argv) {
 
       if(!file_exists(ens_file_list[i].c_str()) &&
          !is_python_grdfiletype(etype)) {
-         mlog << Warning << "\n" << method_name
-              << "can't open input ensemble file: "
-              << ens_file_list[i] << "\n\n";
+         log_missing_file(method_name, "input ensemble file", ens_file_list[i]);
          ens_file_vld.add(0);
       }
       else {
@@ -488,9 +462,7 @@ void process_command_line(int argc, char **argv) {
    // User-specified ensemble mean file
    if(ens_mean_file.nonempty()) {
       if(!file_exists(ens_mean_file.c_str())) {
-         mlog << Warning << "\n" << method_name
-              << "can't open input ensemble mean file: "
-              << ens_mean_file << "\n\n";
+         log_missing_file(method_name, "input ensemble mean file", ens_mean_file);
          ens_mean_file = "";
       }
    }
@@ -501,10 +473,6 @@ void process_command_line(int argc, char **argv) {
            << "control_id is set in the config file but "
            << "control file is not provided with -ctrl argument\n\n";
    }
-
-   // Deallocate memory for data files
-   if(ens_mtddf) { delete ens_mtddf; ens_mtddf = (Met2dDataFile *) nullptr; }
-   if(obs_mtddf) { delete obs_mtddf; obs_mtddf = (Met2dDataFile *) nullptr; }
 
    return;
 }
@@ -975,10 +943,8 @@ void process_point_obs(int i_nc) {
 #endif
       if(!nc_point_obs.open(point_obs_file_list[i_nc].c_str())) {
          nc_point_obs.close();
-      
-         mlog << Warning << "\n" << method_name
-              << "can't open observation netCDF file: "
-              << point_obs_file_list[i_nc] << "\n\n";
+         log_missing_file(method_name, "observation netCDF file",
+                          point_obs_file_list[i_nc]);
          return;
       }
       


### PR DESCRIPTION
This PR includes the following changes:
- Define new `parse_file_list_type(const StringArray&)` utility function to loop through the input files and determine the file type of the first *non-missing* file.
- Define new `log_missing_file(...)` utility function to write a warning message about missing files or just DEBUG(3) if the missing file name begins with the `MISSING` keyword from METplus wrappers.
- Update Ensemble-Stat and Gen-Ens-Prod to call these utility functions.

Note the following two tweaks to the logic:
- Previously if the *first* input file was missing, Ensemble-Stat and Gen-Ens-Prod would error out with:
```
ERROR  : grd_file_type() -> file does not exist "MISSING"
```
Calling `parse_file_list_type(...)` instead enables the first file in the list to be missing. So that's an improvement.
- Previously these tools actually called `open()` on the first input file, and that may have applied a little extra validation logic. But that isn't REALLY needed here because we open the files later when we process them. Not opening them here is every so slightly more efficient but it's possible that if a runtime error was going to occur, it may have occurred sooner rather than later in the logic.

## Expected Differences ##

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

1. Ran Gen-Ens-Prod:
```
cd scripts; export TEST_OUT_DIR=../out;
../bin/gen_ens_prod \
-ens MISSING \
    ../data/sample_fcst/2009123112/*gep*/d01_2009123112_02400.grib \
    MISSING/path/info /a/real/bad/path -config config/GenEnsProdConfig \
-out ${TEST_OUT_DIR}/gen_ens_prod/gen_ens_prod_20100101_120000V_ens.nc \
-v 3 -log gen_ens_prod.log
```
Observe the following log messages... 2 DEBUG and 1 WARNING:
```
DEBUG 3: process_command_line() -> cannot open input ensemble file: MISSING
DEBUG 3: process_command_line() -> cannot open input ensemble file: MISSING/path/info
WARNING: 
WARNING: process_command_line() -> cannot open input ensemble file: /a/real/bad/path
WARNING: 
```
2. Ran Ensemble-Stat:
```
cd scripts; export TEST_OUT_DIR=../out;
../bin/ensemble_stat 9 \
/a/bad/path \
../data/sample_fcst/2009123112/*gep*/d01_2009123112_02400.grib \
MISSING \
MISSING/path/to/MISSING config/EnsembleStatConfig \
-grid_obs ../data/sample_obs/ST4/ST4.2010010112.24h \
-point_obs /a/real/bad/path \
-point_obs ${TEST_OUT_DIR}/ascii2nc/precip24_2010010112.nc \
-outdir ${TEST_OUT_DIR}/ensemble_stat \
-v 3 -log ensemble_stat.log
```
Observe the following log messages... 
```
WARNING:
WARNING: process_command_line() -> cannot open input ensemble file: /a/bad/path
WARNING:
DEBUG 3: process_command_line() -> cannot open input ensemble file: MISSING
DEBUG 3: process_command_line() -> cannot open input ensemble file: MISSING/path/to/MISSING
...
WARNING:
WARNING: process_point_obs() -> cannot open observation netCDF file: /a/real/bad/path
WARNING:
```
I'll note that providing a `-grid_obs` bad path as the first one in the list (`-grid_obs /a/bath/path`) does result in a runtime error. So this PR doesn't solve all the issues with bad data inputs... just the ones described in the issue.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
The code for this PR is compiled and available for testing as the `met_test` user in `seneca:/d1/projects/MET/MET_pull_requests/met-12.0.0/beta5/MET-feature_2870_remove_MISSING_warning`.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**
I couldn't decide whether or not documenting the subtle difference between a warning and debug log message for missing files that start with the `MISSING` keyword is really warranted. So I did NOT add a note about to the user's guide. Do you think I should?

- [x] Do these changes include sufficient testing updates? **[Yes]**
I updated the existing `unit_gen_ens_prod.xml` file. It includes 3 references to a `gep3` file that does NOT actually exist. I increased the verbosity level to 3 for all these runs and updated those 3 references to:
1. `MISSING`
2. `MISSING/&DATA_DIR_MODEL;/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib`
3. `&DATA_DIR_MODEL;/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib`

The first 2 should produce a DEBUG(3) log message and the 3rd should still produce a warning message.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.
I will change the log output from METplus ensemble use cases, but not the actual output.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:
This PR passed the SonarQube quality gate check.

- [x] Please complete this pull request review by **[Fri 5/3/24]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **MET-X.Y.Z Development** project for official releases
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
