### PR TITLE
Bugfix 2936 point2grid gfs

### DIFF
--- a/internal/test_unit/config/Point2GridConfig_SST
+++ b/internal/test_unit/config/Point2GridConfig_SST
@@ -1,0 +1,7 @@
+file_type      = NETCDF_NCCF;
+
+var_name_map = [
+  { key = "lat_vname";     val = "yh"; },
+  { key = "lon_vname";     val = "xh"; }
+];
+

--- a/internal/test_unit/xml/unit_point2grid.xml
+++ b/internal/test_unit/xml/unit_point2grid.xml
@@ -284,26 +284,6 @@
     </output>
   </test>
 
-<!--
-  <test name="point2grid_tripolar_gfs_ocean">
-    <exec>&MET_BIN;/point2grid</exec>
-    <env>
-      <pair><name>MET_TMP_DIR</name>  <value>&OUTPUT_DIR;/point2grid</value></pair>
-    </env>
-    <param> \
-      &DATA_DIR_OBS;/point_obs/gfs.ocean.t00z.6hr_avg.f006_SST.nc \
-      "latlon 360 180 -90 -180 1.0 1.0" \
-      &OUTPUT_DIR;/point2grid/point2grid_gfs_ocean_SST.nc \
-      -field 'name="SST"; level="(0,*,*)";' \
-      -config &CONFIG_DIR;/Point2GridConfig_SST \
-      -v 1
-    </param>
-    <output>
-      <grid_nc>&OUTPUT_DIR;/point2grid/point2grid_gfs_ocean_SST.nc</grid_nc>
-    </output>
-  </test>
--->
-
   <test name="point2grid_tripolar_rtofs">
     <exec>&MET_BIN;/point2grid</exec>
     <env>
@@ -318,6 +298,24 @@
     </param>
     <output>
       <grid_nc>&OUTPUT_DIR;/point2grid/point2grid_rtofs_ice_coverage.nc</grid_nc>
+    </output>
+  </test>
+
+  <test name="point2grid_gfs_1D_lat_lon">
+    <exec>&MET_BIN;/point2grid</exec>
+    <env>
+      <pair><name>MET_TMP_DIR</name>  <value>&OUTPUT_DIR;/point2grid</value></pair>
+    </env>
+    <param> \
+      &DATA_DIR_OBS;/point_obs/gfs.ocean.t00z.6hr_avg.f006_SST.nc \
+      G231 \
+      &OUTPUT_DIR;/point2grid/point2grid_gfs.ocean.SST.nc \
+      -config &CONFIG_DIR;/Point2GridConfig_SST \
+      -field 'name="SST";  level="(0,*,*)";' \
+      -v 1
+    </param>
+    <output>
+      <grid_nc>&OUTPUT_DIR;/point2grid/point2grid_gfs.ocean.SST.nc</grid_nc>
     </output>
   </test>
 

--- a/src/tools/other/point2grid/point2grid.cc
+++ b/src/tools/other/point2grid/point2grid.cc
@@ -963,7 +963,7 @@ void process_point_met_data(MetPointData *met_point_obs, MetConfig &config, VarI
 
             var_index_array.add(idx);
             var_count++;
-            if (is_eq(obs_data->obs_vals[idx], 0.)) obs_count_zero_from++;
+            if (is_eq(obs_data->obs_vals[idx], (float)0.)) obs_count_zero_from++;
             else obs_count_non_zero_from++;
          }
       }


### PR DESCRIPTION
## Expected Differences ##

2D latitude and 2D longitude variables were expected to point2grid when the data variables are gridded data, The GFS3 input data has 1 D lat/lon variables. The mapping to the target cell was corrected with 1 dimensional lat/lon variables.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

This is the same command at unit test (at seneca): 
```
/d1/personal/hsoh/git/pull_request/MET_bugfix_2936_point2grid_gfs/bin/point2grid \
      /d1/projects/MET/MET_test_data/unit_test/obs_data/point_obs/gfs.ocean.t00z.6hr_avg.f006_SST.nc \
      G231 \
      point2grid_gfs.ocean.SST.nc \
      -config /d1/personal/hsoh/git/pull_request/MET_bugfix_2936_point2grid_gfs/internal/test_unit/config/Point2GridConfig_SST \
      -field 'name="SST";  level="(0,*,*)";' \
      -v 1
```

log message:
```
DEBUG 2: Range of data (name="SST"; level="(0,*,*)";)
DEBUG 2:        input: -1.906446934 to 32.41591644      regridded: -1.898247123 to 31.46335125.
```

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

NA. Please do test if you have other input data
The branch build is available at seneca:/d1/personal/hsoh/git/pull_request/MET_bugfix_2936_point2grid_gfs

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**

- [x] Do these changes include sufficient testing updates? **[Yes]**

One unit test is added

- [x] Will this PR result in changes to the MET test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

  One more output:
  - point2grid/point2grid_gfs.ocean.SST.nc


- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:

- [x] Please complete this pull request review by **[9/06/2024]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **MET-X.Y.Z Development** project for official releases
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
