### PR TITLE
Feature 2709 mvmode multithreshradii

### DIFF
--- a/data/table_files/Makefile.in
+++ b/data/table_files/Makefile.in
@@ -310,6 +310,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 tablefilesdir = $(pkgdatadir)/table_files
 tablefiles_DATA = \
+	met_header_columns_V12.1.txt \
 	met_header_columns_V12.0.txt \
 	met_header_columns_V11.1.txt \
 	met_header_columns_V11.0.txt \

--- a/docs/Users_Guide/mode.rst
+++ b/docs/Users_Guide/mode.rst
@@ -323,7 +323,7 @@ The **conv_radius** entry defines the radius of the circular convolution applied
 
 The **conv_thresh** entry specifies the threshold values to be applied to the convolved field to define objects. By default, objects are defined using a convolution threshold of 5.0. Multiple convolution thresholds may be specified as an array (e.g. **conv_thresh = [ >=5.0, >=10.0, >=15.0 ];)**.
 
-Multiple convolution radii and thresholds and processed using the logic defined by the **quilt** entry.  The logic specific to multivariate mode is described in the multivariate mode section above.
+Multiple convolution radii and thresholds are processed using the logic defined by the **quilt** entry.  The logic specific to multivariate mode is described in the multivariate mode section above.
 
 The **vld_thresh** entry must be set between 0 and 1. When performing the circular convolution step if the proportion of bad data values in the convolution area is greater than or equal to this threshold, the resulting convolved value will be bad data. If the proportion is less than this threshold, the convolution will be performed on only the valid data. By default, the **vld_thresh** is set to 0.5.
 

--- a/docs/Users_Guide/mode.rst
+++ b/docs/Users_Guide/mode.rst
@@ -121,6 +121,10 @@ When regridding to the FCST or OBS field (e.g. to_grid = FCST), the first field 
 
 "file_type" can be set independently for each input in multivariate mode. If not set for an input, MET uses file names and file content to determine the type.
 
+In multivariate mode, with quilt=**FALSE**, for all inputs the number of forecast and observation convolution radii and thresholds must all match. One configuration of MODE will be run for each group of settings in those lists.
+
+In multivariate mode, with quilt=**TRUE**, for all inputs the number of forecast and observation convolution radii must match and the number of forecast and observation convolution thresholds must match. When each input has N radii and M thresholds, NxM configurations of MODE will be run.
+
 When setting a threshold to a percentile, some choices require both an observation input and a forecast input.  When this is the case, it's assumed the indices match, so for example if forecast input 1 has such a percentile setting, then observation input 1 will be used to compute the percentile.  Percentiles in which this will happen are:
 
 * SFP in an observation input.
@@ -319,7 +323,7 @@ The **conv_radius** entry defines the radius of the circular convolution applied
 
 The **conv_thresh** entry specifies the threshold values to be applied to the convolved field to define objects. By default, objects are defined using a convolution threshold of 5.0. Multiple convolution thresholds may be specified as an array (e.g. **conv_thresh = [ >=5.0, >=10.0, >=15.0 ];)**.
 
-Multiple convolution radii and thresholds and processed using the logic defined by the **quilt** entry.
+Multiple convolution radii and thresholds and processed using the logic defined by the **quilt** entry.  The logic specific to multivariate mode is described in the multivariate mode section above.
 
 The **vld_thresh** entry must be set between 0 and 1. When performing the circular convolution step if the proportion of bad data values in the convolution area is greater than or equal to this threshold, the resulting convolved value will be bad data. If the proportion is less than this threshold, the convolution will be performed on only the valid data. By default, the **vld_thresh** is set to 0.5.
 

--- a/src/libcode/vx_shapedata/engine.cc
+++ b/src/libcode/vx_shapedata/engine.cc
@@ -602,7 +602,6 @@ void ModeFuzzyEngine::do_fcst_convolution() {
    if(!need_fcst_conv) return;
 
    r = conf_info.Fcst->conv_radius;
-
    *fcst_conv = *fcst_raw;
 
    mlog << Debug(3) << "Applying circular convolution of radius "
@@ -645,7 +644,6 @@ void ModeFuzzyEngine::do_obs_convolution() {
    if(!need_obs_conv) return;
 
    r = conf_info.Obs->conv_radius;
-
    *obs_conv = *obs_raw;
 
    mlog << Debug(3) << "Applying circular convolution of radius "

--- a/src/libcode/vx_shapedata/mode_conf_info.cc
+++ b/src/libcode/vx_shapedata/mode_conf_info.cc
@@ -1831,84 +1831,90 @@ void ModeConfInfo::check_multivar_not_implemented()
    }
 
    bool status = false;
-   // if (quilt) {
-   //    mlog << Error
-   //         << "\nModeConfInfo::check_multivar_not_implemented():\n"
-   //         << "  quilting not yet implemented for multivar mode\n\n";
-   //    status = true;
-   // }
+
+   // All inputs must have the same number of convolution radii
+   // All inputs must have the same number of convolution thresholds
+   // Without quilting, the radii/thresh array lengths must be the same
    
-   int nForFcst = 0;
-   int nForObs = 0;
+
+   int nRForFcst = 0;
+   int nRForObs = 0;
+   int nTForFcst = 0;
+   int nTForObs = 0;
    for (int i=0; i<N_fields_f; ++i) {
-      //if (data_type != ModeDataType::MvMode_Obs) {
-         if (fcst_array[i].merge_flag == MergeType::Both || fcst_array[i].merge_flag == MergeType::Engine)
-         {
+      if (fcst_array[i].merge_flag == MergeType::Both || fcst_array[i].merge_flag == MergeType::Engine)
+      {
+         mlog << Error
+              << "\nModeConfInfo::check_multivar_not_implemented():\n"
+              << "  merge_flag ENGINE or BOTH not implemented for multivariate mode\n\n";
+         status = true;
+      }
+      if (i == 0) {
+         nTForFcst = fcst_array[i].conv_thresh_array.n();
+         nRForFcst = fcst_array[i].conv_radius_array.n_elements();
+      }
+      int nti = fcst_array[i].conv_thresh_array.n();
+      int nri = fcst_array[i].conv_radius_array.n_elements();
+      if (nti != nTForFcst || nri != nRForFcst)  {
+         mlog << Error
+              << "\nModeConfInfo::check_multivar_not_implemented():\n"
+              << "  Unequal array lengths for conv_thresh or conv_radii not allowed in multivariate mode\n\n";
+         status = true;
+      }
+      if (fcst_array[i].merge_flag != MergeType::None) {
+         int nmi = fcst_array[i].merge_thresh_array.n();
+         if (nmi != nTForFcst) {
             mlog << Error
                  << "\nModeConfInfo::check_multivar_not_implemented():\n"
-                 << "  merge_flag ENGINE or BOTH not implemented for multivariate mode\n\n";
+                 << "  Unequal array lengths for merge_thresh not allowed in multivariate mode\n\n";
             status = true;
-         }
-         if (i == 0) {
-            nForFcst = fcst_array[i].conv_thresh_array.n();
-         }
-         int nti = fcst_array[i].conv_thresh_array.n();
-         int nri = fcst_array[i].conv_radius_array.n_elements();
-         if (nti != nForFcst || nri != nForFcst)  {
-            mlog << Error
-                 << "\nModeConfInfo::check_multivar_not_implemented():\n"
-                 << "  Unequal array lengths for conv_thresh or conv_radii not allowed in multivariate mode\n\n";
-            status = true;
-         }
-         if (fcst_array[i].merge_flag != MergeType::None) {
-            int nmi = fcst_array[i].merge_thresh_array.n();
-            if (nmi != nForFcst) {
-               mlog << Error
-                    << "\nModeConfInfo::check_multivar_not_implemented():\n"
-                    << "  Unequal array lengths for merge_thresh not allowed in multivariate mode\n\n";
-               status = true;
-            }               
-         }
+         }               
+      }
    }
    for (int i=0; i<N_fields_o; ++i) {
-      //if (data_type != ModeDataType::MvMode_Fcst) {
-         if (obs_array[i].merge_flag == MergeType::Both || obs_array[i].merge_flag == MergeType::Engine) {
+      if (obs_array[i].merge_flag == MergeType::Both || obs_array[i].merge_flag == MergeType::Engine) {
+         mlog << Error
+              << "\nModeConfInfo::check_multivar_not_implemented():\n"
+              << "  merge_flag ENGINE or BOTH not implemented for multivariate mode\n\n";
+         status = true;
+         break;
+      }
+      if (i == 0) {
+         nTForObs = obs_array[i].conv_thresh_array.n();
+         nRForObs = obs_array[i].conv_radius_array.n_elements();
+      }
+      int nti = obs_array[i].conv_thresh_array.n();
+      int nri = obs_array[i].conv_radius_array.n_elements();
+      if (nti != nTForObs || nri != nRForObs)  {
+         mlog << Error
+              << "\nModeConfInfo::check_multivar_not_implemented():\n"
+              << "  Unequal array lengths for conv_thresh or conv_radii not allowed in multivariate mode\n\n";
+         status = true;
+      }
+      if (obs_array[i].merge_flag != MergeType::None) {
+         int nmi = obs_array[i].merge_thresh_array.n();
+         if (nmi != nTForObs) {
             mlog << Error
                  << "\nModeConfInfo::check_multivar_not_implemented():\n"
-                 << "  merge_flag ENGINE or BOTH not implemented for multivariate mode\n\n";
+                 << "  Unequal array lengths for merge_thresh not allowed in multivariate mode\n\n";
             status = true;
-            break;
-         }
-         if (i == 0) {
-            nForObs = obs_array[i].conv_thresh_array.n();
-         }
-         int nti = obs_array[i].conv_thresh_array.n();
-         int nri = obs_array[i].conv_radius_array.n_elements();
-         if (nti != nForObs || nri != nForObs)  {
-            mlog << Error
-                 << "\nModeConfInfo::check_multivar_not_implemented():\n"
-                 << "  Unequal array lengths for conv_thresh or conv_radii not allowed in multivariate mode\n\n";
-            status = true;
-         }
-         if (obs_array[i].merge_flag != MergeType::None) {
-            int nmi = obs_array[i].merge_thresh_array.n();
-            if (nmi != nForObs) {
-               mlog << Error
-                    << "\nModeConfInfo::check_multivar_not_implemented():\n"
-                    << "  Unequal array lengths for merge_thresh not allowed in multivariate mode\n\n";
-               status = true;
-            }               
-         }
-         // if (obs_array[i].conv_thresh_array.n() > 1 || obs_array[i].merge_thresh_array.n() > 1) {
-         //    mlog << Error
-         //         << "\nModeConfInfo::check_multivar_not_implemented():\n"
-         //         << "  more than one conv_thresh or merge_thresh per input is not allowed in multivariate mode\n\n";
-         //    status = true;
-         // }
-         //}
+         }               
+      }
    }
 
-   if (!quilt && (nForObs != nForFcst)) {
+   if (nTForObs != nTForFcst) {
+      mlog << Error
+           << "\nModeConfInfo::check_multivar_not_implemented():\n"
+           << "  Obs convolution thresh/radius arrays must have the same number of elements as Fcst thresh/radius arrays\n\n";
+      status = true;
+   }      
+   if (nRForObs != nRForFcst) {
+      mlog << Error
+           << "\nModeConfInfo::check_multivar_not_implemented():\n"
+           << "  Obs convolution thresh/radius arrays must have the same number of elements as Fcst thresh/radius arrays\n\n";
+      status = true;
+   }      
+   if (!quilt && (nTForObs != nRForObs)) {
       mlog << Error
            << "\nModeConfInfo::check_multivar_not_implemented():\n"
            << "  Obs convolution thresh/radius arrays must have the same number of elements as Fcst thresh/radius arrays unless quilt=true\n\n";
@@ -1922,7 +1928,6 @@ void ModeConfInfo::check_multivar_not_implemented()
       exit ( 1 );
    }
 }
-
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/src/libcode/vx_shapedata/mode_conf_info.cc
+++ b/src/libcode/vx_shapedata/mode_conf_info.cc
@@ -1368,6 +1368,45 @@ void ModeConfInfo::set_conv_radius_by_index(int k)
 
 ////////////////////////////////////////////////////////////////////////
 
+void ModeConfInfo::set_obs_conv_radius_by_index(int k)
+
+{
+   // if (data_type != ModeDataType::MvMode_Obs) {
+   //    if ( (k < 0) || (k >= Fcst->conv_radius_array.n_elements()) )  {
+   //       mlog << Error 
+   //            << "\nModeConfInfo::set_conv_radius_by_index(int) -> "
+   //            << "range check error\n\n";
+   //       exit ( 1 );
+   //    }
+   //    Fcst->conv_radius =  Fcst->conv_radius_array[k];
+   // }
+   // if (data_type != ModeDataType::MvMode_Fcst) {
+   if ( (k < 0) || (k >= Obs->conv_radius_array.n_elements()) )  {
+      mlog << Error 
+           << "\nModeConfInfo::set_conv_radius_by_index(int) -> "
+           << "range check error\n\n";
+      exit ( 1 );
+   }
+   Obs->conv_radius = Obs->conv_radius_array[k];
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+void ModeConfInfo::set_fcst_conv_radius_by_index(int k)
+
+{
+   if ( (k < 0) || (k >= Fcst->conv_radius_array.n_elements()) )  {
+      mlog << Error 
+           << "\nModeConfInfo::set_conv_radius_by_index(int) -> "
+           << "range check error\n\n";
+      exit ( 1 );
+   }
+   Fcst->conv_radius =  Fcst->conv_radius_array[k];
+}
+
+////////////////////////////////////////////////////////////////////////
+
 
 void ModeConfInfo::set_conv_thresh(SingleThresh s)
 {
@@ -1381,6 +1420,21 @@ void ModeConfInfo::set_conv_thresh(SingleThresh s)
 
 ////////////////////////////////////////////////////////////////////////
 
+
+void ModeConfInfo::set_fcst_conv_thresh(SingleThresh s)
+{
+   Fcst->conv_thresh = s;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void ModeConfInfo::set_obs_conv_thresh(SingleThresh s)
+{
+   Obs->conv_thresh =  s;
+}
+
+////////////////////////////////////////////////////////////////////////
+
 void ModeConfInfo::set_conv_radius(int r)
 {
    if (data_type != ModeDataType::MvMode_Obs) {
@@ -1389,6 +1443,20 @@ void ModeConfInfo::set_conv_radius(int r)
    if (data_type != ModeDataType::MvMode_Fcst) {
       Obs->conv_radius = r;
    }
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void ModeConfInfo::set_fcst_conv_radius(int r)
+{
+   Fcst->conv_radius = r;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void ModeConfInfo::set_obs_conv_radius(int r)
+{
+   Obs->conv_radius = r;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1416,6 +1484,37 @@ void ModeConfInfo::set_conv_thresh_by_index(int k)
       Fcst->conv_thresh = Fcst->conv_thresh_array[k];
    }
    return;
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+void ModeConfInfo::set_obs_conv_thresh_by_index(int k)
+
+{
+   if ( (k < 0) || (k >= Obs->conv_thresh_array.n_elements()) )  {
+      mlog << Error 
+           << "\nModeConfInfo::set_conv_thresh_by_index(int) -> "
+           << "range check error\n\n";
+      exit ( 1 );
+   }
+   Obs->conv_thresh =  Obs->conv_thresh_array[k];
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+void ModeConfInfo::set_fcst_conv_thresh_by_index(int k)
+
+{
+   if ( (k < 0) || (k >= Fcst->conv_thresh_array.n_elements()) )  {
+      
+      mlog << Error 
+           << "\nModeConfInfo::set_conv_thresh_by_index(int) -> "
+           << "range check error\n\n";
+      exit ( 1 );
+   }
+   Fcst->conv_thresh = Fcst->conv_thresh_array[k];
 }
 
 
@@ -1732,15 +1831,17 @@ void ModeConfInfo::check_multivar_not_implemented()
    }
 
    bool status = false;
-   if (quilt) {
-      mlog << Error
-           << "\nModeConfInfo::check_multivar_not_implemented():\n"
-           << "  quilting not yet implemented for multivar mode\n\n";
-      status = true;
-   }
+   // if (quilt) {
+   //    mlog << Error
+   //         << "\nModeConfInfo::check_multivar_not_implemented():\n"
+   //         << "  quilting not yet implemented for multivar mode\n\n";
+   //    status = true;
+   // }
    
+   int nForFcst = 0;
+   int nForObs = 0;
    for (int i=0; i<N_fields_f; ++i) {
-      if (data_type != ModeDataType::MvMode_Obs) {
+      //if (data_type != ModeDataType::MvMode_Obs) {
          if (fcst_array[i].merge_flag == MergeType::Both || fcst_array[i].merge_flag == MergeType::Engine)
          {
             mlog << Error
@@ -1748,16 +1849,29 @@ void ModeConfInfo::check_multivar_not_implemented()
                  << "  merge_flag ENGINE or BOTH not implemented for multivariate mode\n\n";
             status = true;
          }
-         if (fcst_array[i].conv_thresh_array.n() > 1 || fcst_array[i].merge_thresh_array.n() > 1) {
+         if (i == 0) {
+            nForFcst = fcst_array[i].conv_thresh_array.n();
+         }
+         int nti = fcst_array[i].conv_thresh_array.n();
+         int nri = fcst_array[i].conv_radius_array.n_elements();
+         if (nti != nForFcst || nri != nForFcst)  {
             mlog << Error
                  << "\nModeConfInfo::check_multivar_not_implemented():\n"
-                 << "  more than one conv_thresh or merge_thresh per input is not allowed in multivariate mode\n\n";
+                 << "  Unequal array lengths for conv_thresh or conv_radii not allowed in multivariate mode\n\n";
             status = true;
          }
-      }
+         if (fcst_array[i].merge_flag != MergeType::None) {
+            int nmi = fcst_array[i].merge_thresh_array.n();
+            if (nmi != nForFcst) {
+               mlog << Error
+                    << "\nModeConfInfo::check_multivar_not_implemented():\n"
+                    << "  Unequal array lengths for merge_thresh not allowed in multivariate mode\n\n";
+               status = true;
+            }               
+         }
    }
    for (int i=0; i<N_fields_o; ++i) {
-      if (data_type != ModeDataType::MvMode_Fcst) {
+      //if (data_type != ModeDataType::MvMode_Fcst) {
          if (obs_array[i].merge_flag == MergeType::Both || obs_array[i].merge_flag == MergeType::Engine) {
             mlog << Error
                  << "\nModeConfInfo::check_multivar_not_implemented():\n"
@@ -1765,13 +1879,40 @@ void ModeConfInfo::check_multivar_not_implemented()
             status = true;
             break;
          }
-         if (obs_array[i].conv_thresh_array.n() > 1 || obs_array[i].merge_thresh_array.n() > 1) {
+         if (i == 0) {
+            nForObs = obs_array[i].conv_thresh_array.n();
+         }
+         int nti = obs_array[i].conv_thresh_array.n();
+         int nri = obs_array[i].conv_radius_array.n_elements();
+         if (nti != nForObs || nri != nForObs)  {
             mlog << Error
                  << "\nModeConfInfo::check_multivar_not_implemented():\n"
-                 << "  more than one conv_thresh or merge_thresh per input is not allowed in multivariate mode\n\n";
+                 << "  Unequal array lengths for conv_thresh or conv_radii not allowed in multivariate mode\n\n";
             status = true;
          }
-      }
+         if (obs_array[i].merge_flag != MergeType::None) {
+            int nmi = obs_array[i].merge_thresh_array.n();
+            if (nmi != nForObs) {
+               mlog << Error
+                    << "\nModeConfInfo::check_multivar_not_implemented():\n"
+                    << "  Unequal array lengths for merge_thresh not allowed in multivariate mode\n\n";
+               status = true;
+            }               
+         }
+         // if (obs_array[i].conv_thresh_array.n() > 1 || obs_array[i].merge_thresh_array.n() > 1) {
+         //    mlog << Error
+         //         << "\nModeConfInfo::check_multivar_not_implemented():\n"
+         //         << "  more than one conv_thresh or merge_thresh per input is not allowed in multivariate mode\n\n";
+         //    status = true;
+         // }
+         //}
+   }
+
+   if (!quilt && (nForObs != nForFcst)) {
+      mlog << Error
+           << "\nModeConfInfo::check_multivar_not_implemented():\n"
+           << "  Obs convolution thresh/radius arrays must have the same number of elements as Fcst thresh/radius arrays unless quilt=true\n\n";
+      status = true;
    }
 
    if (status) {

--- a/src/libcode/vx_shapedata/mode_conf_info.cc
+++ b/src/libcode/vx_shapedata/mode_conf_info.cc
@@ -74,11 +74,11 @@ void ModeConfInfo::init_from_scratch()
    Field_Index_f = 0;
    Field_Index_o = 0;
 
-   fcst_array = 0;
-    obs_array = 0;
+   fcst_array = nullptr;
+    obs_array = nullptr;
 
-   fcst_array = 0;
-    obs_array = 0;
+   fcst_array = nullptr;
+    obs_array = nullptr;
 
    clear();
 
@@ -115,8 +115,8 @@ void ModeConfInfo::assign( const ModeConfInfo &m)
    complexity_ratio_wt = m.complexity_ratio_wt;
    inten_perc_ratio_wt = m.inten_perc_ratio_wt;
 
-   fcst_array = 0;
-   Fcst = 0;
+   fcst_array = nullptr;
+   Fcst = nullptr;
    if (N_fields_f > 0) {
       fcst_array = new Mode_Field_Info[N_fields_f];
       for (int i=0; i<N_fields_f; ++i)
@@ -125,8 +125,8 @@ void ModeConfInfo::assign( const ModeConfInfo &m)
       }
       Fcst = fcst_array + Field_Index_f;
    }
-   obs_array = 0;
-   Obs = 0;
+   obs_array = nullptr;
+   Obs = nullptr;
    if (N_fields_o > 0) {
       obs_array = new Mode_Field_Info[N_fields_o];
       for (int i=0; i<N_fields_o; ++i)
@@ -137,8 +137,7 @@ void ModeConfInfo::assign( const ModeConfInfo &m)
    }
 
    // need to be recomputed, maybe, so do so just in case
-   Dictionary * dict      = (Dictionary *) nullptr;
-   dict = conf.lookup_dictionary(conf_key_interest_function);
+   Dictionary * dict   = conf.lookup_dictionary(conf_key_interest_function);
    centroid_dist_if    = parse_interest_function(dict, conf_key_centroid_dist);
    boundary_dist_if    = parse_interest_function(dict, conf_key_boundary_dist);
    convex_hull_dist_if = parse_interest_function(dict, conf_key_convex_hull_dist);
@@ -260,11 +259,11 @@ void ModeConfInfo::clear()
    quilt = false;
 
    // Deallocate memory
-   if ( fcst_array )  { delete [] fcst_array;  fcst_array = 0; }
-   if (  obs_array )  { delete []  obs_array;   obs_array = 0; }
+   if ( fcst_array )  { delete [] fcst_array;  fcst_array = nullptr; }
+   if (  obs_array )  { delete []  obs_array;   obs_array = nullptr; }
 
-   Fcst = 0;
-    Obs = 0;
+   Fcst = nullptr;
+    Obs = nullptr;
 
    // so traditional mode will have the right value
    data_type = ModeDataType::Traditional;
@@ -308,7 +307,7 @@ void ModeConfInfo::process_config_traditional(GrdFileType ftype, GrdFileType oty
 
 void ModeConfInfo::process_config_except_fields()
 {
-   Dictionary * dict      = (Dictionary *) nullptr;
+   Dictionary * dict = nullptr;
 
       // Dump the contents of the config file
 
@@ -533,16 +532,11 @@ void ModeConfInfo::process_config_field(GrdFileType ftype, GrdFileType otype,
 void ModeConfInfo::process_config_both(GrdFileType ftype, GrdFileType otype,
                                        int field_index)
 {
-   int j, k, n;
-
-
-   Dictionary * fcst_dict = (Dictionary *) nullptr;
-   Dictionary * obs_dict  = (Dictionary *) nullptr;
 
       // Conf: fcst and obs
 
-   fcst_dict = conf.lookup_dictionary(conf_key_fcst);
-   obs_dict  = conf.lookup_dictionary(conf_key_obs);
+   Dictionary * fcst_dict = conf.lookup_dictionary(conf_key_fcst);
+   Dictionary * obs_dict  = conf.lookup_dictionary(conf_key_obs);
 
       // Conf: shift_right
 
@@ -606,11 +600,8 @@ void ModeConfInfo::process_config_both(GrdFileType ftype, GrdFileType otype,
 
 void ModeConfInfo::process_config_fcst(GrdFileType ftype, int field_index)
 {
-   int j, k, n;
 
-   Dictionary * fcst_dict = (Dictionary *) nullptr;
-
-   fcst_dict = conf.lookup_dictionary(conf_key_fcst);
+   Dictionary * fcst_dict = conf.lookup_dictionary(conf_key_fcst);
    shift_right = fcst_dict->lookup_int(conf_key_shift_right);
 
    if (field_index == 0) {
@@ -643,11 +634,8 @@ void ModeConfInfo::process_config_fcst(GrdFileType ftype, int field_index)
 
 void ModeConfInfo::process_config_obs(GrdFileType otype, int field_index)
 {
-   int j, k, n;
 
-   Dictionary * obs_dict  = (Dictionary *) nullptr;
-
-   obs_dict  = conf.lookup_dictionary(conf_key_obs);
+   Dicationary * obs_dict = conf.lookup_dictionary(conf_key_obs);
    shift_right = obs_dict->lookup_int(conf_key_shift_right);
 
    if (field_index == 0) {
@@ -688,7 +676,8 @@ void ModeConfInfo::config_set_all_percentile_thresholds(const std::vector<ModeIn
    // right now I simply go with frequency bias as highest priority
 
    // indices of forecast and obs inputs that have frequency bias percentile thresholding
-   vector<int> fcst_freq, obs_freq;
+   vector<int> fcst_freq;
+   vector<int> obs_freq;
 
    // indices (common to forecast and obs) that require both inputs (fcst and obs)
    // which is either frequency bias, or sample obs with a forecast input, or sample fcst
@@ -776,9 +765,8 @@ void ModeConfInfo::config_set_all_percentile_thresholds(const std::vector<ModeIn
    }
 
    // make sure no overlap in fcst/obs frequencies, as that's a no no
-   for (size_t i=0; i<fcst_freq.size(); ++i)
+   for (auto &findex : fcst_freq)
    {
-      int findex = fcst_freq[i];
       if (find(obs_freq.begin(), obs_freq.end(), findex) != obs_freq.end())
       {
          mlog << Error << "\nModeConfInfo::config_set_all_percentile_thresholds\n"
@@ -787,9 +775,8 @@ void ModeConfInfo::config_set_all_percentile_thresholds(const std::vector<ModeIn
          exit(1);
       }
    }
-   for (size_t i=0; i<obs_freq.size(); ++i)
+   for (auto &findex : obs_freq)
    {
-      int findex = obs_freq[i];
       if (find(fcst_freq.begin(), fcst_freq.end(), findex) != fcst_freq.end())
       {
          mlog << Error << "\nModeConfInfo::config_set_all_percentile_thresholds\n"
@@ -801,8 +788,7 @@ void ModeConfInfo::config_set_all_percentile_thresholds(const std::vector<ModeIn
 
    // now do all the indices with both, which come from FBIAS and SOP on forecasts
    // and SFP on obs  
-   for (size_t i=0; i<indices_with_both.size(); ++i) {
-      int index = indices_with_both[i];
+   for (auto &index : indices_with_both) {
       data_type = ModeDataType::MvMode_Both;
       set_field_index(index, index);
       set_perc_thresh(fdata[index]._dataPlane, odata[index]._dataPlane);
@@ -916,7 +902,7 @@ void ModeConfInfo::evaluate_obs_settings(int j)
 ////////////////////////////////////////////////////////////////////////
 
 
-void ModeConfInfo::read_fields_0 (Mode_Field_Info * & info_array, Dictionary * dict, GrdFileType type, char _fo)
+void ModeConfInfo::read_fields_0 (Mode_Field_Info * & info_array, Dictionary * dict, GrdFileType, char _fo)
 
 {
 
@@ -938,19 +924,19 @@ info_array = new Mode_Field_Info [N];
 
 if ( field->is_array() ) {
 
-   int j, k;
-   const DictionaryEntry * e = 0;
+   const DictionaryEntry * e = nullptr;
    const Dictionary & D = *field;
 
-   if (data_type == ModeDataType::Traditional) {
-      // traditional mode, extra test
-      if ( (N_fields_f > 0) && (N != N_fields_f) )  {
-         mlog << Error
-              << "\nModeConfInfo::read_fields() -> fcst and obs dictionaries have different number of entries in traditional mode"
-              << ", not allowed\n\n";
-         exit ( 1 );
+   // traditional mode, extra test
+   if ( (data_type == ModeDataType::Traditional) &&
+        (N_fields_f > 0) &&
+        (N != N_fields_f) )  {
+      mlog << Error
+           << "\nModeConfInfo::read_fields() -> fcst and obs dictionaries have different number of entries in traditional mode"
+           << ", not allowed\n\n";
+     
+      exit ( 1 );
 
-      }
    }
    
    if (_fo == 'F')  {
@@ -958,7 +944,7 @@ if ( field->is_array() ) {
    } else {
       N_fields_o = N;
    }
-   for (j=0; j<N; ++j)  {
+   for (int j=0; j<N; ++j)  {
 
       e = D[j];
 
@@ -1011,11 +997,9 @@ void ModeConfInfo::read_fields_1 (Mode_Field_Info * & info_array, Dictionary * d
 
 const Dictionary * field = ee->dict();
 
-const int N = ( (field->is_array()) ? (field->n_entries()) : 1 );
-
 if ( field->is_array() ) {
 
-   const DictionaryEntry * e = 0;
+   const DictionaryEntry * e = nullptr;
    const Dictionary & D = *field;
 
     e = D[field_index];
@@ -1175,7 +1159,8 @@ void ModeConfInfo::set_perc_thresh(const DataPlane &f_dp,
    //
    // Sort the input arrays
    //
-   NumArray fsort, osort;
+   NumArray fsort;
+   NumArray osort;
    int nxy = f_dp.nx() * f_dp.ny();
 
    fsort.extend(nxy);
@@ -1276,7 +1261,7 @@ void ModeConfInfo::parse_nc_info()
 
 {
 
-const DictionaryEntry * e = (const DictionaryEntry *) nullptr;
+const DictionaryEntry * e = nullptr;
 
 e = conf.lookup(conf_key_nc_pairs_flag);
 
@@ -1371,16 +1356,6 @@ void ModeConfInfo::set_conv_radius_by_index(int k)
 void ModeConfInfo::set_obs_conv_radius_by_index(int k)
 
 {
-   // if (data_type != ModeDataType::MvMode_Obs) {
-   //    if ( (k < 0) || (k >= Fcst->conv_radius_array.n_elements()) )  {
-   //       mlog << Error 
-   //            << "\nModeConfInfo::set_conv_radius_by_index(int) -> "
-   //            << "range check error\n\n";
-   //       exit ( 1 );
-   //    }
-   //    Fcst->conv_radius =  Fcst->conv_radius_array[k];
-   // }
-   // if (data_type != ModeDataType::MvMode_Fcst) {
    if ( (k < 0) || (k >= Obs->conv_radius_array.n_elements()) )  {
       mlog << Error 
            << "\nModeConfInfo::set_conv_radius_by_index(int) -> "
@@ -1522,11 +1497,11 @@ void ModeConfInfo::set_fcst_conv_thresh_by_index(int k)
 
 void ModeConfInfo::set_merge_thresh_by_index(int k)
 {
-   if (data_type != ModeDataType::MvMode_Fcst) {
-      if ( Obs->need_merge_thresh  () )  set_obs_merge_thresh_by_index  (k);
+   if ( data_type != ModeDataType::MvMode_Fcst &&
+        Obs->need_merge_thresh() ) set_obs_merge_thresh_by_index  (k);
    }
-   if (data_type != ModeDataType::MvMode_Obs) {
-         if ( Fcst->need_merge_thresh () )  set_fcst_merge_thresh_by_index (k);
+   if ( data_type != ModeDataType::MvMode_Obs &&
+        Fcst->need_merge_thresh() ) set_fcst_merge_thresh_by_index (k);
    }
 }   
 
@@ -1556,11 +1531,11 @@ void ModeConfInfo::set_fcst_merge_thresh_by_index(int k)
 
 void ModeConfInfo::set_conv_thresh_by_merge_index(int k)
 {
-   if (data_type != ModeDataType::MvMode_Fcst) {
-      if (Obs->need_merge_thresh()) set_obs_conv_thresh_by_merge_index (k);
+   if ( data_type != ModeDataType::MvMode_Fcst &&
+        Obs->need_merge_thresh() ) set_obs_conv_thresh_by_merge_index (k);
    }
-   if (data_type != ModeDataType::MvMode_Obs) {
-      if (Fcst->need_merge_thresh()) set_fcst_conv_thresh_by_merge_index (k);
+   if ( data_type != ModeDataType::MvMode_Obs &&
+        Fcst->need_merge_thresh() ) set_fcst_conv_thresh_by_merge_index (k);
    }
 }
 
@@ -1692,7 +1667,7 @@ GrdFileType ModeConfInfo::file_type_for_field(bool isFcst, int field_index)
    // look at the dictionary for the obs or forecast at index, with
    // parents
    
-   Dictionary * dict = (Dictionary *) nullptr;
+   Dictionary * dict = nullptr;
    if (isFcst) {
       dict = conf.lookup_dictionary(conf_key_fcst);
    } else {
@@ -1787,7 +1762,7 @@ void ModeConfInfo::get_multivar_programs()
 
 {
 
-Dictionary * dict = (Dictionary *) nullptr;
+Dictionary * dict = nullptr;
 
 fcst_multivar_logic.clear();
 obs_multivar_logic.clear();
@@ -1930,8 +1905,8 @@ void ModeConfInfo::check_multivar_not_implemented()
 
 PercThreshType ModeConfInfo::perctype(const Mode_Field_Info &f)  const
 {
-   PercThreshType pm=no_perc_thresh_type;;
-   PercThreshType pc=no_perc_thresh_type;;
+   PercThreshType pm=no_perc_thresh_type;
+   PercThreshType pc=no_perc_thresh_type;
    if  (f.merge_thresh_array.n() > 0) {
       pm = f.merge_thresh_array[0].get_ptype();
    }

--- a/src/libcode/vx_shapedata/mode_conf_info.cc
+++ b/src/libcode/vx_shapedata/mode_conf_info.cc
@@ -635,7 +635,7 @@ void ModeConfInfo::process_config_fcst(GrdFileType ftype, int field_index)
 void ModeConfInfo::process_config_obs(GrdFileType otype, int field_index)
 {
 
-   Dicationary * obs_dict = conf.lookup_dictionary(conf_key_obs);
+   Dictionary * obs_dict = conf.lookup_dictionary(conf_key_obs);
    shift_right = obs_dict->lookup_int(conf_key_shift_right);
 
    if (field_index == 0) {
@@ -765,7 +765,7 @@ void ModeConfInfo::config_set_all_percentile_thresholds(const std::vector<ModeIn
    }
 
    // make sure no overlap in fcst/obs frequencies, as that's a no no
-   for (auto &findex : fcst_freq)
+   for (const auto &findex : fcst_freq)
    {
       if (find(obs_freq.begin(), obs_freq.end(), findex) != obs_freq.end())
       {
@@ -775,7 +775,7 @@ void ModeConfInfo::config_set_all_percentile_thresholds(const std::vector<ModeIn
          exit(1);
       }
    }
-   for (auto &findex : obs_freq)
+   for (const auto &findex : obs_freq)
    {
       if (find(fcst_freq.begin(), fcst_freq.end(), findex) != fcst_freq.end())
       {
@@ -788,7 +788,7 @@ void ModeConfInfo::config_set_all_percentile_thresholds(const std::vector<ModeIn
 
    // now do all the indices with both, which come from FBIAS and SOP on forecasts
    // and SFP on obs  
-   for (auto &index : indices_with_both) {
+   for (const auto &index : indices_with_both) {
       data_type = ModeDataType::MvMode_Both;
       set_field_index(index, index);
       set_perc_thresh(fdata[index]._dataPlane, odata[index]._dataPlane);
@@ -1499,10 +1499,8 @@ void ModeConfInfo::set_merge_thresh_by_index(int k)
 {
    if ( data_type != ModeDataType::MvMode_Fcst &&
         Obs->need_merge_thresh() ) set_obs_merge_thresh_by_index  (k);
-   }
    if ( data_type != ModeDataType::MvMode_Obs &&
         Fcst->need_merge_thresh() ) set_fcst_merge_thresh_by_index (k);
-   }
 }   
 
 ////////////////////////////////////////////////////////////////////////
@@ -1533,10 +1531,8 @@ void ModeConfInfo::set_conv_thresh_by_merge_index(int k)
 {
    if ( data_type != ModeDataType::MvMode_Fcst &&
         Obs->need_merge_thresh() ) set_obs_conv_thresh_by_merge_index (k);
-   }
    if ( data_type != ModeDataType::MvMode_Obs &&
         Fcst->need_merge_thresh() ) set_fcst_conv_thresh_by_merge_index (k);
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/libcode/vx_shapedata/mode_conf_info.cc
+++ b/src/libcode/vx_shapedata/mode_conf_info.cc
@@ -1922,9 +1922,6 @@ void ModeConfInfo::check_multivar_not_implemented()
    }
 
    if (status) {
-      mlog << Error
-           << "\nModeConfInfo::check_multivar_not_implemented:\n"
-           << "  Some features not yet implemented in multivar mode\n\n";
       exit ( 1 );
    }
 }

--- a/src/libcode/vx_shapedata/mode_conf_info.h
+++ b/src/libcode/vx_shapedata/mode_conf_info.h
@@ -262,16 +262,29 @@ class ModeConfInfo {
 
       void parse_nc_info  ();
 
-      // might need addtional methods here for pass2 multivariate, if/when we allow more than 1 radius
       void set_conv_radius_by_index  (int);
-      // might need addtional methods here for pass2 multivariate, if/when we allow more than 1 thresh
+      void set_obs_conv_radius_by_index  (int);
+      void set_fcst_conv_radius_by_index  (int);
+
       void set_conv_thresh_by_index  (int);
+      void set_obs_conv_thresh_by_index  (int);
+      void set_fcst_conv_thresh_by_index  (int);
 
       void set_conv_thresh(SingleThresh);
+      void set_fcst_conv_thresh(SingleThresh);
+      void set_obs_conv_thresh(SingleThresh);
       void set_conv_radius(int);
+      void set_fcst_conv_radius(int);
+      void set_obs_conv_radius(int);
 
       int n_conv_threshs  () const;
       int n_conv_radii    () const;
+
+      int n_conv_threshs_fcst  () const;
+      int n_conv_radii_fcst    () const;
+
+      int n_conv_threshs_obs  () const;
+      int n_conv_radii_obs    () const;
 
       int n_runs() const;   //  # threshs times # radii
 
@@ -316,6 +329,7 @@ inline int ModeConfInfo::n_conv_radii() const
 {
    // this could break down if multivar mode relaxes
    // its limitations on number of radii (obs and fcst could be different)
+   // so far that is not the case.
    if (data_type == ModeDataType::MvMode_Obs)
    {
       return ( Obs->conv_radius_array.n_elements() );
@@ -324,16 +338,37 @@ inline int ModeConfInfo::n_conv_radii() const
    }
 }
 
+inline int ModeConfInfo::n_conv_radii_fcst() const
+{
+   return ( Fcst->conv_radius_array.n_elements() );
+}
+
+inline int ModeConfInfo::n_conv_radii_obs() const
+{
+   return ( Obs->conv_radius_array.n_elements() );
+}
+
 inline int ModeConfInfo::n_conv_threshs() const
 {
    // this could break down if multivar mode relaxes
    // its limitations on number of thresh (obs and fcst could be different)
+   // so far that is not the case.
    if (data_type == ModeDataType::MvMode_Obs)
    {
       return ( Obs->conv_thresh_array.n_elements() );
    } else {
       return ( Fcst->conv_thresh_array.n_elements() );
    }
+}
+
+inline int ModeConfInfo::n_conv_threshs_fcst() const
+{
+   return ( Fcst->conv_thresh_array.n_elements() );
+}
+
+inline int ModeConfInfo::n_conv_threshs_obs() const
+{
+   return ( Obs->conv_thresh_array.n_elements() );
 }
 
 inline int ModeConfInfo::get_compression_level() { return conf.nc_compression(); }

--- a/src/tools/core/mode/Makefile.am
+++ b/src/tools/core/mode/Makefile.am
@@ -22,6 +22,7 @@ mode_SOURCES = mode_usage.cc \
 	mode_ps_file.cc \
 	plot_engine.cc \
 	page_1.cc \
+	simple_objects.cc \
 	fcst_enlarge_page.cc \
 	obs_enlarge_page.cc \
 	cluster_page.cc \

--- a/src/tools/core/mode/Makefile.in
+++ b/src/tools/core/mode/Makefile.in
@@ -107,7 +107,7 @@ am_mode_OBJECTS = mode-mode_usage.$(OBJEXT) \
 	mode-mode.$(OBJEXT) mode-combine_boolplanes.$(OBJEXT) \
 	mode-objects_from_netcdf.$(OBJEXT) mode-mode_ps_file.$(OBJEXT) \
 	mode-plot_engine.$(OBJEXT) mode-page_1.$(OBJEXT) \
-	mode-fcst_enlarge_page.$(OBJEXT) \
+	mode-simple_objects.$(OBJEXT) mode-fcst_enlarge_page.$(OBJEXT) \
 	mode-obs_enlarge_page.$(OBJEXT) mode-cluster_page.$(OBJEXT) \
 	mode-overlap_page.$(OBJEXT) mode-mode_exec.$(OBJEXT)
 mode_OBJECTS = $(am_mode_OBJECTS)
@@ -145,7 +145,8 @@ am__depfiles_remade = ./$(DEPDIR)/mode-cluster_page.Po \
 	./$(DEPDIR)/mode-objects_from_netcdf.Po \
 	./$(DEPDIR)/mode-obs_enlarge_page.Po \
 	./$(DEPDIR)/mode-overlap_page.Po ./$(DEPDIR)/mode-page_1.Po \
-	./$(DEPDIR)/mode-plot_engine.Po
+	./$(DEPDIR)/mode-plot_engine.Po \
+	./$(DEPDIR)/mode-simple_objects.Po
 am__mv = mv -f
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -361,6 +362,7 @@ mode_SOURCES = mode_usage.cc \
 	mode_ps_file.cc \
 	plot_engine.cc \
 	page_1.cc \
+	simple_objects.cc \
 	fcst_enlarge_page.cc \
 	obs_enlarge_page.cc \
 	cluster_page.cc \
@@ -515,6 +517,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mode-overlap_page.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mode-page_1.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mode-plot_engine.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mode-simple_objects.Po@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
 	@$(MKDIR_P) $(@D)
@@ -689,6 +692,20 @@ mode-page_1.obj: page_1.cc
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='page_1.cc' object='mode-page_1.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(mode_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o mode-page_1.obj `if test -f 'page_1.cc'; then $(CYGPATH_W) 'page_1.cc'; else $(CYGPATH_W) '$(srcdir)/page_1.cc'; fi`
+
+mode-simple_objects.o: simple_objects.cc
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(mode_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT mode-simple_objects.o -MD -MP -MF $(DEPDIR)/mode-simple_objects.Tpo -c -o mode-simple_objects.o `test -f 'simple_objects.cc' || echo '$(srcdir)/'`simple_objects.cc
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/mode-simple_objects.Tpo $(DEPDIR)/mode-simple_objects.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='simple_objects.cc' object='mode-simple_objects.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(mode_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o mode-simple_objects.o `test -f 'simple_objects.cc' || echo '$(srcdir)/'`simple_objects.cc
+
+mode-simple_objects.obj: simple_objects.cc
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(mode_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT mode-simple_objects.obj -MD -MP -MF $(DEPDIR)/mode-simple_objects.Tpo -c -o mode-simple_objects.obj `if test -f 'simple_objects.cc'; then $(CYGPATH_W) 'simple_objects.cc'; else $(CYGPATH_W) '$(srcdir)/simple_objects.cc'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/mode-simple_objects.Tpo $(DEPDIR)/mode-simple_objects.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='simple_objects.cc' object='mode-simple_objects.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(mode_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o mode-simple_objects.obj `if test -f 'simple_objects.cc'; then $(CYGPATH_W) 'simple_objects.cc'; else $(CYGPATH_W) '$(srcdir)/simple_objects.cc'; fi`
 
 mode-fcst_enlarge_page.o: fcst_enlarge_page.cc
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(mode_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT mode-fcst_enlarge_page.o -MD -MP -MF $(DEPDIR)/mode-fcst_enlarge_page.Tpo -c -o mode-fcst_enlarge_page.o `test -f 'fcst_enlarge_page.cc' || echo '$(srcdir)/'`fcst_enlarge_page.cc
@@ -903,6 +920,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/mode-overlap_page.Po
 	-rm -f ./$(DEPDIR)/mode-page_1.Po
 	-rm -f ./$(DEPDIR)/mode-plot_engine.Po
+	-rm -f ./$(DEPDIR)/mode-simple_objects.Po
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -964,6 +982,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/mode-overlap_page.Po
 	-rm -f ./$(DEPDIR)/mode-page_1.Po
 	-rm -f ./$(DEPDIR)/mode-plot_engine.Po
+	-rm -f ./$(DEPDIR)/mode-simple_objects.Po
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/src/tools/core/mode/combine_boolplanes.cc
+++ b/src/tools/core/mode/combine_boolplanes.cc
@@ -23,6 +23,7 @@ using namespace std;
 //
 
 void combine_boolplanes(const string &name,
+                        int rIndex, int tIndex,
                         const BoolPlane * bpa, const int n_planes, 
                         BoolCalc & calc, 
                         BoolPlane & bp_out)
@@ -57,7 +58,7 @@ void combine_boolplanes(const string &name,
 
    }   //  for x
 
-   mlog << Debug(1) << name << " has " << nTrue << " superobject points.\n";
+   mlog << Debug(1) << name << " has " << nTrue << " superobject points.  rIndex[" << rIndex << "] tIndex[" << tIndex << "]\n";
 
    //
    //  done

--- a/src/tools/core/mode/combine_boolplanes.h
+++ b/src/tools/core/mode/combine_boolplanes.h
@@ -35,6 +35,7 @@
 
 
 extern void combine_boolplanes(const std::string &name,
+                               int rIndex, int tIndex,
                                const BoolPlane * array, const int n_planes, 
                                BoolCalc & calc, 
                                BoolPlane & bp_out);

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -203,7 +203,7 @@ void ModeExecutive::init_traditional(int n_files)
 ///////////////////////////////////////////////////////////////////////
 
 void ModeExecutive::init_multivar_simple(int rIndex, int tIndex,
-                                         int j, int n_files, ModeDataType dtype,
+                                         int j, ModeDataType dtype,
                                          const ModeConfInfo &conf)
 
 {
@@ -215,8 +215,6 @@ void ModeExecutive::init_multivar_simple(int rIndex, int tIndex,
    engine.set_data_type(dtype);
 
    engine.conf_info.set_field_index(j);
-
-   // engine.conf_info.nc_info.compress_level = engine.conf_info.get_compression_level();
 
    return;
 
@@ -238,8 +236,6 @@ void ModeExecutive::init_multivar_intensities(const ModeConfInfo &conf)
    // check one again for multivar problems
    engine.conf_info.check_multivar_not_implemented();
 
-   // engine.conf_info.nc_info.compress_level = engine.conf_info.get_compression_level();
-
    return;
 
 }
@@ -252,8 +248,10 @@ void ModeExecutive::setup_traditional_fcst_obs_data()
 
 {
 
-   // ShapeData fcst_sd, obs_sd;
-   double fmin, omin, fmax, omax;
+   double fmin;
+   double omin;
+   double fmax;
+   double omax;
 
    Fcst_sd.clear();
    Obs_sd.clear();
@@ -443,7 +441,8 @@ void ModeExecutive::setup_multivar_fcst_data(const Grid &verification_grid,
                                              const ModeInputData &input)
 {
 
-   double fmin, fmax;
+   double fmin;
+   double fmax;
 
    Fcst_sd.clear();
    Fcst_sd.data = input._dataPlane;
@@ -506,8 +505,8 @@ void ModeExecutive::setup_multivar_obs_data(const Grid &verification_grid,
                                             const ModeInputData &input)
 {
 
-   // ShapeData fcst_sd, obs_sd;
-   double omin, omax;
+   double omin;
+   double omax;
 
    Obs_sd.clear();
 
@@ -572,7 +571,10 @@ void ModeExecutive::setup_multivar_obs_data(const Grid &verification_grid,
 void ModeExecutive::setup_multivar_fcst_obs_data_intensities(const MultiVarData &mvdf,
                                                              const MultiVarData &mvdo)
 {
-   double fmin, fmax, omin, omax;
+   double fmin;
+   double fmax;
+   double omin;
+   double omax;
 
    bool simple = true;
    Fcst_sd = *(mvdf.shapedata_ptr(simple));
@@ -674,9 +676,11 @@ void ModeExecutive::setup_multivar_fcst_obs_data_super(const ShapeData &f_super,
                                                        const ShapeData &o_super,
                                                        const Grid &igrid)
 {
-   double fmin, omin, fmax, omax;
+   double fmin;
+   double omin;
+   double fmax;
+   double omax;
 
-   bool simple = true;
    Fcst_sd = f_super;
    Fcst_sd.debug_examine();
    Obs_sd = o_super;
@@ -816,7 +820,7 @@ void ModeExecutive::do_conv_thresh_traditional(const int r_index, const int t_in
 ///////////////////////////////////////////////////////////////////////
 
 void ModeExecutive::do_conv_thresh_multivar_super(int rIndexF, int tIndexF,
-                                                  int rIndexO, int tIndexO)
+                                                  int, int)
 {
 
    ModeConfInfo & conf = engine.conf_info;
@@ -828,10 +832,9 @@ void ModeExecutive::do_conv_thresh_multivar_super(int rIndexF, int tIndexF,
    conf.set_fcst_conv_thresh(s);
    conf.set_fcst_conv_radius(0.0);
    conf.set_fcst_merge_thresh(s);
-   //conf.set_fcst_merge_thresh_by_index(0);
    conf.set_obs_conv_thresh(s);
    conf.set_obs_conv_radius(0.0);
-   conf.set_obs_merge_thresh(s);//_by_index(0);
+   conf.set_obs_merge_thresh(s);
 
    //
    //  Set up the engine with these raw fields
@@ -903,7 +906,7 @@ void ModeExecutive::do_conv_thresh_multivar_intensity_compare(int rIndexF, int t
 
 ///////////////////////////////////////////////////////////////////////
 
-void ModeExecutive::do_conv_thresh_multivar_simple(Processing_t p, int rIndex, int tIndex)
+void ModeExecutive::do_conv_thresh_multivar_simple(Processing_t p, int rIndex, int)
 {
    ModeConfInfo & conf = engine.conf_info;
    bool obs = conf.data_type == ModeDataType::MvMode_Obs;
@@ -1072,7 +1075,8 @@ void ModeExecutive::process_masks(ShapeData & fcst_sd, ShapeData & obs_sd)
 
 {
 
-   ShapeData grid_mask_sd, poly_mask_sd;
+   ShapeData grid_mask_sd;
+   ShapeData poly_mask_sd;
    ConcatString name;
 
    mlog << Debug(2)
@@ -1129,7 +1133,8 @@ void ModeExecutive::process_fcst_masks(ShapeData & fcst_sd)
 
 {
 
-   ShapeData grid_mask_sd, poly_mask_sd;
+   ShapeData grid_mask_sd;
+   ShapeData poly_mask_sd;
    ConcatString name;
 
    mlog << Debug(3) << "Processing masking regions.\n";
@@ -1173,7 +1178,8 @@ void ModeExecutive::process_obs_masks(ShapeData & obs_sd)
 
 {
 
-   ShapeData grid_mask_sd, poly_mask_sd;
+   ShapeData grid_mask_sd;
+   ShapeData poly_mask_sd;
    ConcatString name;
 
    mlog << Debug(3) << "Processing masking regions.\n";
@@ -1287,21 +1293,22 @@ void ModeExecutive::process_output_multivar_intensity_compare(const MultiVarData
    double fmax = mvdf->_data_max;
    double omin = mvdo->_data_min;
    double omax = mvdo->_data_max;
-   double data_min, data_max;
-   if     (!is_bad_data(fmin) && !is_bad_data(omin)) data_min = min(fmin, omin);
-   else if(!is_bad_data(fmin) &&  is_bad_data(omin)) data_min = fmin;
-   else if( is_bad_data(fmin) && !is_bad_data(omin)) data_min = omin;
+   double dmin;
+   double dmax;
+   if     (!is_bad_data(fmin) && !is_bad_data(omin)) dmin = min(fmin, omin);
+   else if(!is_bad_data(fmin) &&  is_bad_data(omin)) dmin = fmin;
+   else if( is_bad_data(fmin) && !is_bad_data(omin)) dmin = omin;
 
-   if     (!is_bad_data(fmax) && !is_bad_data(omax)) data_max = max(fmax, omax);
-   else if(!is_bad_data(fmax) &&  is_bad_data(omax)) data_max = fmax;
-   else if( is_bad_data(fmax) && !is_bad_data(omax)) data_max = omax;
+   if     (!is_bad_data(fmax) && !is_bad_data(omax)) dmax = max(fmax, omax);
+   else if(!is_bad_data(fmax) &&  is_bad_data(omax)) dmax = fmax;
+   else if( is_bad_data(fmax) && !is_bad_data(omax)) dmax = omax;
          
    set_raw_to_full(mvdf->_simple->_raw_data,mvdo->_simple->_raw_data,
-                   mvdf->_nx, mvdf->_ny, data_min, data_max);
+                   mvdf->_nx, mvdf->_ny, dmin, dmax);
 
    write_obj_netcdf(engine.conf_info.nc_info);
 
-   if ( engine.conf_info.ps_plot_flag )   plot_engine();
+   if ( engine.conf_info.ps_plot_flag )  plot_engine();
 
    return;
 
@@ -1338,13 +1345,13 @@ void ModeExecutive::compute_ct_stats()
 
 {
 
-   int i, x, y;
-   ShapeData fcst_mask, obs_mask;
+   ShapeData fcst_mask;
+   ShapeData obs_mask;
 
    mlog << Debug(2)
         << "Computing contingency table statistics...\n";
 
-   for(i=0; i<n_cts; i++) {
+   for(int i=0; i<n_cts; i++) {
 
       cts[i].zero_out();
       cts[i].set_name(cts_str[i]);
@@ -1365,8 +1372,8 @@ void ModeExecutive::compute_ct_stats()
       }
 
       // Compute contingency table counts
-      for(x=0; x<fcst_mask.data.nx(); x++) {
-         for(y=0; y<fcst_mask.data.ny(); y++) {
+      for(int x=0; x<fcst_mask.data.nx(); x++) {
+         for(int y=0; y<fcst_mask.data.ny(); y++) {
 
             // Key off of the bad data values in the raw field
             if(engine.fcst_raw->is_bad_data(x, y) ||
@@ -1517,7 +1524,9 @@ void ModeExecutive::write_obj_stats()
 
 {
 
-   AsciiTable obj_at, fcst_merge_at, obs_merge_at;
+   AsciiTable obj_at;
+   AsciiTable fcst_merge_at;
+   AsciiTable obs_merge_at;
    ofstream out;
    ConcatString stat_file;
 
@@ -1703,45 +1712,44 @@ void ModeExecutive::write_obj_netcdf(const ModeNcOutInfo & info)
 
    if ( info.all_false() )  return;
 
-   int n, x, y;
    ConcatString out_file;
    ConcatString s;
    const ConcatString fcst_thresh = engine.conf_info.Fcst->conv_thresh.get_str(5);
    const ConcatString  obs_thresh = engine.conf_info.Obs->conv_thresh.get_str(5);
 
-   float *fcst_raw_data      = (float *) nullptr;
-   float *fcst_obj_raw_data  = (float *) nullptr;
-   int   *fcst_obj_data      = (int *)   nullptr;
-   int   *fcst_clus_data     = (int *)   nullptr;
+   float *fcst_raw_data      = nullptr;
+   float *fcst_obj_raw_data  = nullptr;
+   int   *fcst_obj_data      = nullptr;
+   int   *fcst_clus_data     = nullptr;
 
-   float *obs_raw_data       = (float *) nullptr;
-   float *obs_obj_raw_data   = (float *) nullptr;
-   int   *obs_obj_data       = (int *)   nullptr;
-   int   *obs_clus_data      = (int *)   nullptr;
+   float *obs_raw_data       = nullptr;
+   float *obs_obj_raw_data   = nullptr;
+   int   *obs_obj_data       = nullptr;
+   int   *obs_clus_data      = nullptr;
 
-   NcFile *f_out             = (NcFile *) nullptr;
+   NcFile *f_out             = nullptr;
 
-   NcDim  lat_dim           ;
-   NcDim  lon_dim           ;
+   NcDim  lat_dim;
+   NcDim  lon_dim;
 
-   NcDim  fcst_thresh_dim   ;
-   NcDim   obs_thresh_dim   ;
+   NcDim  fcst_thresh_dim;
+   NcDim   obs_thresh_dim;
 
-   NcVar  fcst_raw_var      ;
-   NcVar  fcst_obj_raw_var  ;
-   NcVar  fcst_obj_var      ;
-   NcVar  fcst_clus_var     ;
+   NcVar  fcst_raw_var;
+   NcVar  fcst_obj_raw_var;
+   NcVar  fcst_obj_var;
+   NcVar  fcst_clus_var;
 
-   NcVar  obs_raw_var       ;
-   NcVar  obs_obj_raw_var   ;
-   NcVar  obs_obj_var       ;
-   NcVar  obs_clus_var      ;
+   NcVar  obs_raw_var;
+   NcVar  obs_obj_raw_var;
+   NcVar  obs_obj_var;
+   NcVar  obs_clus_var;
 
-   NcVar  fcst_radius_var   ;
-   NcVar   obs_radius_var   ;
+   NcVar  fcst_radius_var;
+   NcVar   obs_radius_var;
 
-   NcVar  fcst_thresh_var   ;
-   NcVar   obs_thresh_var   ;
+   NcVar  fcst_thresh_var;
+   NcVar   obs_thresh_var;
 
    //
    // Create output NetCDF file name
@@ -1948,11 +1956,11 @@ void ModeExecutive::write_obj_netcdf(const ModeNcOutInfo & info)
 
    }
 
-   for(x=0; x<grid.nx(); x++) {
+   for(int x=0; x<grid.nx(); x++) {
 
-      for(y=0; y<grid.ny(); y++) {
+      for(int y=0; y<grid.ny(); y++) {
 
-         n = DefaultTO.two_to_one(grid.nx(), grid.ny(), x, y);
+         int n = DefaultTO.two_to_one(grid.nx(), grid.ny(), x, y);
 
          //
          // Get raw values and object ID's for each grid box
@@ -1962,14 +1970,14 @@ void ModeExecutive::write_obj_netcdf(const ModeNcOutInfo & info)
               fcst_raw_data != nullptr && obs_raw_data != nullptr &&
               engine.fcst_raw != nullptr && engine.obs_raw != nullptr  )  {
 
-            fcst_raw_data[n] = engine.fcst_raw->data (x, y);
-            obs_raw_data[n] = engine.obs_raw->data  (x, y);
+            fcst_raw_data[n] = (float) engine.fcst_raw->data (x, y);
+            obs_raw_data[n] = (float) engine.obs_raw->data  (x, y);
 
          }
 
          if(engine.fcst_split->is_nonzero(x, y) ) {
             if ( info.do_object_raw && fcst_obj_raw_data != nullptr && engine.fcst_raw != nullptr ) {
-               fcst_obj_raw_data[n] = engine.fcst_raw->data(x, y);
+               fcst_obj_raw_data[n] = (float) engine.fcst_raw->data(x, y);
             }
             if ( info.do_object_id && fcst_obj_data != nullptr && engine.fcst_split != nullptr ) {
                fcst_obj_data[n] = nint(engine.fcst_split->data(x, y));
@@ -1986,7 +1994,7 @@ void ModeExecutive::write_obj_netcdf(const ModeNcOutInfo & info)
 
          if(engine.obs_split->is_nonzero(x, y) ) {
             if ( info.do_object_raw && obs_obj_raw_data != nullptr ) {
-               obs_obj_raw_data[n] = engine.obs_raw->data(x, y);
+               obs_obj_raw_data[n] = (float) engine.obs_raw->data(x, y);
             }
             if ( info.do_object_id && obs_obj_data != nullptr ) {
                obs_obj_data[n] = nint(engine.obs_split->data(x, y));
@@ -2043,75 +2051,63 @@ void ModeExecutive::write_obj_netcdf(const ModeNcOutInfo & info)
    // Write the forecast and observation raw value variables
    //
 
-   if ( info.do_raw )  {
+   if( info.do_raw &&
+       (!put_nc_data_with_dims(&fcst_raw_var, &fcst_raw_data[0], grid.ny(), grid.nx()) ||
+        !put_nc_data_with_dims(&obs_raw_var, &obs_raw_data[0], grid.ny(), grid.nx())) ) {
 
-      if( !put_nc_data_with_dims(&fcst_raw_var, &fcst_raw_data[0], grid.ny(), grid.nx()) ||
-          !put_nc_data_with_dims(&obs_raw_var, &obs_raw_data[0], grid.ny(), grid.nx()) ) {
-
-         mlog << Error << "\nModeExecutive::write_obj_netcdf() -> "
-              << "error with the fcst_raw_var->put or obs_raw_var->put\n\n";
-         exit(1);
-      }
-
+      mlog << Error << "\nModeExecutive::write_obj_netcdf() -> "
+           << "error with the fcst_raw_var->put or obs_raw_var->put\n\n";
+      exit(1);
    }
 
-   if ( info.do_object_raw )  {
+   if ( info.do_object_raw && 
+       (!put_nc_data_with_dims(&fcst_obj_raw_var, &fcst_obj_raw_data[0], grid.ny(), grid.nx()) ||
+        !put_nc_data_with_dims(&obs_obj_raw_var, &obs_obj_raw_data[0], grid.ny(), grid.nx())) ) {
 
-      if( !put_nc_data_with_dims(&fcst_obj_raw_var, &fcst_obj_raw_data[0], grid.ny(), grid.nx()) ||
-          !put_nc_data_with_dims(&obs_obj_raw_var, &obs_obj_raw_data[0], grid.ny(), grid.nx()) ) {
-
-         mlog << Error << "\nModeExecutive::write_obj_netcdf() -> "
-              << "error with the fcst_obj_raw_var->put or obs_obj_raw_var->put\n\n";
-         exit(1);
-      }
-
+      mlog << Error << "\nModeExecutive::write_obj_netcdf() -> "
+           << "error with the fcst_obj_raw_var->put or obs_obj_raw_var->put\n\n";
+      exit(1);
    }
 
    //
    // Write the forecast and observation object ID variables
    //
 
-   if ( info.do_object_id )  {
+   if ( info.do_object_id &&
+       (!put_nc_data_with_dims(&fcst_obj_var, &fcst_obj_data[0], grid.ny(), grid.nx()) ||
+        !put_nc_data_with_dims(&obs_obj_var, &obs_obj_data[0], grid.ny(), grid.nx())) ) {
 
-      if( !put_nc_data_with_dims(&fcst_obj_var, &fcst_obj_data[0], grid.ny(), grid.nx()) ||
-          !put_nc_data_with_dims(&obs_obj_var, &obs_obj_data[0], grid.ny(), grid.nx()) ) {
-
-         mlog << Error << "\nModeExecutive::write_obj_netcdf() -> "
-              << "error with the fcst_obj_var->put or obs_obj_var->put\n\n";
-         exit(1);
-      }
-
+      mlog << Error << "\nModeExecutive::write_obj_netcdf() -> "
+           << "error with the fcst_obj_var->put or obs_obj_var->put\n\n";
+      exit(1);
    }
 
    //
    // Write the forecast and observation cluster object ID variables
    //
 
-   if ( info.do_cluster_id )  {
+   if ( info.do_cluster_id && 
+       (!put_nc_data_with_dims(&fcst_clus_var, &fcst_clus_data[0], grid.ny(), grid.nx()) ||
+        !put_nc_data_with_dims(&obs_clus_var, &obs_clus_data[0], grid.ny(), grid.nx())) ) {
 
-      if( !put_nc_data_with_dims(&fcst_clus_var, &fcst_clus_data[0], grid.ny(), grid.nx()) ||
-          !put_nc_data_with_dims(&obs_clus_var, &obs_clus_data[0], grid.ny(), grid.nx()) ) {
-
-         mlog << Error << "\nModeExecutive::write_obj_netcdf() -> "
-              << "error with the fcst_clus_var->put or obs_clus_var->put\n\n";
-         exit(1);
-      }
-
+      mlog << Error << "\nModeExecutive::write_obj_netcdf() -> "
+           << "error with the fcst_clus_var->put or obs_clus_var->put\n\n";
+      exit(1);
    }
 
    //
    // Delete allocated memory
    //
 
-   if (fcst_raw_data)      { delete [] fcst_raw_data;      fcst_raw_data     = (float *) nullptr; }
-   if (fcst_obj_raw_data)  { delete [] fcst_obj_raw_data;  fcst_obj_raw_data = (float *) nullptr; }
-   if (fcst_obj_data)      { delete [] fcst_obj_data;      fcst_obj_data     = (int *)   nullptr; }
-   if (fcst_clus_data)     { delete [] fcst_clus_data;     fcst_clus_data    = (int *)   nullptr; }
+   if (fcst_raw_data)      { delete [] fcst_raw_data;      fcst_raw_data     = nullptr; }
+   if (fcst_obj_raw_data)  { delete [] fcst_obj_raw_data;  fcst_obj_raw_data = nullptr; }
+   if (fcst_obj_data)      { delete [] fcst_obj_data;      fcst_obj_data     = nullptr; }
+   if (fcst_clus_data)     { delete [] fcst_clus_data;     fcst_clus_data    = nullptr; }
 
-   if (obs_raw_data)       { delete [] obs_raw_data;       obs_raw_data      = (float *) nullptr; }
-   if (obs_obj_raw_data)   { delete [] obs_obj_raw_data;   obs_obj_raw_data  = (float *) nullptr; }
-   if (obs_obj_data)       { delete [] obs_obj_data;       obs_obj_data      = (int *)   nullptr; }
-   if (obs_clus_data)      { delete [] obs_clus_data;      obs_clus_data     = (int *)   nullptr; }
+   if (obs_raw_data)       { delete [] obs_raw_data;       obs_raw_data      = nullptr; }
+   if (obs_obj_raw_data)   { delete [] obs_obj_raw_data;   obs_obj_raw_data  = nullptr; }
+   if (obs_obj_data)       { delete [] obs_obj_data;       obs_obj_data      = nullptr; }
+   if (obs_clus_data)      { delete [] obs_clus_data;      obs_clus_data     = nullptr; }
 
    //
    // Write out the values of the vertices of the polylines.
@@ -2185,42 +2181,53 @@ void ModeExecutive::write_poly_netcdf(NcFile *f_out, ObjPolyType poly_type)
 
 {
 
-   int i, j, x, y, n_pts, n_poly;
-   double lat, lon;
+   int n_pts;
+   int n_poly;
+   double lat;
+   double lon;
 
-   Polyline **poly            = (Polyline **) nullptr;
+   Polyline **poly = nullptr;
 
-   int   *poly_start          = (int       *) nullptr;
-   int   *poly_npts           = (int       *) nullptr;
-   float *poly_lat            = (float     *) nullptr;
-   float *poly_lon            = (float     *) nullptr;
-   int   *poly_x              = (int       *) nullptr;
-   int   *poly_y              = (int       *) nullptr;
+   int   *poly_start = nullptr;
+   int   *poly_npts  = nullptr;
+   float *poly_lat   = nullptr;
+   float *poly_lon   = nullptr;
+   int   *poly_x     = nullptr;
+   int   *poly_y     = nullptr;
 
    // Dimensions and variables for each object
-   NcDim  obj_dim            ;
-   NcVar  obj_poly_start_var ;
-   NcVar  obj_poly_npts_var  ;
+   NcDim obj_dim;
+   NcVar obj_poly_start_var;
+   NcVar obj_poly_npts_var;
 
    // Dimensions and variables for each boundary point
-   NcDim  poly_dim           ;
-   NcVar  poly_lat_var       ;
-   NcVar  poly_lon_var       ;
-   NcVar  poly_x_var         ;
-   NcVar  poly_y_var         ;
+   NcDim poly_dim;
+   NcVar poly_lat_var;
+   NcVar poly_lon_var;
+   NcVar poly_x_var;
+   NcVar poly_y_var;
 
    // Dimension names
-   ConcatString obj_dim_name,   poly_dim_name;
+   ConcatString obj_dim_name;
+   ConcatString poly_dim_name;
 
    // Variable names
-   ConcatString start_var_name, start_long_name;
-   ConcatString npts_var_name,  npts_long_name;
-   ConcatString lat_var_name,   lat_long_name;
-   ConcatString lon_var_name,   lon_long_name;
-   ConcatString x_var_name,     x_long_name;
-   ConcatString y_var_name,     y_long_name;
-   ConcatString field_name,     field_long;
-   ConcatString poly_name,      poly_long;
+   ConcatString start_var_name;
+   ConcatString start_long_name;
+   ConcatString npts_var_name;
+   ConcatString npts_long_name;
+   ConcatString lat_var_name;
+   ConcatString lat_long_name;
+   ConcatString lon_var_name;
+   ConcatString lon_long_name;
+   ConcatString x_var_name;
+   ConcatString x_long_name;
+   ConcatString y_var_name;
+   ConcatString y_long_name;
+   ConcatString field_name;
+   ConcatString field_long;
+   ConcatString poly_name;
+   ConcatString poly_long;
 
    // Determine the number of polylines to be written
    // and set up strings
@@ -2306,7 +2313,7 @@ void ModeExecutive::write_poly_netcdf(NcFile *f_out, ObjPolyType poly_type)
    poly = new Polyline * [n_poly];
 
    // Point at the polyline to be written
-   for(i=0; i<n_poly; i++) {
+   for(int i=0; i<n_poly; i++) {
 
       switch(poly_type) {
 
@@ -2340,7 +2347,7 @@ void ModeExecutive::write_poly_netcdf(NcFile *f_out, ObjPolyType poly_type)
    }
 
    // Get the number of polyline points
-   for(i=0, n_pts=0; i<n_poly; i++) n_pts += poly[i]->n_points;
+   for(int i=0, n_pts=0; i<n_poly; i++) n_pts += poly[i]->n_points;
 
    // Define dimensions
    NcDim tmp_obj_dim = get_nc_dim(f_out, (string)obj_dim_name);
@@ -2384,7 +2391,7 @@ void ModeExecutive::write_poly_netcdf(NcFile *f_out, ObjPolyType poly_type)
    // Store the points for each polyline
    //
    n_pts = 0;
-   for(i=0; i<n_poly; i++) {
+   for(int i=0; i<n_poly; i++) {
 
       // Store the starting point for this object.
       poly_start[i] = n_pts;
@@ -2392,18 +2399,18 @@ void ModeExecutive::write_poly_netcdf(NcFile *f_out, ObjPolyType poly_type)
       // Store the number of points in this polyline.
       poly_npts[i] = poly[i]->n_points;
 
-      for(j=0; j<poly_npts[i]; j++, n_pts++) {
+      for(int j=0; j<poly_npts[i]; j++, n_pts++) {
 
          // Get the boundary point (x,y) coordinates and store them
-         x = nint(poly[i]->u[j]);
-         y = nint(poly[i]->v[j]);
+         int x = nint(poly[i]->u[j]);
+         int y = nint(poly[i]->v[j]);
          poly_x[n_pts] = x;
          poly_y[n_pts] = y;
 
          // Convert to lat/lon and store them
          grid.xy_to_latlon(x, y, lat, lon);
-         poly_lat[n_pts] = lat;
-         poly_lon[n_pts] = -1.0*lon;
+         poly_lat[n_pts] = (float) lat;
+         poly_lon[n_pts] = (float) -1.0*lon;
       }
    }
 
@@ -2465,7 +2472,7 @@ void ModeExecutive::write_ct_stats()
 
    AsciiTable cts_at;
    ofstream out;
-   int i, c;
+   int c;
    double v;
    ConcatString stat_file;
 
@@ -2496,8 +2503,8 @@ void ModeExecutive::write_ct_stats()
    // Setup the AsciiTable to be used
    //
    cts_at.clear();
-   i = n_mode_hdr_columns + n_mode_cts_columns;
-   cts_at.set_size(3, i);                        // Set table size
+   c = n_mode_hdr_columns + n_mode_cts_columns;
+   cts_at.set_size(3, c);                        // Set table size
    justify_mode_cols(cts_at);                    // Justify columns
    cts_at.set_precision(                         // Set the precision
                         engine.conf_info.conf.output_precision());
@@ -2508,14 +2515,14 @@ void ModeExecutive::write_ct_stats()
    //
    // Write out the MODE header columns
    //
-   for(i=0; i<n_mode_hdr_columns; i++) {
+   for(int i=0; i<n_mode_hdr_columns; i++) {
       cts_at.set_entry(0, i, mode_hdr_columns[i]);
    }
 
    //
    // Write out the MODE contingecy table header columns
    //
-   for(i=0; i<n_mode_cts_columns; i++) {
+   for(int i=0; i<n_mode_cts_columns; i++) {
       cts_at.set_entry(0, i + n_mode_hdr_columns, (string)mode_cts_columns[i]);
    }
 
@@ -2523,7 +2530,7 @@ void ModeExecutive::write_ct_stats()
    // Store the contingency table counts and statistics in the AsciiTable
    // object.
    //
-   for(i=0; i<n_cts; i++) {
+   for(int i=0; i<n_cts; i++) {
 
       // Write out the header columns
       write_header_columns(engine, grid, cts_at, i+1);
@@ -2648,7 +2655,7 @@ void ModeExecutive::conf_read()
    default_config_file = replace_path(default_config_filename);
 
    // If the merge config file was not set, use the match config file
-   if(merge_config_file.length() == 0)
+   if(merge_config_file.empty())
       merge_config_file = match_config_file;
 
    // List the config files
@@ -2679,7 +2686,6 @@ string ModeExecutive::stype(Processing_t t)
    case MULTIVAR_SUPER:
       s = "Multivar Superobjects";
       break;
-   case TRADITIONAL:
    default:
       s = "Traditional";
       break;
@@ -2700,14 +2706,14 @@ string ModeExecutive::stype(Processing_t t)
 ///////////////////////////////////////////////////////////////////////
 
 
-void nc_add_string(NcFile * f, const char * text, const char * var_name, const char * dim_name)
+static void nc_add_string(NcFile * f, const char * text, const char * var_name, const char * dim_name)
 
 {
 
    NcDim  dim;
    NcVar  var;
 
-   const char * t = 0;
+   const char * t = nullptr;
 
    if ( ! text )  t = "XXX";
    else           t = text;
@@ -2739,7 +2745,7 @@ void nc_add_string(NcFile * f, const char * text, const char * var_name, const c
 
 ///////////////////////////////////////////////////////////////////////
 
-void replaceAll(std::string& str, const std::string& from, const std::string& to)
+static void replaceAll(std::string& str, const std::string& from, const std::string& to)
 {
    if(from.empty())
       return;

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -202,11 +202,13 @@ void ModeExecutive::init_traditional(int n_files)
 
 ///////////////////////////////////////////////////////////////////////
 
-void ModeExecutive::init_multivar_simple(int j, int n_files, ModeDataType dtype,
+void ModeExecutive::init_multivar_simple(int rIndex, int tIndex,
+                                         int j, int n_files, ModeDataType dtype,
                                          const ModeConfInfo &conf)
 
 {
-   R_index = T_index = 0;
+   R_index = rIndex;
+   T_index = tIndex;
    engine.conf_info = conf;
 
    // tell the engine which type of data it is
@@ -772,8 +774,7 @@ void ModeExecutive::do_conv_thresh_traditional(const int r_index, const int t_in
    ModeConfInfo & conf = engine.conf_info;
 
    // note that we are assuming the same r_index and t_index for both forecasts
-   // and obs, which might not be true if mvmode were to allow >1 index
-   // (currently it does not)
+   // and obs
 
    R_index = r_index;
    T_index = t_index;
@@ -814,18 +815,22 @@ void ModeExecutive::do_conv_thresh_traditional(const int r_index, const int t_in
 
 ///////////////////////////////////////////////////////////////////////
 
-void ModeExecutive::do_conv_thresh_multivar_super()
+void ModeExecutive::do_conv_thresh_multivar_super(int rIndexF, int tIndexF,
+                                                  int rIndexO, int tIndexO)
 {
 
    ModeConfInfo & conf = engine.conf_info;
 
-   R_index = 0;
-   T_index = 0;
+   // R_index = convIndex;
+   // T_index = convIndex;
 
    SingleThresh s("ne-9999");
-   conf.set_conv_thresh(s);
-   conf.set_conv_radius(0.0);
-   conf.set_merge_thresh_by_index(T_index);
+   conf.set_fcst_conv_thresh(s);
+   conf.set_fcst_conv_radius(0.0);
+   conf.set_fcst_merge_thresh_by_index(tIndexF);
+   conf.set_obs_conv_thresh(s);
+   conf.set_obs_conv_radius(0.0);
+   conf.set_obs_merge_thresh_by_index(tIndexO);
 
    //
    //  Set up the engine with these raw fields
@@ -855,17 +860,21 @@ void ModeExecutive::do_conv_thresh_multivar_super()
 ///////////////////////////////////////////////////////////////////////
 
 
-void ModeExecutive::do_conv_thresh_multivar_intensity_compare()
+void ModeExecutive::do_conv_thresh_multivar_intensity_compare(int rIndexF, int tIndexF, int rIndexO, int tIndexO)
 {
 
    ModeConfInfo & conf = engine.conf_info;
 
-   R_index = 0;
-   T_index = 0;
+   R_index = rIndexF;
+   T_index = tIndexF;
 
-   conf.set_conv_radius_by_index(R_index);
-   conf.set_conv_thresh_by_index(T_index);
-   conf.set_merge_thresh_by_index(T_index);
+   conf.set_obs_conv_radius_by_index(rIndexO);
+   conf.set_obs_conv_thresh_by_index(tIndexO);
+   conf.set_obs_merge_thresh_by_index(tIndexO);
+
+   conf.set_fcst_conv_radius_by_index(rIndexF);
+   conf.set_fcst_conv_thresh_by_index(tIndexF);
+   conf.set_fcst_merge_thresh_by_index(tIndexF);
 
    //
    //  Set up the engine with these raw fields
@@ -893,39 +902,38 @@ void ModeExecutive::do_conv_thresh_multivar_intensity_compare()
 
 ///////////////////////////////////////////////////////////////////////
 
-void ModeExecutive::do_conv_thresh_multivar_simple(Processing_t p)
+void ModeExecutive::do_conv_thresh_multivar_simple(Processing_t p, int rIndex, int tIndex)
 {
+   // R_index = convIndex;
+   // T_index = convIndex;
 
    ModeConfInfo & conf = engine.conf_info;
-
-   R_index = 0;
-   T_index = 0;
+   bool obs = conf.data_type == ModeDataType::MvMode_Obs;
+   string what;
+   if (obs) {
+      what = "observation field";
+   } else {
+      what = "forecast field";
+   }      
+   mlog << Debug(2) << "Identifying objects in the " << what << "...\n";
 
    if (p == MULTIVAR_SIMPLE_MERGE) {
+      conf.set_conv_radius_by_index(R_index);   // need this because exec was killed after SIMPLE
       conf.set_conv_thresh_by_merge_index(T_index);
    } else if (p == MULTIVAR_SIMPLE) {
-      conf.set_conv_radius_by_index(0);
-      conf.set_conv_thresh_by_index(0);
+      conf.set_conv_radius_by_index(R_index);
+      conf.set_conv_thresh_by_index(T_index);
    } else {
       mlog << Error << "\nModeExecutive::do_conv_thresh_multivar_simple() -> "
            << "Wrong processing type input " << stype(p) << "\"\n\n";
       exit(1);
    }         
 
-   conf.set_merge_thresh_by_index(0);
+   conf.set_merge_thresh_by_index(T_index);
 
    //
    //  Set up the engine with these raw fields
    //
-
-   string what;
-   if (conf.data_type == ModeDataType::MvMode_Obs) {
-      what = "observation field";
-   } else {
-      what = "forecast field";
-   }
-   mlog << Debug(2) << "Identifying objects in the " << what << "...\n";
-
    engine.set(Fcst_sd, Obs_sd);
 
    // (ct_stats not needed for simple or merge, only one field)
@@ -933,7 +941,7 @@ void ModeExecutive::do_conv_thresh_multivar_simple(Processing_t p)
    //  done
    //
 
-   local_r_index = 0;
+   local_r_index = rIndex;
 
    return;
 

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -2181,7 +2181,6 @@ void ModeExecutive::write_poly_netcdf(NcFile *f_out, ObjPolyType poly_type)
 
 {
 
-   int n_pts;
    int n_poly;
    double lat;
    double lon;
@@ -2347,7 +2346,8 @@ void ModeExecutive::write_poly_netcdf(NcFile *f_out, ObjPolyType poly_type)
    }
 
    // Get the number of polyline points
-   for(int i=0, n_pts=0; i<n_poly; i++) n_pts += poly[i]->n_points;
+   int n_pts = 0;
+   for(int i=0; i<n_poly; i++) n_pts += poly[i]->n_points;
 
    // Define dimensions
    NcDim tmp_obj_dim = get_nc_dim(f_out, (string)obj_dim_name);
@@ -2410,7 +2410,7 @@ void ModeExecutive::write_poly_netcdf(NcFile *f_out, ObjPolyType poly_type)
          // Convert to lat/lon and store them
          grid.xy_to_latlon(x, y, lat, lon);
          poly_lat[n_pts] = (float) lat;
-         poly_lon[n_pts] = (float) -1.0*lon;
+         poly_lon[n_pts] = -1.0 * ((float) lon);
       }
    }
 

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -821,16 +821,17 @@ void ModeExecutive::do_conv_thresh_multivar_super(int rIndexF, int tIndexF,
 
    ModeConfInfo & conf = engine.conf_info;
 
-   // R_index = convIndex;
-   // T_index = convIndex;
+   R_index = rIndexF;
+   T_index = tIndexF;
 
    SingleThresh s("ne-9999");
    conf.set_fcst_conv_thresh(s);
    conf.set_fcst_conv_radius(0.0);
-   conf.set_fcst_merge_thresh_by_index(tIndexF);
+   conf.set_fcst_merge_thresh(s);
+   //conf.set_fcst_merge_thresh_by_index(0);
    conf.set_obs_conv_thresh(s);
    conf.set_obs_conv_radius(0.0);
-   conf.set_obs_merge_thresh_by_index(tIndexO);
+   conf.set_obs_merge_thresh(s);//_by_index(0);
 
    //
    //  Set up the engine with these raw fields

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -904,9 +904,6 @@ void ModeExecutive::do_conv_thresh_multivar_intensity_compare(int rIndexF, int t
 
 void ModeExecutive::do_conv_thresh_multivar_simple(Processing_t p, int rIndex, int tIndex)
 {
-   // R_index = convIndex;
-   // T_index = convIndex;
-
    ModeConfInfo & conf = engine.conf_info;
    bool obs = conf.data_type == ModeDataType::MvMode_Obs;
    string what;

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -913,7 +913,7 @@ void ModeExecutive::do_conv_thresh_multivar_simple(Processing_t p, int rIndex, i
    } else {
       what = "forecast field";
    }      
-   mlog << Debug(2) << "Identifying objects in the " << what << "...\n";
+   mlog << Debug(2) << "Identifying objects in the " << what << " for " << stype(p) << "\n";
 
    if (p == MULTIVAR_SIMPLE_MERGE) {
       conf.set_conv_radius_by_index(R_index);   // need this because exec was killed after SIMPLE
@@ -1176,8 +1176,7 @@ void ModeExecutive::process_obs_masks(ShapeData & obs_sd)
    ShapeData grid_mask_sd, poly_mask_sd;
    ConcatString name;
 
-   mlog << Debug(2)
-        << "Processing masking regions.\n";
+   mlog << Debug(3) << "Processing masking regions.\n";
 
    // Parse the grid mask into a ShapeData object
    if(engine.conf_info.mask_grid_flag != FieldType::None) {

--- a/src/tools/core/mode/mode_exec.h
+++ b/src/tools/core/mode/mode_exec.h
@@ -81,14 +81,13 @@ class ModeExecutive {
    void clear();
 
    void init_traditional(int n_files);
-   void init_multivar_simple(int j, int n_files, ModeDataType dtype, const ModeConfInfo &conf);
+   void init_multivar_simple(int rIndex, int tIndex, int j, int n_files, ModeDataType dtype, const ModeConfInfo &conf);
    void init_multivar_intensities(const ModeConfInfo &conf);
 
    int n_conv_radii   () const;
    int n_conv_threshs () const;
    int n_runs() const;
 
-   // these are used only for traditional mode
    int R_index;   //  indices into the convolution radius and threshold arrays
    int T_index;   //  for the current run
 
@@ -167,9 +166,10 @@ class ModeExecutive {
                                            const Grid &igrid);
 
    void do_conv_thresh_traditional(const int r_index, const int t_index);
-   void do_conv_thresh_multivar_super();
-   void do_conv_thresh_multivar_intensity_compare();
-   void do_conv_thresh_multivar_simple(Processing_t p);
+   void do_conv_thresh_multivar_super(int rIndexF, int tIndexF,
+                                      int rIndexO, int tIndexO);
+   void do_conv_thresh_multivar_intensity_compare(int rIndexF, int tIndexF, int rIndexO, int tIndexO);
+   void do_conv_thresh_multivar_simple(Processing_t p, int rIndex, int tIndex);
 
    void do_merging_traditional();
    void do_merging_multivar(const ShapeData &f_merge, const ShapeData &o_merge,

--- a/src/tools/core/mode/mode_exec.h
+++ b/src/tools/core/mode/mode_exec.h
@@ -81,7 +81,7 @@ class ModeExecutive {
    void clear();
 
    void init_traditional(int n_files);
-   void init_multivar_simple(int rIndex, int tIndex, int j, int n_files, ModeDataType dtype, const ModeConfInfo &conf);
+   void init_multivar_simple(int rIndex, int tIndex, int j, ModeDataType dtype, const ModeConfInfo &conf);
    void init_multivar_intensities(const ModeConfInfo &conf);
 
    int n_conv_radii   () const;
@@ -130,21 +130,26 @@ class ModeExecutive {
    ConcatString out_dir;
 
    // set for both trad and multivar mode, used for plotting limits
-   double data_min, data_max;
+   double data_min;
+   double data_max;
 
    // set for trad and multivar, used in the engine mode algorithm
-   ShapeData Fcst_sd, Obs_sd;
+   ShapeData Fcst_sd;
+   ShapeData Obs_sd;
 
    // not used by multivar
-   GrdFileType ftype, otype;
+   GrdFileType ftype;
+   GrdFileType otype;
 
    // set into execs's conf varInfo object, only for multivar intensity comparisons
    // for trad it's read in from the config
-   string funits, ounits;
+   string funits;
+   string ounits;
 
    // set into execs's conf varInfo object, only for multivar intensity comparisons
    // for trad it's read in from the config
-   string flevel, olevel;
+   string flevel;
+   string olevel;
 
    // used in multivar only to customize outputs correctly
    bool isMultivarOutput;

--- a/src/tools/core/mode/mode_superobject.cc
+++ b/src/tools/core/mode/mode_superobject.cc
@@ -17,6 +17,7 @@ using namespace std;
 
 
 ////////////////////////////////////////////////////////////////////////
+
 static void _mask_super(const string &name, int nx, int ny, DataPlane &data)
 {
 
@@ -28,7 +29,8 @@ static void _mask_super(const string &name, int nx, int ny, DataPlane &data)
       exit( 1 );
    }
 
-   int nmasked=0, nkeep=0;
+   int nmasked=0;
+   int nkeep=0;
    
    for (int x=0; x<nx; ++x)  {
 
@@ -67,7 +69,7 @@ static void _mask(const string &name, int nx, int ny, const BoolPlane &bp,
       for (int y=0; y<ny; ++y)  {
 
          if ( bp(x, y) == false) {
-            data.set(bad_data_float, x, y);;
+            data.set(bad_data_float, x, y);
             nmasked ++;
          } else {
             nkeep ++;
@@ -82,8 +84,8 @@ static void _mask(const string &name, int nx, int ny, const BoolPlane &bp,
 
 ////////////////////////////////////////////////////////////////////////
 
-static void _debug_shape_examine(string &name, const ShapeData &sd,
-                                  int nx, int ny)
+static void _debug_shape_examine(const string &name, const ShapeData &sd,
+                                 int nx, int ny)
 {
    vector<double> values;
    vector<int> count;
@@ -99,7 +101,7 @@ static void _debug_shape_examine(string &name, const ShapeData &sd,
             values.push_back(v);
             count.push_back(1);
          } else {
-            int ii = vi - values.begin();
+            int ii = nint(vi - values.begin());
             count[ii] = count[ii] + 1;
          }
       }
@@ -126,8 +128,8 @@ ModeSuperObject::ModeSuperObject(bool isFcst, int n_files, bool do_clusters,
    //  set the BoolPlane values using the mvd content
    //
 
-   BoolPlane * simple_plane = new BoolPlane [n_files];
-   BoolPlane * merge_plane = new BoolPlane [n_files];
+   auto simple_plane = new BoolPlane [n_files];
+   auto merge_plane = new BoolPlane [n_files];
 
    for (int j=0; j<n_files; ++j)  {
       mvd[j]->objects_from_arrays(do_clusters, true, simple_plane[j]);
@@ -144,7 +146,8 @@ ModeSuperObject::ModeSuperObject(bool isFcst, int n_files, bool do_clusters,
    _simple_result.set_size(nx, ny);
    merge_result.set_size(nx, ny);
 
-   string simple_name, merge_name;
+   string simple_name;
+   string merge_name;
    
    if (isFcst) {
       simple_name = "Fcst_Simple";
@@ -172,7 +175,7 @@ ModeSuperObject::ModeSuperObject(bool isFcst, int n_files, bool do_clusters,
       }
    }
 
-   ShapeData merge_sd = ShapeData(*(mvd[0]->_simple->_sd));
+   auto merge_sd = ShapeData(*(mvd[0]->_simple->_sd));
    for (int x=0; x<nx; ++x) {
       for (int y=0; y<ny; ++y) {
          if (merge_result.get(x, y)) {

--- a/src/tools/core/mode/mode_superobject.cc
+++ b/src/tools/core/mode/mode_superobject.cc
@@ -101,7 +101,7 @@ static void _debug_shape_examine(const string &name, const ShapeData &sd,
             values.push_back(v);
             count.push_back(1);
          } else {
-            int ii = nint(vi - values.begin());
+            auto ii = (int) (vi - values.begin());
             count[ii] = count[ii] + 1;
          }
       }

--- a/src/tools/core/mode/mode_superobject.cc
+++ b/src/tools/core/mode/mode_superobject.cc
@@ -109,6 +109,10 @@ static void _debug_shape_examine(string &name, const ShapeData &sd,
    }
 }   
 
+ModeSuperObject::ModeSuperObject()
+{
+}
+
 ModeSuperObject::ModeSuperObject(bool isFcst, int n_files, bool do_clusters,
                                  const vector<MultiVarData *> &mvd,
                                  BoolCalc &calc)

--- a/src/tools/core/mode/mode_superobject.cc
+++ b/src/tools/core/mode/mode_superobject.cc
@@ -114,10 +114,13 @@ ModeSuperObject::ModeSuperObject()
 }
 
 ModeSuperObject::ModeSuperObject(bool isFcst, int n_files, bool do_clusters,
+                                 int r_index, int t_index,
                                  const vector<MultiVarData *> &mvd,
                                  BoolCalc &calc)
 {
    _hasUnion = calc.has_union();
+   _rIndex = r_index;
+   _tIndex = t_index;
    
    //
    //  set the BoolPlane values using the mvd content
@@ -150,8 +153,10 @@ ModeSuperObject::ModeSuperObject(bool isFcst, int n_files, bool do_clusters,
       simple_name = "Obs_Simple";
       merge_name = "Obs_Merge";
    }      
-   combine_boolplanes(simple_name, simple_plane, n_files, calc, _simple_result);
-   combine_boolplanes(merge_name,  merge_plane, n_files, calc, merge_result);
+
+   mlog << Debug(1) << "\n";
+   combine_boolplanes(simple_name, _rIndex, _tIndex, simple_plane, n_files, calc, _simple_result);
+   combine_boolplanes(merge_name,  _rIndex, _tIndex, merge_plane, n_files, calc, merge_result);
 
    // create ShapeData objects using something from mvd as a template
    // (shape data has 1's or bad)

--- a/src/tools/core/mode/mode_superobject.h
+++ b/src/tools/core/mode/mode_superobject.h
@@ -30,6 +30,8 @@ class ModeSuperObject {
 
  public:
 
+   ModeSuperObject();
+
    ModeSuperObject(bool isFcst, int n_files, bool do_clusters,
                    const std::vector<MultiVarData *> &mvd,
                    BoolCalc &calc);

--- a/src/tools/core/mode/mode_superobject.h
+++ b/src/tools/core/mode/mode_superobject.h
@@ -33,6 +33,7 @@ class ModeSuperObject {
    ModeSuperObject();
 
    ModeSuperObject(bool isFcst, int n_files, bool do_clusters,
+                   int r_index, int t_index,
                    const std::vector<MultiVarData *> &mvd,
                    BoolCalc &calc);
    inline ~ModeSuperObject() {}
@@ -42,6 +43,7 @@ class ModeSuperObject {
 
    bool _isFcst;
    bool _hasUnion;
+   int _rIndex, _tIndex;
    BoolPlane _simple_result;
    ShapeData _simple_sd;
    ShapeData _merge_sd_split;

--- a/src/tools/core/mode/mode_superobject.h
+++ b/src/tools/core/mode/mode_superobject.h
@@ -43,7 +43,8 @@ class ModeSuperObject {
 
    bool _isFcst;
    bool _hasUnion;
-   int _rIndex, _tIndex;
+   int _rIndex;
+   int _tIndex;
    BoolPlane _simple_result;
    ShapeData _simple_sd;
    ShapeData _merge_sd_split;

--- a/src/tools/core/mode/multivar_frontend.cc
+++ b/src/tools/core/mode/multivar_frontend.cc
@@ -64,7 +64,7 @@ int MultivarFrontEnd::run(const StringArray & Argv)
 
    _init(Argv);
 
-   mlog << Debug(2) << "\n" << sep << "\n";
+   mlog << Debug(1) << "\n" << sep << "\n";
 
    // in the conf object, shift *can* be set independently for obs and fcst
    int shift = config.shift_right;
@@ -175,7 +175,7 @@ int MultivarFrontEnd::run(const StringArray & Argv)
       }
    }
    
-   mlog << Debug(2) << "\n finished with multivar intensity comparisons \n" << sep << "\n";
+   mlog << Debug(1) << "\n finished with multivar intensity comparisons \n" << sep << "\n";
 
    // clear out memory stored in the simple objects
    
@@ -509,7 +509,7 @@ void MultivarFrontEnd::_read_input(const string &name, int index, ModeDataType t
 
 void MultivarFrontEnd::_create_verif_grid()
 {
-   mlog << Debug(2) << "\n creating the verification grid \n" << sep << "\n";
+   mlog << Debug(1) << "\n creating the verification grid \n" << sep << "\n";
 
    _init_exec(ModeExecutive::TRADITIONAL, "None", "None");
    mode_exec->setup_verification_grid(fcstInput[0], obsInput[0], config);
@@ -527,9 +527,9 @@ void MultivarFrontEnd::_create_simple_objects(ModeDataType dtype, const std::str
 {
    O.init(dtype, rIndex, tIndex);
    for (int j=0; j<n_files; ++j)  {
-      mlog << Debug(2) 
+      mlog << Debug(1) 
            << "\n" << sep << "\ncreating simple " << name << " objects from " << name << " "
-           << (j + 1) << " of " << n_files << "\nconv_radius[" << rIndex+1 << "] conv_thresh["
+           << (j + 1) << " of " << n_files << " conv_radius[" << rIndex+1 << "] conv_thresh["
            << tIndex+1 << "]\n" << sep << "\n";
       MultiVarData *mvdi = _create_simple_multivar_data(dtype, rIndex, tIndex, j, n_files, 
                                                         filenames[j], input[j]);
@@ -614,7 +614,11 @@ MultivarFrontEnd::_create_intensity_comparisons(SimpleObjects &fcsts, int findex
    fcsts._super.mask_data_simple("Fcst", *mvdf);
    obs._super.mask_data_simple("Obs", *mvdo);
 
-   mlog << Debug(1) << "Running mvmode intensity comparisions \n\n";
+   // this debug statement assumes fcsts and obs have same conv radius and thresh indices
+   // which is currently required
+   mlog << Debug(1) << "\n" << sep
+        << "\nRunning mvmode intensity comparisions conv_radius[" << fcsts._rIndex+1
+        << "] conv_thresh[" << fcsts._tIndex+1 << "]\n" << sep << "\n";
 
    _init_exec(ModeExecutive::MULTIVAR_INTENSITY, fcst_filename, obs_filename);
    mode_exec->init_multivar_intensities(config);
@@ -678,7 +682,9 @@ MultivarFrontEnd::_intensity_compare_mode_algorithm(int rIndexF, int tIndexF,
 
 void MultivarFrontEnd::_process_superobjects(SimpleObjects &fcsts, SimpleObjects &obs)
 {
-   mlog << Debug(1) << "Running superobject mode \n\n";
+   mlog << Debug(1) << "\n" << sep
+        << "\nRunning mvmode superobject analysis conv_radius[" << fcsts._rIndex+1
+        << "] conv_thresh[" << fcsts._tIndex+1 << "]\n" << sep << "\n";
 
    MultiVarData *mvdf = fcsts._mvd[0];
    MultiVarData *mvdo = obs._mvd[0];
@@ -739,7 +745,7 @@ void MultivarFrontEnd::_init_exec(ModeExecutive::Processing_t p,
                                   const string &ffile,
                                   const string &ofile) const
 {
-   mlog << Debug(1) << "Running multivar front end for " << ModeExecutive::stype(p) << "\n";
+   mlog << Debug(4) << "Running multivar front end for " << ModeExecutive::stype(p) << "\n";
 
    if ( mode_exec )  { delete mode_exec;  mode_exec = 0; }
 

--- a/src/tools/core/mode/multivar_frontend.cc
+++ b/src/tools/core/mode/multivar_frontend.cc
@@ -10,7 +10,6 @@
 
 
 #include "multivar_frontend.h"
-
 #include "mode_usage.h"
 
 #ifdef WITH_PYTHON
@@ -37,7 +36,6 @@ static const int dir_creation_mode = 0755;
 
 static ModeExecutive *mode_exec = 0;
 
-
 ////////////////////////////////////////////////////////////////////////
 
 MultivarFrontEnd::MultivarFrontEnd()
@@ -51,13 +49,20 @@ MultivarFrontEnd::MultivarFrontEnd()
 
 ////////////////////////////////////////////////////////////////////////
 
-int MultivarFrontEnd::run(const StringArray & Argv)
-
+MultivarFrontEnd::~MultivarFrontEnd()
 {
+   if ( mode_exec ) {
+      delete mode_exec;  mode_exec = 0;
+   }
+ }
 
+////////////////////////////////////////////////////////////////////////
+
+int MultivarFrontEnd::run(const StringArray & Argv)
+{
    // initialize
 
-   init(Argv);
+   _init(Argv);
 
    mlog << Debug(2) << "\n" << sep << "\n";
 
@@ -70,14 +75,14 @@ int MultivarFrontEnd::run(const StringArray & Argv)
       GrdFileType ft, ot;
       ft = config.file_type_for_field(true, i);
       ot = parse_conf_file_type(config.conf.lookup_dictionary(conf_key_obs));
-      read_input(fcst_filenames[i], i, ModeDataType::MvMode_Fcst, ft, ot, shift);
+      _read_input(fcst_filenames[i], i, ModeDataType::MvMode_Fcst, ft, ot, shift);
 
    }
    for (int i=0; i<n_obs_files; ++i) {
       GrdFileType ft, ot;
       ft = parse_conf_file_type(config.conf.lookup_dictionary(conf_key_fcst));
       ot = config.file_type_for_field(false, i);
-      read_input(obs_filenames[i], i, ModeDataType::MvMode_Obs, ot, ft, shift);
+      _read_input(obs_filenames[i], i, ModeDataType::MvMode_Obs, ot, ft, shift);
    }
    
    // double check some thing that are now set
@@ -88,69 +93,103 @@ int MultivarFrontEnd::run(const StringArray & Argv)
 
 
    // Define the verification grid using the 0th fcst and obs inputs
-   create_verif_grid();
+   _create_verif_grid();
 
-   //
-   // do the individual mode runs which produce everything needed to create
-   // super objects (stored in 'mvdObs', 'mvdFcst') (both simple and merge steps
-   // are done here).
-   //
+   // in the implementation now, all 4 of these numbers must be the same
+   int NCTF = config.n_conv_threshs_fcst();
+   int NCRF = config.n_conv_radii_fcst();
+   int NCTO = config.n_conv_threshs_obs();
+   int NCRO = config.n_conv_radii_obs();
 
-   for (int j=0; j<n_fcst_files; ++j)  {
+   if ( NCTF != NCRF || NCTO != NCRO)  {
+      mlog << Error << "\nMultivarFrontEnd::run() ->"
+           << "all convolution radius and threshold arrays must have the same number of elements\n\n";
 
-      mlog << Debug(2) 
-           << "\n" << sep << "\ncreating simple forecast objects from forecast "
-           << (j + 1) << " of " << n_fcst_files << "\n" << sep << "\n";
-      MultiVarData *mvdi = create_simple_objects(ModeDataType::MvMode_Fcst, j,
-                                                 n_fcst_files, fcst_filenames[j],
-                                                 fcstInput[j]);
-      mvdFcst.push_back(mvdi);
-      mvdi->print();
-   }   //  for j
-
-   for (int j=0; j<n_obs_files; ++j)  {
-
-      mlog << Debug(2) 
-           << "\n" << sep << "\ncreating simple obs objects from obs "
-           << (j + 1) << " of " << n_obs_files << "\n" << sep << "\n";
-      MultiVarData *mvdi = create_simple_objects(ModeDataType::MvMode_Obs, j,
-                                                 n_obs_files, obs_filenames[j],
-                                                 obsInput[j]);
-      mvdObs.push_back(mvdi);
-      mvdi->print();
-   }   //  for j
-
-   mlog << Debug(2) << "\n finished with simple multivar mode runs " << "\n" << sep << "\n";
-
-   // now create forecast and obs superobjects
-   
-   ModeSuperObject fsuper(true, n_fcst_files, do_clusters, mvdFcst, f_calc);
-   ModeSuperObject osuper(true, n_obs_files, do_clusters, mvdObs, o_calc);
-                          
-   //
-   // Filter the data to within the superobjects only and do statistics by invoking mode
-   // algorithm again on the masked data pairs
-   //
-
-   for (int k=0; k<config.fcst_multivar_compare_index.n(); ++k)
-   {
-      int findex = config.fcst_multivar_compare_index[k] - 1;
-      int oindex = config.obs_multivar_compare_index[k] - 1;
-
-      create_intensity_comparisons(findex, oindex, fsuper, osuper,
-                                   *mvdFcst[findex], *mvdObs[oindex],
-                                   fcst_filenames[findex], obs_filenames[oindex]);
+      exit ( 1 );
    }
 
+   if (NCRO != NCRF) {
+      mlog << Error << "\nMultivarFrontEnd::run() ->"
+           << "Unequal number of forecast and obs convolution radii not yet supported\n\n";
+      exit ( 1 );
+   }
+
+   // the single array length
+   int NCONV = NCRO;
+   
+   // containers for information needed to do things with simple objects after creation
+   vector<SimpleObjects> fcstSimple, obsSimple;
+
+   if (config.quilt) {
+      for (int ir=0; ir<NCONV; ++ir) {
+         for (int it=0; it<NCONV; ++it) {
+            SimpleObjects O;
+            _create_simple_objects(ModeDataType::MvMode_Fcst, "forecast", ir, it, n_fcst_files,
+                                   fcst_filenames, fcstInput, f_calc, O);
+            fcstSimple.push_back(O);
+         }
+      }
+      for (int ir=0; ir<NCONV; ++ir) {
+         for (int it=0; it<NCONV; ++it) {
+            SimpleObjects O;
+            _create_simple_objects(ModeDataType::MvMode_Obs, "obs", ir, it, n_obs_files,
+                                   obs_filenames, obsInput, o_calc, O);
+            obsSimple.push_back(O);
+         }
+      }
+   }
+   else {
+      for (int ir=0; ir<NCONV; ++ir) {
+         SimpleObjects O;
+         _create_simple_objects(ModeDataType::MvMode_Fcst, "forecast", ir, ir, n_fcst_files,
+                                fcst_filenames, fcstInput, f_calc, O);
+         fcstSimple.push_back(O);
+      }
+      for (int ir=0; ir<NCONV; ++ir) {
+         SimpleObjects O;
+         _create_simple_objects(ModeDataType::MvMode_Obs, "obs", ir, ir, n_obs_files,
+                                obs_filenames, obsInput, o_calc, O);
+         obsSimple.push_back(O);
+      }
+   }
+
+   for (int fi=0; fi<NCONV; ++fi) {
+      int oi = fi;
+      //
+      // Filter the data to within the superobjects only and do statistics by invoking mode
+      // algorithm again on the masked data pairs
+      //
+      // Note at this point we know the compare index arrays are the same length for fcst
+      // and obs
+      //
+      for (int k=0; k<config.fcst_multivar_compare_index.n(); ++k)
+      {
+         int findex = config.fcst_multivar_compare_index[k] - 1;
+         int oindex = config.obs_multivar_compare_index[k] - 1;
+
+         _create_intensity_comparisons(fcstSimple[fi], findex, obsSimple[oi], oindex, 
+                                       fcst_filenames[findex], obs_filenames[oindex]);
+      }
+
+      //
+      // special case of just superobject statistics, no comparisons configured
+      //
+      if (config.fcst_multivar_compare_index.n() <= 0) {
+         _process_superobjects(fcstSimple[fi], obsSimple[oi]);
+      }
+   }
+   
    mlog << Debug(2) << "\n finished with multivar intensity comparisons \n" << sep << "\n";
 
-   // special case of just superobject statistics, no comparisons configured
-
-   if (config.fcst_multivar_compare_index.n() <= 0) {
-
-      process_superobjects(fsuper, osuper, *mvdFcst[0], *mvdObs[0]); 
-   }
+   // clear out memory stored in the simple objects
    
+   for (size_t i=0; i<fcstSimple.size(); ++i) {
+      fcstSimple[i].clear();
+   }   
+   for (size_t i=0; i<obsSimple.size(); ++i) {
+      obsSimple[i].clear();
+   }   
+
    //
    //  done
    //
@@ -159,28 +198,54 @@ int MultivarFrontEnd::run(const StringArray & Argv)
 
 ////////////////////////////////////////////////////////////////////////
 
-MultivarFrontEnd::~MultivarFrontEnd()
+void MultivarFrontEnd::set_outdir(const StringArray & a)
+
 {
-   if ( mode_exec ) {
-      delete mode_exec;  mode_exec = 0;
-   }
 
+   outdir = a[0];
 
-   for (int j=0; j<n_fcst_files; ++j)  {
-      delete mvdFcst[j];
-      mvdFcst[j] = 0;
-   }
-   for (int j=0; j<n_obs_files; ++j)  {
-      delete mvdObs[j];
-      mvdObs[j] = 0;
-   }
-   
+   return;
+
 }
-
 
 ////////////////////////////////////////////////////////////////////////
 
-void MultivarFrontEnd::init(const StringArray & Argv)
+void MultivarFrontEnd::set_logfile(const StringArray & a)
+
+{
+
+   ConcatString filename;
+
+   filename = a[0];
+
+   mlog.open_log_file(filename);
+
+   return;
+
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void MultivarFrontEnd::set_verbosity (const StringArray & a)
+
+{
+
+   mlog.set_verbosity_level(atoi(a[0].c_str()));
+
+   return;
+
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void MultivarFrontEnd::set_compress(const StringArray & a)
+{
+   compress_level = atoi(a[0].c_str());
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void MultivarFrontEnd::_init(const StringArray & Argv)
 {
    int Argc = Argv.n();
 
@@ -202,224 +267,9 @@ void MultivarFrontEnd::init(const StringArray & Argv)
 
 ////////////////////////////////////////////////////////////////////////
 
-
-void MultivarFrontEnd::set_outdir(const StringArray & a)
-
-{
-
-   outdir = a[0];
-
-   return;
-
-}
-
-
-////////////////////////////////////////////////////////////////////////
-
-
-void MultivarFrontEnd::set_logfile(const StringArray & a)
-
-{
-
-   ConcatString filename;
-
-   filename = a[0];
-
-   mlog.open_log_file(filename);
-
-   return;
-
-}
-
-
-////////////////////////////////////////////////////////////////////////
-
-
-void MultivarFrontEnd::set_verbosity (const StringArray & a)
-
-{
-
-   mlog.set_verbosity_level(atoi(a[0].c_str()));
-
-   return;
-
-}
-
-////////////////////////////////////////////////////////////////////////
-
-void MultivarFrontEnd::set_compress(const StringArray & a)
-{
-   compress_level = atoi(a[0].c_str());
-}
-
-////////////////////////////////////////////////////////////////////////
-
-void MultivarFrontEnd::read_input(const string &name, int index, ModeDataType type,
-                                  GrdFileType f_t, GrdFileType other_t, int shift)
-{
-   Met2dDataFileFactory mtddf_factory;
-   Met2dDataFile *f = mtddf_factory.new_met_2d_data_file(name.c_str(), f_t);
-   if (!f) {
-      mlog << Error << "\nTrouble reading fcst file \""
-           << name << "\"\n\n";
-      exit(1);
-   }
-   Grid g = f->grid();
-   GrdFileType ft = f->file_type();
-
-   //?
-   f->set_shift_right(shift);
-
-   // update config now that we know file type (this sets Fcst to index i)
-   DataPlane dp;
-
-   if (type == ModeDataType::MvMode_Fcst) {
-      config.process_config_field(ft, other_t, type, index);
-      f->data_plane(*(config.Fcst->var_info), dp);
-      fcstInput.push_back(ModeInputData(name, dp, g));
-   } else {
-      config.process_config_field(other_t, ft, type, index);
-      f->data_plane(*(config.Obs->var_info), dp);
-      obsInput.push_back(ModeInputData(name, dp, g));
-   }         
-      
-   delete f;
-}
-      
-////////////////////////////////////////////////////////////////////////
-
-void MultivarFrontEnd::create_verif_grid()
-{
-   mlog << Debug(2) << "\n creating the verification grid \n" << sep << "\n";
-
-   _init_exec(ModeExecutive::TRADITIONAL, "None", "None");
-   mode_exec->setup_verification_grid(fcstInput[0], obsInput[0], config);
-   verification_grid = mode_exec->grid;
-   delete mode_exec;  mode_exec = 0;
-}
-
-////////////////////////////////////////////////////////////////////////
-
-MultiVarData *MultivarFrontEnd::create_simple_objects(ModeDataType dtype,  int j,
-                                                      int n_files,
-                                                      const string &filename,
-                                                      const ModeInputData &input)
-{
-   //
-   // create simple non merged objects
-   //
-   _simple_objects(ModeExecutive::MULTIVAR_SIMPLE, dtype, j, n_files,
-                   filename, input);
-   MultiVarData *mvdi = mode_exec->get_multivar_data(dtype);
-   delete mode_exec; mode_exec = 0;
-
-   //
-   // create simple merged objects
-   //
-   _simple_objects(ModeExecutive::MULTIVAR_SIMPLE_MERGE, dtype, j, n_files,
-                   filename, input);
-   mode_exec->add_multivar_merge_data(mvdi, dtype);
-   delete mode_exec;  mode_exec = 0;
-   return mvdi;
-}
-
-////////////////////////////////////////////////////////////////////////
-
-void
-MultivarFrontEnd::create_intensity_comparisons(int findex, int oindex,
-                                               const ModeSuperObject &fsuper,
-                                               const ModeSuperObject &osuper,
-                                               MultiVarData &mvdf, MultiVarData &mvdo,
-                                               const string &fcst_filename,
-                                               const string &obs_filename)
-{
-
-   // mask the input data to be valid only inside the simple super objects
-   fsuper.mask_data_simple("Fcst", mvdf);
-   osuper.mask_data_simple("Obs", mvdo);
-
-   mlog << Debug(1) << "Running mvmode intensity comparisions \n\n";
-
-   _init_exec(ModeExecutive::MULTIVAR_INTENSITY, fcst_filename, obs_filename);
-   mode_exec->init_multivar_intensities(config);
-
-   ModeConfInfo & conf = mode_exec->engine.conf_info;
-   conf.set_field_index(findex, oindex);
-
-   // for multivar intensities, explicity set the level and units using stored values
-   // from pass1
-   conf.Fcst->var_info->set_level_name(mvdf._level.c_str());
-   conf.Fcst->var_info->set_units(mvdf._units.c_str());
-   if (fsuper._hasUnion && conf.Fcst->merge_flag == MergeType::Thresh) {
-      mlog << Warning << "\nModeFrontEnd::multivar_intensity_comparisons() -> "
-           << "Logic includes union '||' along with  'merge_flag=THRESH' "
-           << ". This can lead to bad results\n\n";
-   }
-   conf.Obs->var_info->set_level_name(mvdo._level.c_str());
-   conf.Obs->var_info->set_units(mvdo._units.c_str());
-   if (osuper._hasUnion && conf.Obs->merge_flag == MergeType::Thresh) {
-      mlog << Warning << "\nModeFrontEnd::multivar_intensity_comparisons() -> "
-           << "Logic includes union '||' along with  'merge_flag=THRESH' "
-           << ". This can lead to bad results\n\n";
-   }
-       
-   //
-   // set up data access using inputs
-   //
-   mode_exec->setup_multivar_fcst_obs_data_intensities(mvdf, mvdo);
-
-   //
-   // run the mode algorithm for multivar intensities
-   //
-   _intensity_compare_mode_algorithm(mvdf, mvdo, fsuper, osuper);
-
-   delete mode_exec;  mode_exec = 0;
-}
-
-////////////////////////////////////////////////////////////////////////
-
-void MultivarFrontEnd::process_superobjects(ModeSuperObject &fsuper,
-                                            ModeSuperObject &osuper,
-                                            const MultiVarData &mvdf,
-                                            const MultiVarData &mvdo)
-{
-   mlog << Debug(1) << "Running superobject mode \n\n";
-
-   // set the data to 0 inside superobjects and missing everywhere else
-
-   fsuper.mask_data_super("FcstSimple", mvdf);
-   osuper.mask_data_super("ObsSimple", mvdo);
-
-   _init_exec(ModeExecutive::MULTIVAR_SUPER, "None", "None");
-   mode_exec->init_multivar_intensities(config);
-
-   ModeConfInfo & conf = mode_exec->engine.conf_info;
-   if ((fsuper._hasUnion || osuper._hasUnion) &&
-       (conf.Fcst->merge_flag == MergeType::Thresh ||
-        conf.Obs->merge_flag == MergeType::Thresh)) {
-      mlog << Warning << "\nModeFrontEnd::run_super() -> "
-           << "Logic includes union '||' along with  'merge_flag=THRESH' "
-           << ". This can lead to bad results\n\n";
-   }
-       
-   //
-   // set up data access using inputs
-   //
-   mode_exec->setup_multivar_fcst_obs_data_super(fsuper._simple_sd, osuper._simple_sd,
-                                                 *mvdf._grid);
-
-   // run the mode algorithm
-   _superobject_mode_algorithm(fsuper, osuper);
-
-   delete mode_exec;  mode_exec = 0;
-}
-
-////////////////////////////////////////////////////////////////////////
-
 void MultivarFrontEnd::_process_command_line(const StringArray & argv)
 
 {
-
    CommandLine cline;
 
    //
@@ -450,16 +300,12 @@ void MultivarFrontEnd::_process_command_line(const StringArray & argv)
    config_file = cline[2];
 
    return;
-
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-
 void MultivarFrontEnd::_read_config(const string & filename)
-
 {
-
    ConcatString path;
 
    path = replace_path(mode_default_config);
@@ -476,9 +322,7 @@ void MultivarFrontEnd::_read_config(const string & filename)
    // from within mode_exec:
    // engine.conf_info.nc_info.compress_level = engine.conf_info.get_compression_level();
 
-
    return;
-
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -491,7 +335,7 @@ void MultivarFrontEnd::_setup_inputs()
 
    if ( config.fcst_multivar_logic.empty() )  {
 
-      mlog << Error << "\nmultivar_consistency_checks() ->"
+      mlog << Error << "\nMultivarFrontEnd::_setup_inputs() ->"
            << "fcst multivar logic not specified in multivar mode!\n\n";
       exit ( 1 );
 
@@ -499,7 +343,7 @@ void MultivarFrontEnd::_setup_inputs()
 
    if ( config.obs_multivar_logic.empty() )  {
 
-      mlog << Error << "\nmultivar_consistency_checks() ->"
+      mlog << Error << "\nMultivarFrontEnd::_setup_inputs() ->"
            << "obs multivar logic not specified in multivar mode!\n\n";
       exit ( 1 );
 
@@ -516,7 +360,7 @@ void MultivarFrontEnd::_setup_inputs()
    //
    if ( n_fcst_files < 2 && n_obs_files < 2) {
 
-      mlog << Error << "\nmultivar_consistency_checks() ->"
+      mlog << Error << "\nMultivarFrontEnd::_setup_inputs() ->"
            << "Want at least 2 input files for fcst or obs in multivar mode, neither had 2 or more\n\n";
       exit ( 1 );
    }
@@ -538,7 +382,7 @@ void MultivarFrontEnd::_setup_inputs()
 
 
    if (config.fcst_multivar_compare_index.n() != config.obs_multivar_compare_index.n()) {
-      mlog << Error << "\nmultivar_consistency_checks() ->"
+      mlog << Error << "\nMultivarFrontEnd::_setup_inputs() ->"
            << " Need equal number of multivar_compare_index entries for obs and fcst\n\n";
       exit(1);
    }
@@ -549,13 +393,13 @@ void MultivarFrontEnd::_setup_inputs()
       int findex = config.fcst_multivar_compare_index[k];
       int oindex = config.obs_multivar_compare_index[k];
       if (findex <= 0 || findex > n_fcst_files) {
-         mlog << Error << "\nmultivar_consistency_checks() ->"
+         mlog << Error << "\nMultivarFrontEnd::_setup_inputs() ->"
               << " forecast index " << findex
               << " out of range, " << conf_key_fcst_multivar_compare_index << " array\n";
          badIndex = true;
       }
       if (oindex <= 0 || oindex > n_obs_files) {
-         mlog << Error << "\nmultivar_consistency_checks() ->"
+         mlog << Error << "\nMultivarFrontEnd::_setup_inputs() ->"
               << " obs index " << oindex
               << " out of range, " << conf_key_obs_multivar_compare_index << " array\n";
          badIndex = true;
@@ -593,7 +437,7 @@ void MultivarFrontEnd::_set_output_path()
 
       if ( status < 0 )  {
 
-         mlog << Error << "\nset_multivar_dir() ->"
+         mlog << Error << "\nMultivarFrontEnd::_set_output_path() ->"
               << " unable to create output directory \""
               << output_path << "\"\n\n";
 
@@ -620,7 +464,8 @@ int MultivarFrontEnd::_mkdir(const char *dir)
          string s = tmp;
          if (s != ".") {
             if (mkdir(tmp, dir_creation_mode) < 0) {
-               mlog << Error << "\n_mkdir() -> Error making " << tmp << "\n";
+               mlog << Error << "\nMultivarFrontEnd::_mkdir() ->"
+                    << "Error making " << tmp << "\n";
                return -1;
             }
          }
@@ -632,29 +477,291 @@ int MultivarFrontEnd::_mkdir(const char *dir)
 
 ////////////////////////////////////////////////////////////////////////
 
+void MultivarFrontEnd::_read_input(const string &name, int index, ModeDataType type,
+                                   GrdFileType f_t, GrdFileType other_t, int shift)
+{
+   Met2dDataFileFactory mtddf_factory;
+   Met2dDataFile *f = mtddf_factory.new_met_2d_data_file(name.c_str(), f_t);
+   if (!f) {
+      mlog << Error << "\nMultivarFrontEnd::_read_input() ->"
+           << "\nTrouble reading fcst file \"" << name << "\"\n\n";
+      exit(1);
+   }
+   Grid g = f->grid();
+   GrdFileType ft = f->file_type();
+
+   //?
+   f->set_shift_right(shift);
+
+   // update config now that we know file type (this sets Fcst to index i)
+   DataPlane dp;
+
+   if (type == ModeDataType::MvMode_Fcst) {
+      config.process_config_field(ft, other_t, type, index);
+      f->data_plane(*(config.Fcst->var_info), dp);
+      fcstInput.push_back(ModeInputData(name, dp, g));
+   } else {
+      config.process_config_field(other_t, ft, type, index);
+      f->data_plane(*(config.Obs->var_info), dp);
+      obsInput.push_back(ModeInputData(name, dp, g));
+   }         
+      
+   delete f;
+}
+      
+////////////////////////////////////////////////////////////////////////
+
+void MultivarFrontEnd::_create_verif_grid()
+{
+   mlog << Debug(2) << "\n creating the verification grid \n" << sep << "\n";
+
+   _init_exec(ModeExecutive::TRADITIONAL, "None", "None");
+   mode_exec->setup_verification_grid(fcstInput[0], obsInput[0], config);
+   verification_grid = mode_exec->grid;
+   delete mode_exec;  mode_exec = 0;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void MultivarFrontEnd::_create_simple_objects(ModeDataType dtype, const std::string &name,
+                                              int rIndex, int tIndex, int n_files,
+                                              const StringArray &filenames,
+                                              const std::vector<ModeInputData> &input,
+                                              BoolCalc &calc, SimpleObjects &O) const
+{
+   O.init(dtype, rIndex, tIndex);
+   for (int j=0; j<n_files; ++j)  {
+      mlog << Debug(2) 
+           << "\n" << sep << "\ncreating simple " << name << " objects from " << name << " "
+           << (j + 1) << " of " << n_files << "\n" << sep << "\n";
+      MultiVarData *mvdi = _create_simple_multivar_data(dtype, rIndex, tIndex, j, n_files, 
+                                                        filenames[j], input[j]);
+      mvdi->print();
+      O._mvd.push_back(mvdi);
+   }
+   O.setSuper(dtype == ModeDataType::MvMode_Fcst, n_files, do_clusters, calc);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+MultiVarData *MultivarFrontEnd::_create_simple_multivar_data(ModeDataType dtype,
+                                                             int rIndex, int tIndex,
+                                                             int j, int n_files,
+                                                             const string &filename,
+                                                             const ModeInputData &input) const
+{
+   //
+   // create simple non merged objects
+   //
+   _simple_objects(ModeExecutive::MULTIVAR_SIMPLE, dtype, rIndex, tIndex, j, n_files,
+                   filename, input);
+   MultiVarData *mvdi = mode_exec->get_multivar_data(dtype);
+   delete mode_exec; mode_exec = 0;
+
+   //
+   // create simple merged objects
+   //
+   _simple_objects(ModeExecutive::MULTIVAR_SIMPLE_MERGE, dtype, rIndex, tIndex, j, n_files,
+                   filename, input);
+   mode_exec->add_multivar_merge_data(mvdi, dtype);
+   delete mode_exec;  mode_exec = 0;
+   return mvdi;
+}
+
+////////////////////////////////////////////////////////////////////////
+
 void MultivarFrontEnd::_simple_objects(ModeExecutive::Processing_t p,
-                                       ModeDataType dtype,
-                                       int j, int n_files, const string &filename,
-                                       const ModeInputData &input)
+                                       ModeDataType dtype, int rIndex, 
+                                       int tIndex, int j, int n_files,
+                                       const string &filename,
+                                      const ModeInputData &input) const
 {
    if (dtype == ModeDataType::MvMode_Fcst) {
       _init_exec(p, filename, "None");
-      mode_exec->init_multivar_simple(j, n_files, dtype, config);
+      mode_exec->init_multivar_simple(rIndex, tIndex, j, n_files, dtype, config);
       mode_exec->setup_multivar_fcst_data(verification_grid, input);
    } else {
       _init_exec(p, "None", filename);
-      mode_exec->init_multivar_simple(j, n_files, dtype, config);
+      mode_exec->init_multivar_simple(rIndex, tIndex, j, n_files, dtype, config);
       mode_exec->setup_multivar_obs_data(verification_grid, input);
    }
    
-   _simple_mode_algorithm(p);
+   _simple_mode_algorithm(p, rIndex, tIndex);
 }   
+
+////////////////////////////////////////////////////////////////////////
+
+void MultivarFrontEnd::_simple_mode_algorithm(ModeExecutive::Processing_t p,
+                                              int rIndex, int tIndex) const
+{
+   // int NCT, NCR;
+   // _mode_algorithm_init(NCT, NCR);
+   mode_exec->clear_internal_r_index();
+   mode_exec->do_conv_thresh_multivar_simple(p, rIndex, tIndex);
+   mode_exec->clear_internal_r_index();
+#ifdef  WITH_PYTHON
+    GP.finalize();
+ #endif
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void
+MultivarFrontEnd::_create_intensity_comparisons(SimpleObjects &fcsts, int findex,
+                                                SimpleObjects &obs, int oindex,
+                                                //int rIndexF, int tIndexF, int findex,
+                                                //int rIndexO, int tIndexO, int oindex,
+                                                //const ModeSuperObject &fsuper,
+                                                //const ModeSuperObject &osuper,
+                                                //MultiVarData &mvdf, MultiVarData &mvdo,
+                                               const string &fcst_filename,
+                                               const string &obs_filename)
+{
+   MultiVarData *mvdf = fcsts._mvd[findex];
+   MultiVarData *mvdo = obs._mvd[oindex];
+   
+   // mask the input data to be valid only inside the simple super objects
+   fcsts._super.mask_data_simple("Fcst", *mvdf);
+   obs._super.mask_data_simple("Obs", *mvdo);
+
+   mlog << Debug(1) << "Running mvmode intensity comparisions \n\n";
+
+   _init_exec(ModeExecutive::MULTIVAR_INTENSITY, fcst_filename, obs_filename);
+   mode_exec->init_multivar_intensities(config);
+
+   ModeConfInfo & conf = mode_exec->engine.conf_info;
+   conf.set_field_index(findex, oindex);
+
+   // for multivar intensities, explicity set the level and units using stored values
+   // from pass1
+   conf.Fcst->var_info->set_level_name(mvdf->_level.c_str());
+   conf.Fcst->var_info->set_units(mvdf->_units.c_str());
+   if (fcsts._super._hasUnion && conf.Fcst->merge_flag == MergeType::Thresh) {
+      mlog << Warning << "\nModeFrontEnd::_create_intensity_comparisons() -> "
+           << "Logic includes union '||' along with  'merge_flag=THRESH' "
+           << ". This can lead to bad results\n\n";
+   }
+   conf.Obs->var_info->set_level_name(mvdo->_level.c_str());
+   conf.Obs->var_info->set_units(mvdo->_units.c_str());
+   if (obs._super._hasUnion && conf.Obs->merge_flag == MergeType::Thresh) {
+      mlog << Warning << "\nModeFrontEnd::_create_intensity_comparisons() -> "
+           << "Logic includes union '||' along with  'merge_flag=THRESH' "
+           << ". This can lead to bad results\n\n";
+   }
+       
+   //
+   // set up data access using inputs
+   //
+   mode_exec->setup_multivar_fcst_obs_data_intensities(*mvdf, *mvdo);
+
+   //
+   // run the mode algorithm for multivar intensities
+   //
+   _intensity_compare_mode_algorithm(fcsts._rIndex, fcsts._tIndex, obs._rIndex, obs._tIndex, *mvdf, *mvdo,
+                                     fcsts._super, obs._super);
+
+   delete mode_exec;  mode_exec = 0;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void
+MultivarFrontEnd::_intensity_compare_mode_algorithm(int rIndexF, int tIndexF, 
+                                                    int rIndexO, int tIndexO,
+                                                    const MultiVarData &mvdf,
+                                                    const MultiVarData &mvdo,
+                                                    const ModeSuperObject &fsuper,
+                                                    const ModeSuperObject &osuper)
+{
+   // int NCT, NCR;
+   // _mode_algorithm_init(NCT, NCR);
+   mode_exec->do_conv_thresh_multivar_intensity_compare(rIndexF, tIndexF, rIndexO, tIndexO);
+   mode_exec->do_match_merge_multivar(fsuper._merge_sd_split, osuper._merge_sd_split,
+                                      ModeExecutive::MULTIVAR_INTENSITY);
+      // here replace raw data and min/max for plotting
+   mode_exec->process_output_multivar_intensity_compare(&mvdf, &mvdo);
+   mode_exec->clear_internal_r_index();
+#ifdef  WITH_PYTHON
+    GP.finalize();
+ #endif
+}                                     
+
+////////////////////////////////////////////////////////////////////////
+
+// void MultivarFrontEnd::_process_superobjects(int rIndexF, int tIndexF,
+//                                             int rIndexO, int tIndexO,
+//                                             ModeSuperObject &fsuper,
+//                                             ModeSuperObject &osuper,
+//                                             const MultiVarData &mvdf,
+//                                             const MultiVarData &mvdo)
+void MultivarFrontEnd::_process_superobjects(SimpleObjects &fcsts, SimpleObjects &obs)
+         // _process_superobjects(fcstSimple[fi]._rIndex, fcstSimple[fi]._tIndex,
+         //                       obsSimple[oi]._rIndex, obsSimple[oi]._tIndex,
+         //                       fcstSimple[fi]._super, obsSimple[oi]._super,
+         //                       *(fcstSimple[fi]._mvd[0]), *(fcstSimple[oi]._mvd[0]));
+{
+   mlog << Debug(1) << "Running superobject mode \n\n";
+
+   MultiVarData *mvdf = fcsts._mvd[0];
+   MultiVarData *mvdo = obs._mvd[0];
+   
+   // set the data to 0 inside superobjects and missing everywhere else
+
+   fcsts._super.mask_data_super("FcstSimple", *mvdf);
+   obs._super.mask_data_super("ObsSimple", *mvdo);
+
+   _init_exec(ModeExecutive::MULTIVAR_SUPER, "None", "None");
+   mode_exec->init_multivar_intensities(config);
+
+   ModeConfInfo & conf = mode_exec->engine.conf_info;
+   if ((fcsts._super._hasUnion || obs._super._hasUnion) &&
+       (conf.Fcst->merge_flag == MergeType::Thresh ||
+        conf.Obs->merge_flag == MergeType::Thresh)) {
+      mlog << Warning << "\nModeFrontEnd::_process_superobjects() -> "
+           << "Logic includes union '||' along with  'merge_flag=THRESH' "
+           << ". This can lead to bad results\n\n";
+   }
+       
+   //
+   // set up data access using inputs
+   //
+   mode_exec->setup_multivar_fcst_obs_data_super(fcsts._super._simple_sd, obs._super._simple_sd,
+                                                 *(mvdf->_grid));
+
+   // run the mode algorithm
+   _superobject_mode_algorithm(fcsts._rIndex, fcsts._tIndex, obs._rIndex, obs._tIndex,
+                               fcsts._super, obs._super);
+
+   delete mode_exec;  mode_exec = 0;
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void
+MultivarFrontEnd::_superobject_mode_algorithm(int rIndexF, int tIndexF,
+                                              int rIndexO, int tIndexO,
+                                              const ModeSuperObject &fsuper,
+                                              const ModeSuperObject &osuper)
+
+{
+   // int NCT, NCR;
+   // _mode_algorithm_init(NCT, NCR);
+   mode_exec->clear_internal_r_index();
+   mode_exec->do_conv_thresh_multivar_super(rIndexF, tIndexF, rIndexO, tIndexO);
+   mode_exec->do_match_merge_multivar(fsuper._merge_sd_split, osuper._merge_sd_split,
+                                      ModeExecutive::MULTIVAR_SUPER);
+   mode_exec->process_output_multivar_super();
+   mode_exec->clear_internal_r_index();
+#ifdef  WITH_PYTHON
+    GP.finalize();
+ #endif
+}
 
 ////////////////////////////////////////////////////////////////////////
 
 void MultivarFrontEnd::_init_exec(ModeExecutive::Processing_t p,
                                   const string &ffile,
-                                  const string &ofile)
+                                  const string &ofile) const
 {
    mlog << Debug(1) << "Running multivar front end for " << ModeExecutive::stype(p) << "\n";
 
@@ -669,91 +776,4 @@ void MultivarFrontEnd::_init_exec(ModeExecutive::Processing_t p,
    mode_exec->out_dir = output_path;
 }
 
-////////////////////////////////////////////////////////////////////////
 
-void
-MultivarFrontEnd::_superobject_mode_algorithm(const ModeSuperObject &fsuper,
-                                              const ModeSuperObject &osuper)
-{
-   _mode_algorithm_init();
-   mode_exec->clear_internal_r_index();
-   mode_exec->do_conv_thresh_multivar_super();
-   mode_exec->do_match_merge_multivar(fsuper._merge_sd_split, osuper._merge_sd_split,
-                                      ModeExecutive::MULTIVAR_SUPER);
-   mode_exec->process_output_multivar_super();
-   mode_exec->clear_internal_r_index();
-#ifdef  WITH_PYTHON
-    GP.finalize();
- #endif
-}
-
-////////////////////////////////////////////////////////////////////////
-
-void
-MultivarFrontEnd::_intensity_compare_mode_algorithm(const MultiVarData &mvdf,
-                                                    const MultiVarData &mvdo,
-                                                    const ModeSuperObject &fsuper,
-                                                    const ModeSuperObject &osuper)
-{
-   _mode_algorithm_init();
-   mode_exec->do_conv_thresh_multivar_intensity_compare();
-   mode_exec->do_match_merge_multivar(fsuper._merge_sd_split, osuper._merge_sd_split,
-                                      ModeExecutive::MULTIVAR_INTENSITY);
-      // here replace raw data and min/max for plotting
-   mode_exec->process_output_multivar_intensity_compare(&mvdf, &mvdo);
-   mode_exec->clear_internal_r_index();
-#ifdef  WITH_PYTHON
-    GP.finalize();
- #endif
-}                                     
-
-
-////////////////////////////////////////////////////////////////////////
-
-void MultivarFrontEnd::_simple_mode_algorithm(ModeExecutive::Processing_t p)
-{
-   _mode_algorithm_init();
-   mode_exec->clear_internal_r_index();
-   mode_exec->do_conv_thresh_multivar_simple(p);
-   mode_exec->clear_internal_r_index();
-   
-#ifdef  WITH_PYTHON
-    GP.finalize();
- #endif
-}
-
-////////////////////////////////////////////////////////////////////////
-
-void MultivarFrontEnd::_mode_algorithm_init() const
-{
-   const ModeConfInfo & conf = mode_exec->engine.conf_info;
-   if ( conf.quilt )  {
-      mlog << Error << "\nMultiVarFontend::mode_algorithm() -> "
-           << "quilting not yet implemented for multivar mode \n\n";
-      exit ( 1 );
-   }
-
-   int NCT = conf.n_conv_threshs();
-   int NCR = conf.n_conv_radii();
-
-   if ( NCT != NCR )  {
-
-      mlog << Error << "\nMultivarFrontEnd::_mode_algorithm_init() ->"
-           << "all convolution radius and threshold arrays must have the same number of elements\n\n";
-
-      exit ( 1 );
-
-   }
-
-   if (NCT > 1) {
-
-      mlog << Error << "\nMultivarFrontEnd::_mode_algorithm_init() ->"
-           << ": multiple convolution radii and thresholds not implemented in multivar mode\n\n";
-
-      exit ( 1 );
-   }
-}
-
-
-
-    

--- a/src/tools/core/mode/multivar_frontend.cc
+++ b/src/tools/core/mode/multivar_frontend.cc
@@ -34,7 +34,7 @@ static const char mode_default_config [] = "MET_BASE/config/MODEMultivarConfig_d
 
 static const int dir_creation_mode = 0755;       
 
-static ModeExecutive *mode_exec = 0;
+static ModeExecutive *mode_exec = nullptr;
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -44,7 +44,7 @@ MultivarFrontEnd::MultivarFrontEnd()
    do_clusters = false;
    default_out_dir = ".";
    compress_level = -1;
-   mode_exec = 0;
+   mode_exec = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -52,7 +52,7 @@ MultivarFrontEnd::MultivarFrontEnd()
 MultivarFrontEnd::~MultivarFrontEnd()
 {
    if ( mode_exec ) {
-      delete mode_exec;  mode_exec = 0;
+      delete mode_exec;  mode_exec = nullptr;
    }
  }
 
@@ -71,16 +71,14 @@ int MultivarFrontEnd::run(const StringArray & Argv)
 
    // read in all the data
    for (int i=0; i<n_fcst_files; ++i) {
-      GrdFileType ft, ot;
-      ft = config.file_type_for_field(true, i);
-      ot = parse_conf_file_type(config.conf.lookup_dictionary(conf_key_obs));
+      GrdFileType ft = config.file_type_for_field(true, i);
+      GrdFileType ot = parse_conf_file_type(config.conf.lookup_dictionary(conf_key_obs));
       _read_input(fcst_filenames[i], i, ModeDataType::MvMode_Fcst, ft, ot, shift);
 
    }
    for (int i=0; i<n_obs_files; ++i) {
-      GrdFileType ft, ot;
-      ft = parse_conf_file_type(config.conf.lookup_dictionary(conf_key_fcst));
-      ot = config.file_type_for_field(false, i);
+      GrdFileType ft = parse_conf_file_type(config.conf.lookup_dictionary(conf_key_fcst));
+      GrdFileType ot = config.file_type_for_field(false, i);
       _read_input(obs_filenames[i], i, ModeDataType::MvMode_Obs, ot, ft, shift);
    }
    
@@ -122,13 +120,15 @@ int MultivarFrontEnd::run(const StringArray & Argv)
    int NR = NCRF;
    
    // containers for information needed to do additional things with simple objects after creation
-   vector<SimpleObjects> fcstSimple, obsSimple;
+   vector<SimpleObjects> fcstSimple;
+   vector<SimpleObjects> obsSimple;
 
    // create simple objects for all convolution settings
    if (config.quilt) {
       for (int ir=0; ir<NR; ++ir) {
          for (int it=0; it<NT; ++it) {
-            SimpleObjects OF, OO;
+            SimpleObjects OF;
+            SimpleObjects OO;
             _create_simple_objects(ModeDataType::MvMode_Fcst, "forecast", ir, it, n_fcst_files,
                                    fcst_filenames, fcstInput, f_calc, OF);
             fcstSimple.push_back(OF);
@@ -140,7 +140,8 @@ int MultivarFrontEnd::run(const StringArray & Argv)
    }
    else {
       for (int ir=0; ir<NR; ++ir) {
-         SimpleObjects OF, OO;
+         SimpleObjects OF;
+         SimpleObjects OO;
          _create_simple_objects(ModeDataType::MvMode_Fcst, "forecast", ir, ir, n_fcst_files,
                                 fcst_filenames, fcstInput, f_calc, OF);
          fcstSimple.push_back(OF);
@@ -154,7 +155,7 @@ int MultivarFrontEnd::run(const StringArray & Argv)
    // and obs
 
    for (size_t fi=0; fi<fcstSimple.size(); ++fi) {
-      int oi = fi;
+      auto oi = (int) fi;
 
       // Filter the data to within the superobjects only and do statistics by invoking mode
       // algorithm again on the masked data pairs
@@ -178,13 +179,9 @@ int MultivarFrontEnd::run(const StringArray & Argv)
    mlog << Debug(1) << "\n finished with multivar intensity comparisons \n" << sep << "\n";
 
    // clear out memory stored in the simple objects
-   
-   for (size_t i=0; i<fcstSimple.size(); ++i) {
-      fcstSimple[i].clear();
-   }   
-   for (size_t i=0; i<obsSimple.size(); ++i) {
-      obsSimple[i].clear();
-   }   
+
+   for (auto &x : fcstSimple) x.clear();
+   for (auto &x : obsSimple) x.clear();
 
    //
    //  done
@@ -315,8 +312,6 @@ void MultivarFrontEnd::_read_config(const string & filename)
    // what is this, command line overrides config?  look deeper.. remove from exec
    // except traditional mode
    if (compress_level >= 0) config.nc_info.set_compress_level(compress_level);
-   // from within mode_exec:
-   // engine.conf_info.nc_info.compress_level = engine.conf_info.get_compression_level();
 
    return;
 }
@@ -444,26 +439,24 @@ void MultivarFrontEnd::_set_output_path()
 
 ////////////////////////////////////////////////////////////////////////
 
-int MultivarFrontEnd::_mkdir(const char *dir)
+int MultivarFrontEnd::_mkdir(const char *dir) const
 {
    char tmp[256];
-   char *p = NULL;
    size_t len;
 
    snprintf(tmp, sizeof(tmp),"%s",dir);
    len = strlen(tmp);
    if (tmp[len - 1] == '/')
       tmp[len - 1] = 0;
-   for (p = tmp + 1; *p; p++)
+   for (char *p = tmp + 1; *p; p++)
       if (*p == '/') {
          *p = 0;
          string s = tmp;
-         if (s != ".") {
-            if (mkdir(tmp, dir_creation_mode) < 0) {
-               mlog << Error << "\nMultivarFrontEnd::_mkdir() ->"
-                    << "Error making " << tmp << "\n";
-               return -1;
-            }
+         if (s != "." &&
+             mkdir(tmp, dir_creation_mode) < 0) {
+            mlog << Error << "\nMultivarFrontEnd::_mkdir() ->"
+                 << "Error making " << tmp << "\n";
+            return -1;
          }
          *p = '/';
       }
@@ -514,7 +507,7 @@ void MultivarFrontEnd::_create_verif_grid()
    _init_exec(ModeExecutive::TRADITIONAL, "None", "None");
    mode_exec->setup_verification_grid(fcstInput[0], obsInput[0], config);
    verification_grid = mode_exec->grid;
-   delete mode_exec;  mode_exec = 0;
+   delete mode_exec;  mode_exec = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -553,7 +546,7 @@ MultiVarData *MultivarFrontEnd::_create_simple_multivar_data(ModeDataType dtype,
    _simple_objects(ModeExecutive::MULTIVAR_SIMPLE, dtype, rIndex, tIndex, j, n_files,
                    filename, input);
    MultiVarData *mvdi = mode_exec->get_multivar_data(dtype);
-   delete mode_exec; mode_exec = 0;
+   delete mode_exec; mode_exec = nullptr;
 
    //
    // create simple merged objects
@@ -561,7 +554,7 @@ MultiVarData *MultivarFrontEnd::_create_simple_multivar_data(ModeDataType dtype,
    _simple_objects(ModeExecutive::MULTIVAR_SIMPLE_MERGE, dtype, rIndex, tIndex, j, n_files,
                    filename, input);
    mode_exec->add_multivar_merge_data(mvdi, dtype);
-   delete mode_exec;  mode_exec = 0;
+   delete mode_exec;  mode_exec = nullptr;
    return mvdi;
 }
 
@@ -575,11 +568,11 @@ void MultivarFrontEnd::_simple_objects(ModeExecutive::Processing_t p,
 {
    if (dtype == ModeDataType::MvMode_Fcst) {
       _init_exec(p, filename, "None");
-      mode_exec->init_multivar_simple(rIndex, tIndex, j, n_files, dtype, config);
+      mode_exec->init_multivar_simple(rIndex, tIndex, j, dtype, config);
       mode_exec->setup_multivar_fcst_data(verification_grid, input);
    } else {
       _init_exec(p, "None", filename);
-      mode_exec->init_multivar_simple(rIndex, tIndex, j, n_files, dtype, config);
+      mode_exec->init_multivar_simple(rIndex, tIndex, j, dtype, config);
       mode_exec->setup_multivar_obs_data(verification_grid, input);
    }
    
@@ -654,7 +647,7 @@ MultivarFrontEnd::_create_intensity_comparisons(SimpleObjects &fcsts, int findex
    _intensity_compare_mode_algorithm(fcsts._rIndex, fcsts._tIndex, obs._rIndex, obs._tIndex, *mvdf, *mvdo,
                                      fcsts._super, obs._super);
 
-   delete mode_exec;  mode_exec = 0;
+   delete mode_exec;  mode_exec = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -716,7 +709,7 @@ void MultivarFrontEnd::_process_superobjects(SimpleObjects &fcsts, SimpleObjects
    _superobject_mode_algorithm(fcsts._rIndex, fcsts._tIndex, obs._rIndex, obs._tIndex,
                                fcsts._super, obs._super);
 
-   delete mode_exec;  mode_exec = 0;
+   delete mode_exec;  mode_exec = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -747,10 +740,9 @@ void MultivarFrontEnd::_init_exec(ModeExecutive::Processing_t p,
 {
    mlog << Debug(4) << "Running multivar front end for " << ModeExecutive::stype(p) << "\n";
 
-   if ( mode_exec )  { delete mode_exec;  mode_exec = 0; }
+   if ( mode_exec )  { delete mode_exec;  mode_exec = nullptr; }
 
    mode_exec = new ModeExecutive();
-   // compress_level = -1;
    mode_exec->fcst_file = ffile;
    mode_exec->obs_file = ofile;
 

--- a/src/tools/core/mode/multivar_frontend.cc
+++ b/src/tools/core/mode/multivar_frontend.cc
@@ -93,34 +93,41 @@ int MultivarFrontEnd::run(const StringArray & Argv)
    // Define the verification grid using the 0th fcst and obs inputs
    _create_verif_grid();
 
-   // in the implementation now, all 4 of these numbers must be the same
+   // in the implementation now, all 4 of these numbers must be the same without quilting
+   // and NCTF must equal NCTO, NCRF must equal NCRO with quilting
    int NCTF = config.n_conv_threshs_fcst();
    int NCRF = config.n_conv_radii_fcst();
    int NCTO = config.n_conv_threshs_obs();
    int NCRO = config.n_conv_radii_obs();
 
-   if ( NCTF != NCRF || NCTO != NCRO)  {
+   if (NCTF != NCTO) {
       mlog << Error << "\nMultivarFrontEnd::run() ->"
-           << "all convolution radius and threshold arrays must have the same number of elements\n\n";
-
+           << "all convolution threshold arrays must have the same number of elements\n\n";
       exit ( 1 );
    }
-   if (NCRO != NCRF) {
+   if (NCRF != NCRO) {
       mlog << Error << "\nMultivarFrontEnd::run() ->"
-           << "Unequal number of forecast and obs convolution radii not yet supported\n\n";
+           << "all convolution radius arrays must have the same number of elements\n\n";
       exit ( 1 );
    }
 
-   // the single number of convolution parameter choices shared by all inputs
-   int NCONV = NCRO;
+   if ((!config.quilt) && NCTF != NCRF || NCTO != NCRO) {
+      mlog << Error << "\nMultivarFrontEnd::run() ->"
+           << "all convolution radius and threshold arrays must have the same number of elements without quilting\n\n";
+      exit ( 1 );
+   }
+
+   // the numbers to use
+   int NT = NCTF;
+   int NR = NCRF;
    
    // containers for information needed to do additional things with simple objects after creation
    vector<SimpleObjects> fcstSimple, obsSimple;
 
    // create simple objects for all convolution settings
    if (config.quilt) {
-      for (int ir=0; ir<NCONV; ++ir) {
-         for (int it=0; it<NCONV; ++it) {
+      for (int ir=0; ir<NR; ++ir) {
+         for (int it=0; it<NT; ++it) {
             SimpleObjects OF, OO;
             _create_simple_objects(ModeDataType::MvMode_Fcst, "forecast", ir, it, n_fcst_files,
                                    fcst_filenames, fcstInput, f_calc, OF);
@@ -132,7 +139,7 @@ int MultivarFrontEnd::run(const StringArray & Argv)
       }
    }
    else {
-      for (int ir=0; ir<NCONV; ++ir) {
+      for (int ir=0; ir<NR; ++ir) {
          SimpleObjects OF, OO;
          _create_simple_objects(ModeDataType::MvMode_Fcst, "forecast", ir, ir, n_fcst_files,
                                 fcst_filenames, fcstInput, f_calc, OF);
@@ -522,7 +529,8 @@ void MultivarFrontEnd::_create_simple_objects(ModeDataType dtype, const std::str
    for (int j=0; j<n_files; ++j)  {
       mlog << Debug(2) 
            << "\n" << sep << "\ncreating simple " << name << " objects from " << name << " "
-           << (j + 1) << " of " << n_files << "\n" << sep << "\n";
+           << (j + 1) << " of " << n_files << "\nconv_radius[" << rIndex+1 << "] conv_thresh["
+           << tIndex+1 << "]\n" << sep << "\n";
       MultiVarData *mvdi = _create_simple_multivar_data(dtype, rIndex, tIndex, j, n_files, 
                                                         filenames[j], input[j]);
       mvdi->print();
@@ -668,17 +676,7 @@ MultivarFrontEnd::_intensity_compare_mode_algorithm(int rIndexF, int tIndexF,
 
 ////////////////////////////////////////////////////////////////////////
 
-// void MultivarFrontEnd::_process_superobjects(int rIndexF, int tIndexF,
-//                                             int rIndexO, int tIndexO,
-//                                             ModeSuperObject &fsuper,
-//                                             ModeSuperObject &osuper,
-//                                             const MultiVarData &mvdf,
-//                                             const MultiVarData &mvdo)
 void MultivarFrontEnd::_process_superobjects(SimpleObjects &fcsts, SimpleObjects &obs)
-         // _process_superobjects(fcstSimple[fi]._rIndex, fcstSimple[fi]._tIndex,
-         //                       obsSimple[oi]._rIndex, obsSimple[oi]._tIndex,
-         //                       fcstSimple[fi]._super, obsSimple[oi]._super,
-         //                       *(fcstSimple[fi]._mvd[0]), *(fcstSimple[oi]._mvd[0]));
 {
    mlog << Debug(1) << "Running superobject mode \n\n";
 

--- a/src/tools/core/mode/multivar_frontend.cc
+++ b/src/tools/core/mode/multivar_frontend.cc
@@ -679,8 +679,8 @@ void MultivarFrontEnd::_process_superobjects(SimpleObjects &fcsts, SimpleObjects
         << "\nRunning mvmode superobject analysis conv_radius[" << fcsts._rIndex+1
         << "] conv_thresh[" << fcsts._tIndex+1 << "]\n" << sep << "\n";
 
-   MultiVarData *mvdf = fcsts._mvd[0];
-   MultiVarData *mvdo = obs._mvd[0];
+   const MultiVarData *mvdf = fcsts._mvd[0];
+   const MultiVarData *mvdo = obs._mvd[0];
    
    // set the data to 0 inside superobjects and missing everywhere else
 
@@ -690,7 +690,7 @@ void MultivarFrontEnd::_process_superobjects(SimpleObjects &fcsts, SimpleObjects
    _init_exec(ModeExecutive::MULTIVAR_SUPER, "None", "None");
    mode_exec->init_multivar_intensities(config);
 
-   ModeConfInfo & conf = mode_exec->engine.conf_info;
+   const ModeConfInfo & conf = mode_exec->engine.conf_info;
    if ((fcsts._super._hasUnion || obs._super._hasUnion) &&
        (conf.Fcst->merge_flag == MergeType::Thresh ||
         conf.Obs->merge_flag == MergeType::Thresh)) {

--- a/src/tools/core/mode/multivar_frontend.cc
+++ b/src/tools/core/mode/multivar_frontend.cc
@@ -66,11 +66,10 @@ int MultivarFrontEnd::run(const StringArray & Argv)
 
    mlog << Debug(2) << "\n" << sep << "\n";
 
-   // read in all the data
-
    // in the conf object, shift *can* be set independently for obs and fcst
    int shift = config.shift_right;
 
+   // read in all the data
    for (int i=0; i<n_fcst_files; ++i) {
       GrdFileType ft, ot;
       ft = config.file_type_for_field(true, i);
@@ -91,7 +90,6 @@ int MultivarFrontEnd::run(const StringArray & Argv)
    // need data to set percentile thresholds so do so now
    config.config_set_all_percentile_thresholds(fcstInput, obsInput);
 
-
    // Define the verification grid using the 0th fcst and obs inputs
    _create_verif_grid();
 
@@ -107,61 +105,53 @@ int MultivarFrontEnd::run(const StringArray & Argv)
 
       exit ( 1 );
    }
-
    if (NCRO != NCRF) {
       mlog << Error << "\nMultivarFrontEnd::run() ->"
            << "Unequal number of forecast and obs convolution radii not yet supported\n\n";
       exit ( 1 );
    }
 
-   // the single array length
+   // the single number of convolution parameter choices shared by all inputs
    int NCONV = NCRO;
    
-   // containers for information needed to do things with simple objects after creation
+   // containers for information needed to do additional things with simple objects after creation
    vector<SimpleObjects> fcstSimple, obsSimple;
 
+   // create simple objects for all convolution settings
    if (config.quilt) {
       for (int ir=0; ir<NCONV; ++ir) {
          for (int it=0; it<NCONV; ++it) {
-            SimpleObjects O;
+            SimpleObjects OF, OO;
             _create_simple_objects(ModeDataType::MvMode_Fcst, "forecast", ir, it, n_fcst_files,
-                                   fcst_filenames, fcstInput, f_calc, O);
-            fcstSimple.push_back(O);
-         }
-      }
-      for (int ir=0; ir<NCONV; ++ir) {
-         for (int it=0; it<NCONV; ++it) {
-            SimpleObjects O;
+                                   fcst_filenames, fcstInput, f_calc, OF);
+            fcstSimple.push_back(OF);
             _create_simple_objects(ModeDataType::MvMode_Obs, "obs", ir, it, n_obs_files,
-                                   obs_filenames, obsInput, o_calc, O);
-            obsSimple.push_back(O);
+                                   obs_filenames, obsInput, o_calc, OO);
+            obsSimple.push_back(OO);
          }
       }
    }
    else {
       for (int ir=0; ir<NCONV; ++ir) {
-         SimpleObjects O;
+         SimpleObjects OF, OO;
          _create_simple_objects(ModeDataType::MvMode_Fcst, "forecast", ir, ir, n_fcst_files,
-                                fcst_filenames, fcstInput, f_calc, O);
-         fcstSimple.push_back(O);
-      }
-      for (int ir=0; ir<NCONV; ++ir) {
-         SimpleObjects O;
+                                fcst_filenames, fcstInput, f_calc, OF);
+         fcstSimple.push_back(OF);
          _create_simple_objects(ModeDataType::MvMode_Obs, "obs", ir, ir, n_obs_files,
-                                obs_filenames, obsInput, o_calc, O);
-         obsSimple.push_back(O);
+                                obs_filenames, obsInput, o_calc, OO);
+         obsSimple.push_back(OO);
       }
    }
 
-   for (int fi=0; fi<NCONV; ++fi) {
+   // Note at this point we know the compare index arrays are the same length for fcst
+   // and obs
+
+   for (size_t fi=0; fi<fcstSimple.size(); ++fi) {
       int oi = fi;
-      //
+
       // Filter the data to within the superobjects only and do statistics by invoking mode
       // algorithm again on the masked data pairs
-      //
-      // Note at this point we know the compare index arrays are the same length for fcst
-      // and obs
-      //
+
       for (int k=0; k<config.fcst_multivar_compare_index.n(); ++k)
       {
          int findex = config.fcst_multivar_compare_index[k] - 1;
@@ -171,9 +161,8 @@ int MultivarFrontEnd::run(const StringArray & Argv)
                                        fcst_filenames[findex], obs_filenames[oindex]);
       }
 
-      //
       // special case of just superobject statistics, no comparisons configured
-      //
+
       if (config.fcst_multivar_compare_index.n() <= 0) {
          _process_superobjects(fcstSimple[fi], obsSimple[oi]);
       }
@@ -594,8 +583,6 @@ void MultivarFrontEnd::_simple_objects(ModeExecutive::Processing_t p,
 void MultivarFrontEnd::_simple_mode_algorithm(ModeExecutive::Processing_t p,
                                               int rIndex, int tIndex) const
 {
-   // int NCT, NCR;
-   // _mode_algorithm_init(NCT, NCR);
    mode_exec->clear_internal_r_index();
    mode_exec->do_conv_thresh_multivar_simple(p, rIndex, tIndex);
    mode_exec->clear_internal_r_index();
@@ -609,11 +596,6 @@ void MultivarFrontEnd::_simple_mode_algorithm(ModeExecutive::Processing_t p,
 void
 MultivarFrontEnd::_create_intensity_comparisons(SimpleObjects &fcsts, int findex,
                                                 SimpleObjects &obs, int oindex,
-                                                //int rIndexF, int tIndexF, int findex,
-                                                //int rIndexO, int tIndexO, int oindex,
-                                                //const ModeSuperObject &fsuper,
-                                                //const ModeSuperObject &osuper,
-                                                //MultiVarData &mvdf, MultiVarData &mvdo,
                                                const string &fcst_filename,
                                                const string &obs_filename)
 {
@@ -673,8 +655,6 @@ MultivarFrontEnd::_intensity_compare_mode_algorithm(int rIndexF, int tIndexF,
                                                     const ModeSuperObject &fsuper,
                                                     const ModeSuperObject &osuper)
 {
-   // int NCT, NCR;
-   // _mode_algorithm_init(NCT, NCR);
    mode_exec->do_conv_thresh_multivar_intensity_compare(rIndexF, tIndexF, rIndexO, tIndexO);
    mode_exec->do_match_merge_multivar(fsuper._merge_sd_split, osuper._merge_sd_split,
                                       ModeExecutive::MULTIVAR_INTENSITY);
@@ -744,8 +724,6 @@ MultivarFrontEnd::_superobject_mode_algorithm(int rIndexF, int tIndexF,
                                               const ModeSuperObject &osuper)
 
 {
-   // int NCT, NCR;
-   // _mode_algorithm_init(NCT, NCR);
    mode_exec->clear_internal_r_index();
    mode_exec->do_conv_thresh_multivar_super(rIndexF, tIndexF, rIndexO, tIndexO);
    mode_exec->do_match_merge_multivar(fsuper._merge_sd_split, osuper._merge_sd_split,

--- a/src/tools/core/mode/multivar_frontend.cc
+++ b/src/tools/core/mode/multivar_frontend.cc
@@ -111,7 +111,7 @@ int MultivarFrontEnd::run(const StringArray & Argv)
       exit ( 1 );
    }
 
-   if ((!config.quilt) && NCTF != NCRF || NCTO != NCRO) {
+   if ((!config.quilt) && (NCTF != NCRF || NCTO != NCRO)) {
       mlog << Error << "\nMultivarFrontEnd::run() ->"
            << "all convolution radius and threshold arrays must have the same number of elements without quilting\n\n";
       exit ( 1 );

--- a/src/tools/core/mode/multivar_frontend.h
+++ b/src/tools/core/mode/multivar_frontend.h
@@ -20,6 +20,7 @@
 #include "two_d_array.h"
 #include "bool_calc.h"
 #include "multivar_data.h"
+#include "simple_objects.hh"
 #include "mode_superobject.h"
 #include "mode_input_data.h"
 #include "mode_exec.h"
@@ -37,21 +38,40 @@ private:
    std::string fcst_fof;
    std::string obs_fof;
 
+   void _init(const StringArray & Argv);
    void _process_command_line(const StringArray &);
    void _read_config(const std::string & filename);
    void _setup_inputs();
    void _set_output_path();
    int  _mkdir(const char *dir);
-   void _simple_objects(ModeExecutive::Processing_t p, ModeDataType dtype,
-                        int j, int n_files, const std::string &filename,
-                        const ModeInputData &input);
-   void _init_exec(ModeExecutive::Processing_t p, const std::string &ffile, const std::string &ofile);
-   void _superobject_mode_algorithm(const ModeSuperObject &fsuper, const ModeSuperObject &osuper);
-   void _intensity_compare_mode_algorithm(const MultiVarData &mvdf, const MultiVarData &mvdo,
-                                          const ModeSuperObject &fsuper, const ModeSuperObject &osuper);
-   void _simple_mode_algorithm(ModeExecutive::Processing_t p);
-   void _mode_algorithm_init() const;
+   void _read_input(const std::string &name, int index, ModeDataType type,
+                    GrdFileType f_t, GrdFileType other_t, int shift);
+   void _create_verif_grid(void);
 
+   void _create_simple_objects(ModeDataType dtype, const std::string &name,
+                               int rIndex, int tIndex, int n_files,
+                               const StringArray &filenames, const std::vector<ModeInputData> &input,
+                               BoolCalc &calc, SimpleObjects &O) const;
+   MultiVarData *_create_simple_multivar_data(ModeDataType dtype, int rIndex, int tIndex,
+                                              int j, int n_files, const std::string &filename,
+                                              const ModeInputData &input) const;
+   void _simple_objects(ModeExecutive::Processing_t p, ModeDataType dtype, int rIndex,
+                        int tIndex, int j, int n_files, const std::string &filename,
+                        const ModeInputData &input) const;
+   void _simple_mode_algorithm(ModeExecutive::Processing_t p, int rIndex, int tIndex) const;
+
+   void _create_intensity_comparisons(SimpleObjects &fcsts, int findex, SimpleObjects &obs, int oindex,
+                                      const string &fcst_filename, const string &obs_filename);
+   void _intensity_compare_mode_algorithm(int rIndexF, int tIndexF, int rIndexO, int tIndexO,
+                                          const MultiVarData &mvdf, const MultiVarData &mvdo,
+                                          const ModeSuperObject &fsuper, const ModeSuperObject &osuper);
+
+   void _process_superobjects(SimpleObjects &fcsts, SimpleObjects &obs);
+   void _superobject_mode_algorithm(int rIndexF, int tIndexF, int rIndexO, int tIndexO,
+                                    const ModeSuperObject &fsuper, const ModeSuperObject &osuper);
+
+   void _init_exec(ModeExecutive::Processing_t p, const std::string &ffile, const std::string &ofile) const;
+   
 public:
 
    bool do_clusters;
@@ -66,36 +86,12 @@ public:
 
    ~MultivarFrontEnd();
 
-
    int run(const StringArray & Argv);
-   void init(const StringArray & Argv);
 
    static void set_outdir    (const StringArray &);
    static void set_logfile   (const StringArray &);
    static void set_verbosity (const StringArray &);
    static void set_compress  (const StringArray &);
-
-   void read_input(const std::string &name, int index, ModeDataType type,
-                   GrdFileType f_t, GrdFileType other_t, int shift);
-
-
-   void create_verif_grid(void);
-
-   MultiVarData *create_simple_objects(ModeDataType dtype, int j, int n_files,
-                                       const std::string &filename,
-                                       const ModeInputData &input);
-
-   void create_intensity_comparisons(int findex, int oindex,
-                                     const ModeSuperObject &fsuper,
-                                     const ModeSuperObject &osuper,
-                                     MultiVarData &mvdf, MultiVarData &mvdo,
-                                     const std::string &fcst_filename,
-                                     const std::string &obs_filename);
-
-   void process_superobjects(ModeSuperObject &fsuper,
-                             ModeSuperObject &osuper,
-                             const MultiVarData &mvdf,
-                             const MultiVarData &mvdo);
 
 };
 

--- a/src/tools/core/mode/multivar_frontend.h
+++ b/src/tools/core/mode/multivar_frontend.h
@@ -32,9 +32,12 @@ private:
    int n_fcst_files, n_obs_files;
    StringArray fcst_filenames;
    StringArray  obs_filenames;
-   BoolCalc f_calc, o_calc ;
-   std::vector<ModeInputData> fcstInput, obsInput;
-   std::vector<MultiVarData *> mvdFcst, mvdObs;
+   BoolCalc f_calc;
+   BoolCalc o_calc;
+   std::vector<ModeInputData> fcstInput;
+   std::vector<ModeInputData>  obsInput;
+   std::vector<MultiVarData *> mvdFcst;
+   std::vector<MultiVarData *> mvdObs;
    std::string fcst_fof;
    std::string obs_fof;
 
@@ -43,7 +46,7 @@ private:
    void _read_config(const std::string & filename);
    void _setup_inputs();
    void _set_output_path();
-   int  _mkdir(const char *dir);
+   int  _mkdir(const char *dir) const;
    void _read_input(const std::string &name, int index, ModeDataType type,
                     GrdFileType f_t, GrdFileType other_t, int shift);
    void _create_verif_grid(void);

--- a/src/tools/core/mode/simple_objects.cc
+++ b/src/tools/core/mode/simple_objects.cc
@@ -1,0 +1,57 @@
+// *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+// ** Copyright UCAR (c) 1992 - 2024
+// ** University Corporation for Atmospheric Research (UCAR)
+// ** National Center for Atmospheric Research (NCAR)
+// ** Research Applications Lab (RAL)
+// ** P.O.Box 3000, Boulder, Colorado, 80307-3000, USA
+// *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+
+
+////////////////////////////////////////////////////////////////////////
+
+#include "simple_objects.hh"
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////
+
+SimpleObjects::SimpleObjects() :
+   _dataType(ModeDataType::MvMode_Both),
+   _rIndex(-1),
+   _tIndex(-1)
+{
+}
+
+////////////////////////////////////////////////////////////////////////
+
+SimpleObjects::~SimpleObjects()
+{
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void SimpleObjects::init(ModeDataType dataType, int rIndex, int tIndex)
+{
+   _dataType = dataType;
+   _rIndex = rIndex;
+   _tIndex = tIndex;
+}             
+
+////////////////////////////////////////////////////////////////////////
+
+void SimpleObjects::setSuper(bool isFcst, int n_fcst_files, bool do_clusters,
+                             BoolCalc &f_calc)
+{
+   _super = ModeSuperObject(isFcst, n_fcst_files, do_clusters, _mvd, f_calc);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+void SimpleObjects::clear(void)
+{
+   for (size_t j=0; j<_mvd.size(); ++j) {
+      delete _mvd[j];
+      _mvd[j] = 0;
+   }
+   _mvd.clear();
+}

--- a/src/tools/core/mode/simple_objects.cc
+++ b/src/tools/core/mode/simple_objects.cc
@@ -50,9 +50,9 @@ void SimpleObjects::setSuper(bool isFcst, int n_fcst_files, bool do_clusters,
 
 void SimpleObjects::clear(void)
 {
-   for (size_t j=0; j<_mvd.size(); ++j) {
-      delete _mvd[j];
-      _mvd[j] = 0;
+   for (auto &x : _mvd) {
+      delete x;
+      x = nullptr;
    }
    _mvd.clear();
 }

--- a/src/tools/core/mode/simple_objects.cc
+++ b/src/tools/core/mode/simple_objects.cc
@@ -42,7 +42,8 @@ void SimpleObjects::init(ModeDataType dataType, int rIndex, int tIndex)
 void SimpleObjects::setSuper(bool isFcst, int n_fcst_files, bool do_clusters,
                              BoolCalc &f_calc)
 {
-   _super = ModeSuperObject(isFcst, n_fcst_files, do_clusters, _mvd, f_calc);
+   _super = ModeSuperObject(isFcst, n_fcst_files, do_clusters,
+                            _rIndex, _tIndex, _mvd, f_calc);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/mode/simple_objects.hh
+++ b/src/tools/core/mode/simple_objects.hh
@@ -1,0 +1,48 @@
+// ** Copyright UCAR (c) 1992 - 2024
+// ** University Corporation for Atmospheric Research (UCAR)
+// ** National Center for Atmospheric Research (NCAR)
+// ** Research Applications Lab (RAL)
+// ** P.O.Box 3000, Boulder, Colorado, 80307-3000, USA
+// *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+#ifndef  __SIMPLE_OBJECTS_H__
+#define  __SIMPLE_OBJECTS_H__
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+#include <iostream>
+#include <vector>
+#include "multivar_data.h"
+#include "mode_superobject.h"
+#include "bool_calc.h"
+
+class SimpleObjects {
+
+ private:
+
+ public:
+
+   SimpleObjects();
+   ~SimpleObjects();
+
+   void init(ModeDataType dataType, int rIndex, int tIndex);
+   void setSuper(bool isFcst, int n_fcst_files, bool do_clusters, BoolCalc &f_calc);
+   void clear(void);
+             
+   ModeDataType _dataType;  /**< observations or forecasts */
+   int _rIndex;             /**< Convolution radius index */
+   int _tIndex;            /**< Convolution threshold index */
+   std::vector<MultiVarData *> _mvd;  /**< The data from each input */
+   ModeSuperObject _super;   /**< The superobject created from the data */
+};
+
+#endif   /*  __MODE_FRONT_END_H__  */
+
+
+/////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/mode/simple_objects.hh
+++ b/src/tools/core/mode/simple_objects.hh
@@ -24,8 +24,6 @@
 
 class SimpleObjects {
 
- private:
-
  public:
 
    SimpleObjects();


### PR DESCRIPTION
## Expected Differences ##
quilting and non-quilting options are now supported. 

Without quilting all inputs (forecast and obs) need to have the same number N of convolution radii and thresholds, with one mvmode run for the first set, one for the second set, etc. for a total of N runs.

With quilting all inputs must have the same number of convolution radii N, and all inputs must have the same number of convolution thresholds M, but N and M can differ. N*M mvmode runs are performed.

- [ ] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>

- [ ] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>

## Pull Request Testing ##

- [ ] Describe testing already performed for these changes:</br>
I ran several tests on seneca on the same case I've used for other MvMode changes.  Tested with and without quilting.  The tests can be found here:  /d1/personal/dave/mvmode_november_test.  The scripts that I ran are:  run-multi.bsh  run-quilt.bsh check-multi.bsh.
Comments in these files show what I was testing.  I did kind of make up some of the convolution settings (not scientific).

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
I'd recommend starting with these tests to see if you like the logging and output file names and content.  Everything is local to /d1/personal/dave/mvmode_november_test.

- [ ] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**  I hope no errors or warning happen, my changes were pretty minor to the user document.

- [ ] Do these changes include sufficient testing updates? **[Maybe]**  @hertneky you are wecome to create a better more meaningful scientific test or two.

- [ ] Will this PR result in changes to the MET test suite? **[Maybe]**</br>
I'm wondering if the version which gets written to the output files will cause the test suite to fail, because the version has changed to v12.1.  We'll find out.
Also, should we add a test that has mvmode with multiple conv. thresh/radii to the unit tests?

- [ ] Will this PR result in changes to existing METplus Use Cases? **[Maybe?]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.
Will this version change to  v12.1  which is written to output files cause problems with existing METplus Use Cases?

- [ ] Do these changes introduce new SonarQube findings? **[?]**</br>  How do I test for that?

- [ ] Please complete this pull request review by **[Dec 31]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **MET-X.Y.Z Development** project for official releases
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
