### PR TITLE
Bugfix #3054 main_v12.0 parusr

### DIFF
--- a/src/libcode/vx_statistics/pair_base.cc
+++ b/src/libcode/vx_statistics/pair_base.cc
@@ -705,22 +705,21 @@ void PairBase::calc_obs_summary(){
    if(!IsPointVx) return;
 
    //  iterate over the keys in the unique station id map
-   for(int i=0; i<map_key.n(); i++) {
-
-      station_values_t svt = map_val[map_key[i]];
+   for(auto &v : map_val) {
 
       //  parse the single key string
       char** mat = nullptr;
       if( 5 != regex_apply("^([^:]+):([^:]+):([^:]+):([^:]+)$", 5,
-                           map_key[i].c_str(), mat) ){
+                           v.first.c_str(), mat) ){
          mlog << Error << "\nPairBase::calc_obs_summary() -> "
               << "regex_apply failed to parse '"
-              << map_key[i] << "'\n\n";
+              << v.first << "'\n\n";
          exit(1);
       }
 
-      string msg_key = str_format("%s:%s:%s:%s", mat[1], mat[2], mat[3],
-                                  mat[4]).text();
+      string msg_key = str_format("%s:%s:%s:%s",
+                                  mat[1], mat[2],
+                                  mat[3], mat[4]).text();
 
       ob_val_t ob;
 
@@ -754,21 +753,22 @@ void PairBase::calc_obs_summary(){
       }
 
       // Store summarized value in the map
-      svt.summary_val = ob.val;
+      v.second.summary_val = ob.val;
 
-      typ_sa.add    (svt.typ.c_str());
-      sid_sa.add    (svt.sid.c_str());
-      lat_na.add    (svt.lat);
-      lon_na.add    (svt.lon);
-      x_na.add      (svt.x);
-      y_na.add      (svt.y);
-      wgt_na.add    (svt.wgt);
+      typ_sa.add    (v.second.typ.c_str());
+      sid_sa.add    (v.second.sid.c_str());
+      lat_na.add    (v.second.lat);
+      lon_na.add    (v.second.lon);
+      x_na.add      (v.second.x);
+      y_na.add      (v.second.y);
+      wgt_na.add    (v.second.wgt);
       vld_ta.add    (ob.ut);
-      lvl_na.add    (svt.lvl);
-      elv_na.add    (svt.elv);
+      lvl_na.add    (v.second.lvl);
+      elv_na.add    (v.second.elv);
       o_na.add      (ob.val);
       o_qc_sa.add   (ob.qc.c_str());
-      ClimoPntInfo cpi(svt.fcmn, svt.fcsd, svt.ocmn, svt.ocsd);
+      ClimoPntInfo cpi(v.second.fcmn, v.second.fcsd,
+                       v.second.ocmn, v.second.ocsd);
       add_climo(ob.val, cpi);
 
       // Increment the number of pairs

--- a/src/libcode/vx_statistics/pair_base.cc
+++ b/src/libcode/vx_statistics/pair_base.cc
@@ -705,15 +705,17 @@ void PairBase::calc_obs_summary(){
    if(!IsPointVx) return;
 
    //  iterate over the keys in the unique station id map
-   for(auto &v : map_val) {
+   for(int i=0; i<map_key.n(); i++) {
+
+      station_values_t * svt = &map_val[map_key[i]];
 
       //  parse the single key string
       char** mat = nullptr;
-      if( 5 != regex_apply("^([^:]+):([^:]+):([^:]+):([^:]+)$", 5,
-                           v.first.c_str(), mat) ){
+      if(5 != regex_apply("^([^:]+):([^:]+):([^:]+):([^:]+)$", 5,
+                          map_key[i].c_str(), mat) ){
          mlog << Error << "\nPairBase::calc_obs_summary() -> "
               << "regex_apply failed to parse '"
-              << v.first << "'\n\n";
+              << map_key[i] << "'\n\n";
          exit(1);
       }
 
@@ -753,22 +755,22 @@ void PairBase::calc_obs_summary(){
       }
 
       // Store summarized value in the map
-      v.second.summary_val = ob.val;
+      svt->summary_val = ob.val;
 
-      typ_sa.add    (v.second.typ.c_str());
-      sid_sa.add    (v.second.sid.c_str());
-      lat_na.add    (v.second.lat);
-      lon_na.add    (v.second.lon);
-      x_na.add      (v.second.x);
-      y_na.add      (v.second.y);
-      wgt_na.add    (v.second.wgt);
+      typ_sa.add    (svt->typ.c_str());
+      sid_sa.add    (svt->sid.c_str());
+      lat_na.add    (svt->lat);
+      lon_na.add    (svt->lon);
+      x_na.add      (svt->x);
+      y_na.add      (svt->y);
+      wgt_na.add    (svt->wgt);
       vld_ta.add    (ob.ut);
-      lvl_na.add    (v.second.lvl);
-      elv_na.add    (v.second.elv);
+      lvl_na.add    (svt->lvl);
+      elv_na.add    (svt->elv);
       o_na.add      (ob.val);
       o_qc_sa.add   (ob.qc.c_str());
-      ClimoPntInfo cpi(v.second.fcmn, v.second.fcsd,
-                       v.second.ocmn, v.second.ocsd);
+      ClimoPntInfo cpi(svt->fcmn, svt->fcsd,
+                       svt->ocmn, svt->ocsd);
       add_climo(ob.val, cpi);
 
       // Increment the number of pairs

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -2461,7 +2461,7 @@ void process_pbfile_metadata(int i_pb) {
    if (has_prepbufr_vars) {
       for (int vIdx=0; vIdx< prepbufr_derive_vars.n(); vIdx++) {
          const string tmp_var_name = prepbufr_derive_vars[vIdx].c_str();
-         bufr_derive_cfgs.emplace_back(derive_var_cfg(tmp_var_name));
+         bufr_derive_cfgs.push_back(derive_var_cfg(tmp_var_name));
          if (do_all_vars || bufr_target_variables.has(tmp_var_name)) {
             // Set the variable index if requested
             bufr_obs_name_arr.add(tmp_var_name);

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -59,6 +59,7 @@
 //   019    07/21/23  Prestopnik, J. MET #2615 Add #include <array> to compile
 //                                   successfully using gcc12
 //   020    08/26/24  Halley Gotway  MET #2938 Silence center time warnings
+//   021    01/30/25  Halley Gotway  MET #3054 Fix PARUSR BUFRLIB error
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -2444,10 +2445,9 @@ void process_pbfile_metadata(int i_pb) {
 
    int bufr_var_index = 0;
    bool has_prepbufr_vars = false;
-   const char * tmp_var_name;
    bufr_obs_name_arr.clear();
    for (index=0; index<prepbufr_vars.n(); index++) {
-      tmp_var_name = prepbufr_vars[index].c_str();
+      const string tmp_var_name = prepbufr_vars[index].c_str();
       if (do_all_vars || bufr_target_variables.has(tmp_var_name, false)) {
          if (tableB_vars.has(tmp_var_name)) {
             bufr_obs_name_arr.add(tmp_var_name);
@@ -2460,8 +2460,8 @@ void process_pbfile_metadata(int i_pb) {
    bufr_derive_cfgs.clear();
    if (has_prepbufr_vars) {
       for (int vIdx=0; vIdx< prepbufr_derive_vars.n(); vIdx++) {
-         tmp_var_name = prepbufr_derive_vars[vIdx].c_str();
-         bufr_derive_cfgs.push_back(derive_var_cfg(tmp_var_name));
+         const string tmp_var_name = prepbufr_derive_vars[vIdx].c_str();
+         bufr_derive_cfgs.emplace_back(derive_var_cfg(tmp_var_name));
          if (do_all_vars || bufr_target_variables.has(tmp_var_name)) {
             // Set the variable index if requested
             bufr_obs_name_arr.add(tmp_var_name);


### PR DESCRIPTION
## Expected Differences ##

This PR fixes two bugs:
1. PB2NC abort from BUFRLIB with `PARUSR` error message when pb2nc is compiled with `-O2` on Intel compilers and `obs_bufr_var` is set to an empty list in the configuration file. Please see this [issue comment](https://github.com/dtcenter/MET/issues/3054#issuecomment-2623020214) for an explanation of the problem and the fix. 
2. Separately, I propose updating `pair_base.cc` to fix a logging bug that arose during METplus/discussions#2875. The `calc_obs_summary()` function was updating the `summary_val` in a local copy rather than the value in the map itself which led to erroneous summary values being reported in the log output.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Debugged and tested extensively at the `met_test` user in `seneca:/d1/projects/MET/intel/parusr_bufrlib_error`.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
As the `met_test` user, run the following command to see that the (1) METv12.0.0 release aborts while the (2) `bugfix_3054_main_v12.0_parusr` and (3) `bugfix_3054_develop_parusr` branches run to completion (when compiled with Intel and `-O2`).
```
runas met_test
cd /d1/projects/MET/intel/parusr_bufrlib_error
source /d1/projects/MET/intel/MET-bugfix_3054_develop_parusr/internal/scripts/environment/development.seneca_intel_oneapi
# Confirm I compiled with -O2
egrep "CFLAGS=|FFLAGS=|CXXFLAGS=" /d1/projects/MET/intel/MET-*/config.log
./run_pb2nc_test.sh
```
- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**
None needed.

- [x] Do these changes include sufficient testing updates? **[No]**
None needed.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:

- [x] Please complete this pull request review by **[Fri 1/31/25]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **MET-X.Y.Z Development** project for official releases
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
