### PR TITLE
Bugfix #2841 main_v11.1 tang_rad_winds

### DIFF
--- a/docs/Users_Guide/tc-diag.rst
+++ b/docs/Users_Guide/tc-diag.rst
@@ -24,7 +24,7 @@ Originally developed for the Statistical Hurricane Intensity Prediction Scheme (
 
 TC-Diag is run once for each initialization time to produce diagnostics for each user-specified combination of TC tracks and model fields. The user provides track data (such as one or more ATCF a-deck track files), along with track filtering criteria as needed, to select one or more tracks to be processed. The user also provides gridded model data from which diagnostics should be computed. Gridded data can be provided for multiple concurrent storms, multiple models, and/or multiple domains (i.e. parent and nest) in a single run.
 
-TC-Diag first determines the list of valid times that appear in any one of the tracks. For each valid time, it processes all track points for that time. For each track point, it reads the gridded model fields requested in the configuration file and transforms the gridded data to a range-azimuth cylindrical coordinates grid. For each domain, it writes the range-azimuth data to a temporary NetCDF file.
+TC-Diag first determines the list of valid times that appear in any one of the tracks. For each valid time, it processes all track points for that time. For each track point, it reads the gridded model fields requested in the configuration file and transforms the gridded data to a range-azimuth cylindrical coordinates grid, as described for the TC-RMW tool in :numref:`tc-rmw`. For each domain, it writes the range-azimuth data to a temporary NetCDF file.
 
 .. note:: The current version of the tool does not yet include the capabilities described in the next three paragraphs. These additional capabilities are planned to be added in the MET v12.0.0 release later in 2023.
 

--- a/docs/Users_Guide/tc-rmw.rst
+++ b/docs/Users_Guide/tc-rmw.rst
@@ -7,7 +7,7 @@ TC-RMW Tool
 Introduction
 ============
 
-The TC-RMW tool regrids tropical cyclone model data onto a moving range-azimuth grid centered on points along the storm track provided in ATCF format, most likely the adeck generated from the file. The radial grid spacing may be set as a factor of the radius of maximum winds (RMW). If wind fields are specified in the configuration file the radial and tangential wind components will be computed. Any regridding method available in MET can be used to interpolate data on the model output grid to the specified range-azimuth grid. The regridding will be done separately on each vertical level. The model data files must coincide with track points in a user provided ATCF formatted track file.
+The TC-RMW tool regrids tropical cyclone model data onto a moving range-azimuth grid centered on points along the storm track provided in ATCF format, most likely the adeck generated from the file. The radial grid spacing can be defined in kilometers or as a factor of the radius of maximum winds (RMW). The azimuthal grid spacing is defined in degrees clockwise from due east. If wind vector fields are specified in the configuration file the radial and tangential wind components will be computed. Any regridding method available in MET can be used to interpolate data on the model output grid to the specified range-azimuth grid. The regridding will be done separately on each vertical level. The model data files must coincide with track points in a user provided ATCF formatted track file.
 
 Practical information
 =====================

--- a/src/libcode/vx_grid/earth_rotation.cc
+++ b/src/libcode/vx_grid/earth_rotation.cc
@@ -179,7 +179,13 @@ M23 =  clat*clon;
 M33 =  slat;
 */
 
-set_np(lat_center, lon_center, lon_center - 180.0);
+   //
+   // MET #2841 define the rotation by subtracting 90 degrees
+   // instead of 180 to define TCRMW grids as pointing east
+   // instead of north.
+   // 
+
+set_np(lat_center, lon_center, lon_center - 90.0);
 
    //
    //

--- a/src/libcode/vx_grid/tcrmw_grid.cc
+++ b/src/libcode/vx_grid/tcrmw_grid.cc
@@ -288,6 +288,7 @@ y = (lat_rot - RData.rot_lat_ll)/(RData.delta_rot_lat);
 
 x = lon_rot/(RData.delta_rot_lon);
 
+x = Nx - x; // MET #2841 switch from counterclockwise to clockwise
 
 RotatedLatLonGrid::xy_to_latlon(x, y, lat, lon);
 
@@ -309,6 +310,8 @@ double x, y;
 const double range_max_deg = deg_per_km*Range_max_km;
 
 RotatedLatLonGrid::latlon_to_xy(lat, lon, x, y);
+
+x = Nx - x; // MET #2841 switch from counterclockwise to clockwise
 
 azi_deg = x*(RData.delta_rot_lon);
 
@@ -378,6 +381,8 @@ RotatedLatLonGrid::latlon_to_xy(true_lat, true_lon, x, y);
 
 x -= Nx*floor(x/Nx);
 
+x = Nx - x; // MET #2841 switch from counterclockwise to clockwise
+
 y -= Ny*floor(y/Ny);
 
 return;
@@ -393,6 +398,8 @@ void TcrmwGrid::xy_to_latlon(double x, double y, double & true_lat, double & tru
 {
 
 x -= Nx*floor(x/Nx);
+
+x = Nx - x; // MET #2841 switch from counterclockwise to clockwise
 
 y -= Ny*floor(y/Ny);
 

--- a/src/libcode/vx_grid/tcrmw_grid.cc
+++ b/src/libcode/vx_grid/tcrmw_grid.cc
@@ -378,7 +378,7 @@ RotatedLatLonGrid::latlon_to_xy(true_lat, true_lon, x, y);
 
 x -= Nx*floor(x/Nx);
 
-x -= Nx*floor(x/Nx);
+y -= Ny*floor(y/Ny);
 
 return;
 
@@ -394,7 +394,7 @@ void TcrmwGrid::xy_to_latlon(double x, double y, double & true_lat, double & tru
 
 x -= Nx*floor(x/Nx);
 
-x -= Nx*floor(x/Nx);
+y -= Ny*floor(y/Ny);
 
 RotatedLatLonGrid::xy_to_latlon(x, y, true_lat, true_lon);
 

--- a/src/libcode/vx_grid/tcrmw_grid.cc
+++ b/src/libcode/vx_grid/tcrmw_grid.cc
@@ -334,7 +334,6 @@ Vector E, N, V;
 Vector B_range, B_azi;
 double azi_deg, range_deg, range_km;
 
-
 latlon_to_range_azi(lat, lon, range_km, azi_deg);
 
 range_deg = deg_per_km*range_km;
@@ -344,18 +343,28 @@ N = latlon_to_north (lat, lon);
 
 V = east_component*E + north_component*N;
 
-
 range_azi_to_basis(range_deg, azi_deg, B_range, B_azi);
 
-
-
-   radial_component = dot(V, B_range);
+radial_component = dot(V, B_range);
 
 azimuthal_component = dot(V, B_azi);
 
+/* JHG From diapost.F90
+         xxx = wcos(icen(k),jcen(k))
+         yyy = wsin(icen(k),jcen(k))
+         IF (  xxx > sqrt2_ ) THEN
+            alfa = Asin(yyy)
+         ELSEIF (  xxx  < -sqrt2_ ) THEN
+            alfa = pi_cnst*Sign(1.,yyy) - Asin(yyy)
+         ELSE ! ( |xxx| <= sqrt2_ ) !
+            alfa = Acos(xxx)*Sign(1.,yyy)
+         ENDIF !* SOUTH-POLAR PROJECTION
+          phi = pi3_2 - alfa - i*dphi
+         rcos = cos(phi) ; rsin = sin(phi)
 
-
-
+             wks(i,j,21) =   rcos*uur + rsin*vvr !*   radial   wind
+             wks(i,j,22) = - rsin*uur + rcos*vvr !* tangential wind
+*/
 
 return;
 
@@ -387,17 +396,13 @@ void TcrmwGrid::range_azi_to_basis(const double range_deg, const double azi_deg,
 
 double u, v, w;
 
-
 u =  cosd(range_deg)*sind(azi_deg);
 
 v =  cosd(range_deg)*cosd(azi_deg);
 
 w = -sind(range_deg);
 
-
-
 B_range = u*Ir + v*Jr + w*Kr;
-
 
 u =  cosd(azi_deg);
 
@@ -405,9 +410,7 @@ v = -sind(azi_deg);
 
 w =  0.0;
 
-
 B_azi = u*Ir + v*Jr + w*Kr;
-
 
 return;
 
@@ -426,7 +429,6 @@ RotatedLatLonGrid::latlon_to_xy(true_lat, true_lon, x, y);
 x -= Nx*floor(x/Nx);
 
 x -= Nx*floor(x/Nx);
-
 
 return;
 
@@ -499,8 +501,4 @@ return;
 
 
 ////////////////////////////////////////////////////////////////////////
-
-
-
-
 

--- a/src/libcode/vx_grid/tcrmw_grid.cc
+++ b/src/libcode/vx_grid/tcrmw_grid.cc
@@ -324,93 +324,43 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void TcrmwGrid::wind_ne_to_ra (const double lat, const double lon, 
-                               const double east_component, const double north_component,
-                               double & radial_component,   double & azimuthal_component) const
+void TcrmwGrid::wind_ne_to_rt (const double azi_deg,
+                               const double u_wind, const double v_wind,
+                               double & radial_wind, double & tangential_wind) const
 
 {
 
-Vector E, N, V;
-Vector B_range, B_azi;
-double azi_deg, range_deg, range_km;
+double rcos = cosd(azi_deg);
+double rsin = sind(azi_deg);
+
+if (is_bad_data(u_wind) || is_bad_data(v_wind)) {
+   radial_wind     = bad_data_double;
+   tangential_wind = bad_data_double;   
+}
+else {
+   radial_wind     =      rcos*u_wind + rsin*v_wind;
+   tangential_wind = -1.0*rsin*u_wind + rcos*v_wind;
+}
+
+return;
+
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+void TcrmwGrid::wind_ne_to_rt (const double lat, const double lon, 
+                               const double u_wind, const double v_wind,
+                               double & radial_wind, double & tangential_wind) const
+
+{
+
+double range_km, azi_deg;
 
 latlon_to_range_azi(lat, lon, range_km, azi_deg);
 
-range_deg = deg_per_km*range_km;
-
-E = latlon_to_east  (lat, lon);
-N = latlon_to_north (lat, lon);
-
-V = east_component*E + north_component*N;
-
-range_azi_to_basis(range_deg, azi_deg, B_range, B_azi);
-
-radial_component = dot(V, B_range);
-
-azimuthal_component = dot(V, B_azi);
-
-/* JHG From diapost.F90
-         xxx = wcos(icen(k),jcen(k))
-         yyy = wsin(icen(k),jcen(k))
-         IF (  xxx > sqrt2_ ) THEN
-            alfa = Asin(yyy)
-         ELSEIF (  xxx  < -sqrt2_ ) THEN
-            alfa = pi_cnst*Sign(1.,yyy) - Asin(yyy)
-         ELSE ! ( |xxx| <= sqrt2_ ) !
-            alfa = Acos(xxx)*Sign(1.,yyy)
-         ENDIF !* SOUTH-POLAR PROJECTION
-          phi = pi3_2 - alfa - i*dphi
-         rcos = cos(phi) ; rsin = sin(phi)
-
-             wks(i,j,21) =   rcos*uur + rsin*vvr !*   radial   wind
-             wks(i,j,22) = - rsin*uur + rcos*vvr !* tangential wind
-*/
-
-return;
-
-}
-
-
-////////////////////////////////////////////////////////////////////////
-
-
-void TcrmwGrid::wind_ne_to_ra_conventional (const double lat, const double lon, 
-                                            const double east_component, const double north_component,
-                                            double & radial_component,   double & azimuthal_component) const
-
-{
-
-wind_ne_to_ra(lat, lon, east_component, north_component, radial_component, azimuthal_component);
-
-return;
-
-}
-
-
-////////////////////////////////////////////////////////////////////////
-
-
-void TcrmwGrid::range_azi_to_basis(const double range_deg, const double azi_deg, Vector & B_range, Vector & B_azi) const
-
-{
-
-double u, v, w;
-
-u =  cosd(range_deg)*sind(azi_deg);
-
-v =  cosd(range_deg)*cosd(azi_deg);
-
-w = -sind(range_deg);
-
-B_range = u*Ir + v*Jr + w*Kr;
-
-u =  cosd(azi_deg);
-
-v = -sind(azi_deg);
-
-w =  0.0;
-
-B_azi = u*Ir + v*Jr + w*Kr;
+wind_ne_to_rt(azi_deg, u_wind, v_wind, radial_wind, tangential_wind);
 
 return;
 

--- a/src/libcode/vx_grid/tcrmw_grid.cc
+++ b/src/libcode/vx_grid/tcrmw_grid.cc
@@ -136,7 +136,7 @@ Ir.set_xyz(1.0, 0.0, 0.0);
 Jr.set_xyz(0.0, 1.0, 0.0);
 Kr.set_xyz(0.0, 0.0, 1.0);
 
-Range_n  = 0;
+Range_n = 0;
 Azimuth_n = 0;
 
 Range_max_km = 0.0;

--- a/src/libcode/vx_grid/tcrmw_grid.h
+++ b/src/libcode/vx_grid/tcrmw_grid.h
@@ -89,12 +89,9 @@ class TcrmwGrid : public RotatedLatLonGrid {
 
       void xy_to_latlon(double x, double y, double & true_lat, double & true_lon) const;
 
-
-
       void wind_ne_to_ra(const double lat, const double lon, 
                          const double east_component, const double north_component, 
                          double & radial_component,   double & azimuthal_component) const;
-
 
          //
          //  possibly toggles the signs of the radial and/or azimuthal components

--- a/src/libcode/vx_grid/tcrmw_grid.h
+++ b/src/libcode/vx_grid/tcrmw_grid.h
@@ -35,10 +35,7 @@ class TcrmwGrid : public RotatedLatLonGrid {
 
       void calc_ijk();   //  calculate rotated basis vectors
 
-      void range_azi_to_basis(const double range_deg, const double azi_deg, Vector & B_range, Vector & B_azi) const;
-
       TcrmwData TData;
-
 
       Vector Ir, Jr, Kr;
 
@@ -89,20 +86,15 @@ class TcrmwGrid : public RotatedLatLonGrid {
 
       void xy_to_latlon(double x, double y, double & true_lat, double & true_lon) const;
 
-      void wind_ne_to_ra(const double lat, const double lon, 
-                         const double east_component, const double north_component, 
-                         double & radial_component,   double & azimuthal_component) const;
+      void wind_ne_to_rt(const double azi_deg,
+                         const double u_wind, const double v_wind, 
+                         double & radial_wind, double & tangential_wind) const;
 
-         //
-         //  possibly toggles the signs of the radial and/or azimuthal components
-         //
-         //      to align with the conventions used in the TC community
-         //
+      void wind_ne_to_rt(const double lat, const double lon, 
+                         const double u_wind, const double v_wind, 
+                         double & radial_wind, double & tangential_wind) const;
 
-      void wind_ne_to_ra_conventional (const double lat, const double lon, 
-                                       const double east_component, const double north_component, 
-                                       double & radial_component,   double & azimuthal_component) const;
-  
+
 };
 
 

--- a/src/libcode/vx_series_data/series_data.cc
+++ b/src/libcode/vx_series_data/series_data.cc
@@ -49,7 +49,7 @@ void get_series_entry(int i_series, VarInfo* data_info,
    if(!found) {
       mlog << Error << "\nget_series_entry() -> "
            << "Could not find data for " << data_info->magic_time_str()
-           << " in file list:\n:" << write_css(search_files) << "\n\n";
+           << " in file list:\n" << write_css(search_files) << "\n\n";
       exit(1);
    }
 

--- a/src/libcode/vx_tc_util/vx_tc_nc_util.cc
+++ b/src/libcode/vx_tc_util/vx_tc_nc_util.cc
@@ -158,6 +158,21 @@ void write_tc_rmw(NcFile* nc_out,
 
 ////////////////////////////////////////////////////////////////////////
 
+bool has_pressure_level(vector<string> levels) {
+
+    bool status = false;
+
+    for (int j = 0; j < levels.size(); j++) {
+        if (levels[j].substr(0, 1) == "P") {
+            status = true;
+	    break;
+        }
+    }
+
+    return status;
+}
+    
+////////////////////////////////////////////////////////////////////////
 
 set<string> get_pressure_level_strings(
     map<string, vector<string> > variable_levels) {
@@ -538,7 +553,7 @@ void def_tc_variables(NcFile* nc_out,
         string long_name = variable_long_names[i->first];
         string units = variable_units[i->first];
 
-        if (levels.size() > 1) {
+        if (has_pressure_level(levels)) {
             data_var = nc_out->addVar(
                 var_name, ncDouble, dims_3d);
             add_att(&data_var, "long_name", long_name);

--- a/src/libcode/vx_tc_util/vx_tc_nc_util.cc
+++ b/src/libcode/vx_tc_util/vx_tc_nc_util.cc
@@ -338,7 +338,7 @@ void def_tc_range_azimuth(NcFile* nc_out,
     add_att(&range_var, "_FillValue", bad_data_double);
 
     add_att(&azimuth_var, "long_name", "azimuth");
-    add_att(&azimuth_var, "units", "degrees_clockwise_from_north");
+    add_att(&azimuth_var, "units", "degrees_clockwise_from_east");
     add_att(&azimuth_var, "standard_name", "azimuth");
     add_att(&azimuth_var, "_FillValue", bad_data_double);
 

--- a/src/libcode/vx_tc_util/vx_tc_nc_util.cc
+++ b/src/libcode/vx_tc_util/vx_tc_nc_util.cc
@@ -165,7 +165,7 @@ bool has_pressure_level(vector<string> levels) {
     for (int j = 0; j < levels.size(); j++) {
         if (levels[j].substr(0, 1) == "P") {
             status = true;
-	    break;
+            break;
         }
     }
 

--- a/src/libcode/vx_tc_util/vx_tc_nc_util.h
+++ b/src/libcode/vx_tc_util/vx_tc_nc_util.h
@@ -35,6 +35,8 @@ extern void write_tc_track_point(netCDF::NcFile*,
 extern void write_tc_rmw(netCDF::NcFile*,
     const netCDF::NcDim&, const TrackInfo&);
 
+extern bool has_pressure_level(std::vector<std::string>);
+
 extern std::set<std::string> get_pressure_level_strings(
     std::map<std::string, std::vector<std::string> >);
 

--- a/src/tools/tc_utils/tc_diag/tc_diag.cc
+++ b/src/tools/tc_utils/tc_diag/tc_diag.cc
@@ -847,7 +847,7 @@ void compute_lat_lon(TcrmwGrid& grid,
             ia * grid.azimuth_delta_deg(),
             lat, lon);
          lat_arr[i] =  lat;
-         lon_arr[i] = -lon; // degrees east to west
+         lon_arr[i] = -lon; // degrees west to east
       }
    }
 

--- a/src/tools/tc_utils/tc_rmw/tc_rmw.cc
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw.cc
@@ -759,7 +759,7 @@ void process_fields(const TrackInfoArray& tracks) {
             }
 
             // Write data
-            if(variable_levels[data_info->name_attr()].size() > 1) {
+            if(has_pressure_level(variable_levels[data_info->name_attr()])) {
                 write_tc_pressure_level_data(nc_out, tcrmw_grid,
                     pressure_level_indices, data_info->level_attr(),
                     i_point, data_3d_vars[data_info->name_attr()], data_dp.data());

--- a/src/tools/tc_utils/tc_rmw/tc_rmw.cc
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw.cc
@@ -549,19 +549,19 @@ void set_out(const StringArray& a) {
 
 void setup_grid() {
 
-    grid_data.name = "TCRMW";
-    grid_data.range_n = conf_info.n_range;
-    grid_data.azimuth_n = conf_info.n_azimuth;
+    tcrmw_data.name = "TCRMW";
+    tcrmw_data.range_n = conf_info.n_range;
+    tcrmw_data.azimuth_n = conf_info.n_azimuth;
 
     // Define the maximum range in km based on the fixed increment 
     if(is_bad_data(conf_info.rmw_scale)) {
-        grid_data.range_max_km =
+        tcrmw_data.range_max_km =
             conf_info.delta_range_km *
             (conf_info.n_range - 1);
     }
 
-    tcrmw_grid.set_from_data(grid_data);
-    grid.set(grid_data);
+    tcrmw_grid.set_from_data(tcrmw_data);
+    grid_out.set(tcrmw_data);
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -648,8 +648,8 @@ void compute_lat_lon(TcrmwGrid& tcrmw_grid,
                 ir * tcrmw_grid.range_delta_km(),
                 ia * tcrmw_grid.azimuth_delta_deg(),
                 lat, lon);
-            lat_arr[i] = lat;
-            lon_arr[i] = -lon; // switch degrees west to east
+            lat_arr[i] =  lat;
+            lon_arr[i] = -lon; // degrees west to east
         }
     }
 }
@@ -690,12 +690,12 @@ void process_fields(const TrackInfoArray& tracks) {
              << point.lon() << ").\n";
 
         // Set grid center
-        grid_data.lat_center = point.lat();
-        grid_data.lon_center = -1.0*point.lon(); // internal sign change
+        tcrmw_data.lat_center = point.lat();
+        tcrmw_data.lon_center = -1.0*point.lon(); // internal sign change
 
         // Define the maximum range in km relative to the radius of maximum winds
         if(!is_bad_data(conf_info.rmw_scale)) {
-            grid_data.range_max_km =
+            tcrmw_data.range_max_km =
                 conf_info.rmw_scale *
                 point.mrd() * tc_km_per_nautical_miles *
                 (conf_info.n_range - 1);
@@ -703,9 +703,9 @@ void process_fields(const TrackInfoArray& tracks) {
 
         // Re-define the range/azimuth grid
         tcrmw_grid.clear();
-        tcrmw_grid.set_from_data(grid_data);
-        grid.clear();
-        grid.set(grid_data);
+        tcrmw_grid.set_from_data(tcrmw_data);
+        grid_out.clear();
+        grid_out.set(tcrmw_data);
 
         // Compute lat and lon coordinate arrays
         compute_lat_lon(tcrmw_grid, lat_arr, lon_arr);
@@ -733,12 +733,12 @@ void process_fields(const TrackInfoArray& tracks) {
             data_info->set_valid(valid_time);
 
             // Find data for this track point
-            get_series_entry(i_point, data_info, data_files, ftype, data_dp, latlon_arr);
+            get_series_entry(i_point, data_info, data_files, ftype, data_dp, grid_in);
 
             // Regrid data and log the range of values before and after
             double dmin, dmax, dmin_rgd, dmax_rgd;
             data_dp.data_range(dmin, dmax);
-            data_dp = met_regrid(data_dp, latlon_arr, grid, data_info->regrid());
+            data_dp = met_regrid(data_dp, grid_in, grid_out, data_info->regrid());
             data_dp.data_range(dmin_rgd, dmax_rgd);
 
             mlog << Debug(4) << data_info->magic_str()
@@ -747,7 +747,7 @@ void process_fields(const TrackInfoArray& tracks) {
 
             // if this is "U", setup everything for matching "V" and compute the radial/tangential
             if(wind_converter.compute_winds_if_input_is_u(i_point, sname, slevel, valid_time, data_files, ftype,
-                   latlon_arr, lat_arr, lon_arr, grid, data_dp, tcrmw_grid)) {
+                   grid_in, grid_out, data_dp, tcrmw_grid)) {
                 write_tc_pressure_level_data(nc_out, tcrmw_grid,
                     pressure_level_indices, data_info->level_attr(), i_point,
                     data_3d_vars[conf_info.radial_velocity_field_name.string()],

--- a/src/tools/tc_utils/tc_rmw/tc_rmw.h
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw.h
@@ -84,7 +84,6 @@ static TCRMWConfInfo conf_info;
 static GrdFileType   ftype;
 static TCRMW_WindConverter wind_converter;
 
-
 // Optional arguments
 static ConcatString out_dir;
 static ConcatString out_prefix;
@@ -136,19 +135,14 @@ static std::map<std::string, int> pressure_level_indices;
 //
 ////////////////////////////////////////////////////////////////////////
 
-static DataPlane dp;
-static Grid      latlon_arr;
-static TcrmwData grid_data;
+static Grid      grid_in;
+static TcrmwData tcrmw_data;
 static TcrmwGrid tcrmw_grid;
-static Grid      grid;
+static Grid      grid_out;
 
 // Grid coordinate arrays
 static double* lat_arr;
 static double* lon_arr;
-
-// Wind arrays
-/* static double* wind_r_arr; */
-/* static double* wind_t_arr; */
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/src/tools/tc_utils/tc_rmw/tc_rmw_wind_converter.cc
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw_wind_converter.cc
@@ -102,13 +102,16 @@ void TCRMW_WindConverter::init(const TCRMWConfInfo *conf) {
          << _conf->v_wind_field_name.string() << " has " << _vIndexMap.size() << " inputs\n";
     _computeWinds = false;
   }
-  map<string,int>::const_iterator iu, iv;
-  for (iu=_uIndexMap.begin(), iv=_vIndexMap.begin(); iu!=_uIndexMap.end(); ++iu, ++iv) {
-    if (iu->first != iv->first) {
-      mlog << Warning << "Ordering of u/v wind input levels not the same, "
-           << "not implemented, no wind conversions will be done:\n"
-           << "    " << iu->first  << " " << iv->first << "\n";
-      _computeWinds = false;
+  if (_computeWinds) {
+    map<string,int>::const_iterator iu, iv;
+    for (iu=_uIndexMap.begin(), iv=_vIndexMap.begin(); iu!=_uIndexMap.end(); ++iu, ++iv) {
+      if (iu->first != iv->first) {
+        mlog << Warning << "Ordering of u/v wind input levels not the same, "
+             << "not implemented, no wind conversions will be done:\n"
+             << "    " << iu->first  << " " << iv->first << "\n";
+        _computeWinds = false;
+        break;
+      }
     }
   }
 }

--- a/src/tools/tc_utils/tc_rmw/tc_rmw_wind_converter.cc
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw_wind_converter.cc
@@ -147,14 +147,14 @@ void TCRMW_WindConverter::append_nc_output_vars(map<string, vector<string> > &va
   }
   else {
     if (!_foundUInInput) {
-      mlog << Warning << "\nTCWRMW_WindConverter::checkInputs() -> "
+      mlog << Warning << "\nTCWRMW_WindConverter::append_nc_output_vars() -> "
            << "field not found in input \"" << _conf->u_wind_field_name << "\"\n\n";
     }
     if (!_foundVInInput) {
-      mlog << Warning << "\nTCWRMW_WindConverter::checkInputs() -> "
+      mlog << Warning << "\nTCWRMW_WindConverter::append_nc_output_vars() -> "
            << "field not found in input \"" << _conf->v_wind_field_name << "\"\n\n";
     }
-    mlog << Warning << "\nTCWRMW_WindConverter::checkInputs() -> "
+    mlog << Warning << "\nTCWRMW_WindConverter::append_nc_output_vars() -> "
          << "Not computing radial and tangential winds\n\n";
     _computeWinds = false;
   }

--- a/src/tools/tc_utils/tc_rmw/tc_rmw_wind_converter.h
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw_wind_converter.h
@@ -113,11 +113,9 @@ class TCRMW_WindConverter {
                                    unixtime valid_time,
                                    const StringArray &data_files,
                                    const GrdFileType &ftype,
-                                   const Grid &latlon_arr,
-                                   const double *lat_arr,
-                                   const double *lon_arr,
-                                   const Grid &grid,
-                                   const DataPlane &data_dp,
+                                   const Grid &grid_in,
+                                   const Grid &grid_out,
+                                   const DataPlane &u_wind_dp,
                                    const TcrmwGrid &tcrmw_grid);
 };
 

--- a/src/tools/tc_utils/tc_rmw/tc_rmw_wind_converter.h
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw_wind_converter.h
@@ -15,7 +15,7 @@
 //
 //   Mod#  Date      Name      Description
 //   ----  ----      ----      -----------
-//   000   05/11/22  DaveAlbo  New
+//   000   05/11/22  Albo      New
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -31,7 +31,6 @@
 
 using std::map;
 using std::string;
-
 
 ////////////////////////////////////////////////////////////////////////
 //
@@ -98,8 +97,8 @@ class TCRMW_WindConverter {
   // if configured to compute winds, but didn't find U or V, turn off
   // the wind computations and report an error
   void append_nc_output_vars(std::map<std::string, std::vector<std::string> > &variable_levels,
-			     std::map<std::string, std::string> &variable_long_names,
-			     std::map<std::string, std::string> &variable_units);
+                             std::map<std::string, std::string> &variable_long_names,
+                             std::map<std::string, std::string> &variable_units);
 
   // Check input varName against U, and if it's a match, lookup V using the
   // map members, and then compute tangential and radial winds if it is so
@@ -109,17 +108,17 @@ class TCRMW_WindConverter {
   // If true if returned, the winds can be accessed by calls to
   // get_wind_t_arr() and get_wind_r_arr()
   bool compute_winds_if_input_is_u(int i_point,
-				   const string &varName,
-				   const string &varLevel,
-				   unixtime valid_time,
-				   const StringArray &data_files,
-				   const GrdFileType &ftype,
-				   const Grid &latlon_arr,
-				   const double *lat_arr,
-				   const double *lon_arr,
-				   const Grid &grid,
-				   const DataPlane &data_dp,
-				   const TcrmwGrid &tcrmw_grid);
+                                   const string &varName,
+                                   const string &varLevel,
+                                   unixtime valid_time,
+                                   const StringArray &data_files,
+                                   const GrdFileType &ftype,
+                                   const Grid &latlon_arr,
+                                   const double *lat_arr,
+                                   const double *lon_arr,
+                                   const Grid &grid,
+                                   const DataPlane &data_dp,
+                                   const TcrmwGrid &tcrmw_grid);
 };
 
 


### PR DESCRIPTION
## Expected Differences ##

Please review this at the same time as PR #2921, to fix this in the `develop` branch.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Confirmed that the diffs flagged for this PR are limited to 4 output files from tc_rmw, rmw_analysis, and tc_diag:
```
file1: /data/output/met_test_truth/rmw_analysis/rmw_analysis_out.nc
file1: /data/output/met_test_truth/tc_diag/tc_diag_AL092022_GFSO_2022092400_cyl_grid_parent.nc
file1: /data/output/met_test_truth/tc_rmw/tc_rmw_hwrf_gonzalo.nc
file1: /data/output/met_test_truth/tc_rmw/tc_rmw_pressure_lev_out.nc
```
This ncview comparison of TC-RMW output for TMP/P500 shows that the diffs are caused by the intended 90 degree phase shift to the right.
![Screen Shot 2024-06-21 at 10 15 57 AM](https://github.com/dtcenter/MET/assets/21087144/684f15ca-c4c5-494d-a00d-d97a42a17707)

All of the gridded NetCDF differences show this 90 shift to the right.

I also reran the commands listed in this [issue comment](https://github.com/dtcenter/MET/issues/2841#issuecomment-2099155537), using this the PR version of tc_rmw (`/d1/projects/MET/MET_pull_requests/met-11.1.1/MET-bugfix_2841_main_v11.1_tang_rad_winds/bin/tc_rmw`). Here's the graphics to compare:

From HAFS plotting script:
![IDALIA10L 2023082918 HFSA storm azimuth_wind f000](https://github.com/dtcenter/MET/assets/21087144/d6f73c15-ebe0-4923-a73d-155dc45c9977)

And cross-sections of VR and VT from METplotpy:
![tcrmw_cross_section_VR](https://github.com/dtcenter/MET/assets/21087144/9b2eb861-8ba7-418f-bb55-a8db4a27c4de)
![tcrmw_cross_section_VT](https://github.com/dtcenter/MET/assets/21087144/56a9de82-819c-412e-9abd-576597ef0c54)

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Please find the code for testing on seneca in:
`/d1/projects/MET/MET_pull_requests/met-11.1.1/MET-bugfix_2841_main_v11.1_tang_rad_winds`

Note that the differences flagged in this [GHA run](https://github.com/dtcenter/MET/actions/runs/9605780846/job/26494695423) are confined to the output from TC-RMW, RMW-Analysis, and TC-Diag, as expected.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**
I updated the User's Guide for the MET-12.0.0 release, not this MET-11.1.1 bugfix release.

- [x] Do these changes include sufficient testing updates? **[Yes]**
No additional tests are needed.

- [x] Will this PR result in changes to the MET test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>
All output from TC-RMW and TC-Diag will be modified.

- [x] Will this PR result in changes to existing METplus Use Cases? **[Yes]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.
Any use cases that run TC-RMW and TC-Diag will be modified. However, METplus does NOT run tests using `main_v11.1` so no diffs will be flagged.

- [x] Do these changes introduce new SonarQube findings? **[???]**</br>
If **yes**, please describe:
Unknown

- [x] Please complete this pull request review by **[Fri 6/21/24]**.</br>
This needs to be included in the MET-11.1.1 bugfix release, slated for Friday 6/21/24.

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **MET-X.Y.Z Development** project for official releases
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
