### PR TITLE
Feature #3087 vector levels

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -136,7 +136,7 @@ jobs:
           - jobid: 'job1' 
             tests: 'ascii2nc'
           - jobid: 'job2'
-            tests: 'pb2nc madis2nc pcp_combine gen_ens_prod'
+            tests: 'pb2nc madis2nc pcp_combine gen_ens_prod regrid'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -176,7 +176,7 @@ jobs:
           - jobid: 'job1'
             tests: 'ascii2nc_indy pb2nc_indy tc_dland tc_pairs tc_stat plot_tc tc_rmw rmw_analysis tc_diag tc_gen'
           - jobid: 'job2'
-            tests: 'met_test_scripts mode_multivar mode_graphics mtd regrid airnow gsi_tools netcdf modis series_analysis wwmca_regrid gen_vx_mask interp_shape grid_diag grib_tables lidar2nc shift_data_plane trmm2nc aeronet wwmca_plot ioda2nc gaussian'
+            tests: 'met_test_scripts mode_multivar mode_graphics mtd airnow gsi_tools netcdf modis series_analysis wwmca_regrid gen_vx_mask interp_shape grid_diag grib_tables lidar2nc shift_data_plane trmm2nc aeronet wwmca_plot ioda2nc gaussian'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/docs/Users_Guide/ensemble-stat.rst
+++ b/docs/Users_Guide/ensemble-stat.rst
@@ -310,8 +310,6 @@ ____________________
 
 Setting up the **fcst** and **obs** dictionaries of the configuration file is described in :numref:`config_options`. The following are some special considerations for the Ensemble-Stat tool.
 
-The **ens** and **fcst** dictionaries do not need to include the same fields. Users may specify any number of ensemble fields to be summarized, but generally there are many fewer fields with verifying observations available. The **ens** dictionary specifies the fields to be summarized while the **fcst** dictionary specifies the fields to be verified.
-
 The **obs** dictionary looks very similar to the **fcst** dictionary. If verifying against point observations which are assigned GRIB1 codes, the observation section must be defined following GRIB1 conventions. When verifying GRIB1 forecast data, one can easily copy over the forecast settings to the observation dictionary using **obs = fcst;**. However, when verifying non-GRIB1 forecast data, users will need to specify the **fcst** and **obs** sections separately.
 
 The **ens_ssvar_bin_size** and **ens_phist_bin_size** specify the width of the categorical bins used to accumulate frequencies for spread-skill-variance or probability integral transform statistics, respectively.

--- a/internal/test_unit/config/GridStatConfig_nc_vector_levels
+++ b/internal/test_unit/config/GridStatConfig_nc_vector_levels
@@ -1,0 +1,265 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Grid-Stat configuration file.
+//
+// For additional information, please see the MET User's Guide.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Output model name to be written
+//
+model = "GFS";
+
+//
+// Output description to be written
+// May be set separately in each "obs.field" entry
+//
+desc = "NA";
+
+//
+// Output observation type to be written
+//
+obtype = "GFS";
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Verification grid
+// May be set separately in each "field" entry
+//
+regrid = {
+   to_grid    = NONE;
+   method     = NEAREST;
+   width      = 1;
+   vld_thresh = 0.5;
+   shape      = SQUARE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// May be set separately in each "field" entry
+//
+censor_thresh       = [];
+censor_val          = [];
+mpr_column          = [];
+mpr_thresh          = [];
+cat_thresh          = [];
+cnt_thresh          = [ NA ];
+cnt_logic           = UNION;
+wind_thresh         = [ NA ];
+wind_logic          = UNION;
+eclv_points         = 0.05;
+nc_pairs_var_name   = "";
+nc_pairs_var_suffix = "";
+hss_ec_value        = NA;
+rank_corr_flag      = FALSE;
+
+//
+// Forecast and observation fields to be verified
+//
+fcst = {
+
+   field = [
+      { name = "UGRD_P500"; level = "P500"; is_u_wind = true; },
+      { name = "VGRD_P500"; level = "P500"; is_v_wind = true; },
+      { name = "UGRD_P850"; level = "P850"; is_u_wind = true; },
+      { name = "VGRD_P850"; level = "P850"; is_v_wind = true; }
+   ];
+
+}
+obs = fcst;
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Climatology mean data
+// May be set separately in the "fcst" and "obs" dictionaries
+//
+climo_mean = {
+
+   file_name = [];
+   field     = [];
+
+   regrid = {
+      method     = NEAREST;
+      width      = 1;
+      vld_thresh = 0.5;
+      shape      = SQUARE;
+   }
+
+   time_interp_method = DW_MEAN;
+   day_interval       = 31;
+   hour_interval      = 6;
+}
+
+//
+// Climatology standard deviation data
+// May be set separately in the "fcst" and "obs" dictionaries
+//
+climo_stdev = climo_mean;
+climo_stdev = {
+   file_name = [];
+}
+
+//
+// Climatology distribution settings
+// May be set separately in each "obs.field" entry
+//
+climo_cdf = {
+   cdf_bins    = 1;
+   center_bins = FALSE;
+   write_bins  = TRUE;
+   direct_prob = FALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Verification masking regions
+// May be set separately in each "obs.field" entry
+//
+mask = {
+   grid = [ "FULL" ];
+   poly = [];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Confidence interval settings
+// May be set separately in each "obs.field" entry
+//
+ci_alpha  = [ 0.05 ];
+
+boot = {
+   interval = PCTILE;
+   rep_prop = 1.0;
+   n_rep    = 0;
+   rng      = "mt19937";
+   seed     = "";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Data smoothing methods
+// May be set separately in each "obs.field" entry
+//
+interp = {
+   field      = BOTH;
+   vld_thresh = 1.0;
+   shape      = SQUARE;
+
+   type = [
+      {
+         method = NEAREST;
+         width  = 1;
+      }
+   ];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Neighborhood methods
+// May be set separately in each "obs.field" entry
+//
+nbrhd = {
+   field      = BOTH;
+   vld_thresh = 1.0;
+   shape      = SQUARE;
+   width      = [ 1 ];
+   cov_thresh = [ >=0.5 ];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Fourier decomposition
+// May be set separately in each "obs.field" entry
+//
+fourier = {
+   wave_1d_beg = [];
+   wave_1d_end = [];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Gradient statistics
+// May be set separately in each "obs.field" entry
+//
+gradient = {
+   dx = [ 1 ];
+   dy = [ 1 ];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Distance Map statistics
+// May be set separately in each "obs.field" entry
+//
+distance_map = {
+   baddeley_p        = 2;
+   baddeley_max_dist = NA;
+   fom_alpha         = 0.1;
+   zhu_weight        = 0.5;
+   beta_value(n)     = n * n / 2.0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Threshold for SEEPS p1 (Probability of being dry)
+//
+seeps_p1_thresh = >=0.1&&<=0.85;
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// Statistical output types
+// May be set separately in each "obs.field" entry
+//
+output_flag = {
+   fho    = NONE;
+   ctc    = NONE;
+   cts    = NONE;
+   mctc   = NONE;
+   mcts   = NONE;
+   cnt    = NONE;
+   sl1l2  = NONE;
+   sal1l2 = NONE;
+   vl1l2  = STAT;
+   val1l2 = NONE;
+   vcnt   = NONE;
+   pct    = NONE;
+   pstd   = NONE;
+   pjc    = NONE;
+   prc    = NONE;
+   eclv   = NONE;
+   nbrctc = NONE;
+   nbrcts = NONE;
+   nbrcnt = NONE;
+   grad   = NONE;
+   dmap   = NONE;
+   seeps  = NONE;
+}
+
+//
+// NetCDF matched pairs output file
+// May be set separately in each "obs.field" entry
+//
+nc_pairs_flag = FALSE;
+
+////////////////////////////////////////////////////////////////////////////////
+
+grid_weight_flag = NONE;
+
+tmp_dir       = "/tmp";
+output_prefix = "${OUTPUT_PREFIX}";
+version       = "V12.1.0";
+
+////////////////////////////////////////////////////////////////////////////////

--- a/internal/test_unit/config/GridStatConfig_wind_vector_levels
+++ b/internal/test_unit/config/GridStatConfig_wind_vector_levels
@@ -60,16 +60,19 @@ rank_corr_flag      = FALSE;
 // Forecast and observation fields to be verified
 //
 fcst = {
-
    field = [
       { name = "UGRD_P500"; level = "P500"; is_u_wind = true; },
-      { name = "VGRD_P500"; level = "P500"; is_v_wind = true; },
       { name = "UGRD_P850"; level = "P850"; is_u_wind = true; },
+      { name = "VGRD_P500"; level = "P500"; is_v_wind = true; },
       { name = "VGRD_P850"; level = "P850"; is_v_wind = true; }
    ];
-
 }
-obs = fcst;
+obs = {
+   field = [
+      { name = "UGRD"; level = [ "P500", "P850" ]; },
+      { name = "VGRD"; level = [ "P500", "P850" ]; }
+   ];
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/internal/test_unit/xml/unit_grid_stat.xml
+++ b/internal/test_unit/xml/unit_grid_stat.xml
@@ -11,7 +11,7 @@
   <!ENTITY DATA_DIR_CLIMO "&INPUT_DIR;/climatology_data">
 ]>
 
-<!-- Requires: unit_pcp_combine.xml unit_gen_ens_prod.xml -->
+<!-- Requires: unit_pcp_combine.xml unit_gen_ens_prod.xml unit_regrid.xml -->
 
 <met_test>
 
@@ -343,6 +343,22 @@
     </param>
     <output>
       <stat>&OUTPUT_DIR;/grid_stat/grid_stat_GEN_ENS_PROD_240000L_20120410_120000V.stat</stat>
+    </output>
+  </test>
+
+  <test name="grid_stat_MET_NC_VECTOR_LEVELS">
+    <exec>&MET_BIN;/grid_stat</exec>
+    <env>
+      <pair><name>OUTPUT_PREFIX</name> <value>MET_NC_VECTOR_LEVELS</value></pair>
+    </env>
+    <param> \
+      &OUTPUT_DIR;/regrid/regrid_data_plane_MET_NC_VECTOR_LEVELS.nc \
+      &OUTPUT_DIR;/regrid/regrid_data_plane_MET_NC_VECTOR_LEVELS.nc \
+      &CONFIG_DIR;/GridStatConfig_nc_vector_levels \
+      -outdir &OUTPUT_DIR;/grid_stat -v 1
+    </param>
+    <output>
+      <stat>&OUTPUT_DIR;/grid_stat/grid_stat_MET_NC_VECTOR_LEVELS_240000L_20120410_120000V.stat</stat>
     </output>
   </test>
 

--- a/internal/test_unit/xml/unit_grid_stat.xml
+++ b/internal/test_unit/xml/unit_grid_stat.xml
@@ -346,19 +346,19 @@
     </output>
   </test>
 
-  <test name="grid_stat_MET_NC_VECTOR_LEVELS">
+  <test name="grid_stat_WIND_VECTOR_LEVELS">
     <exec>&MET_BIN;/grid_stat</exec>
     <env>
-      <pair><name>OUTPUT_PREFIX</name> <value>MET_NC_VECTOR_LEVELS</value></pair>
+      <pair><name>OUTPUT_PREFIX</name> <value>WIND_VECTOR_LEVELS</value></pair>
     </env>
     <param> \
-      &OUTPUT_DIR;/regrid/regrid_data_plane_MET_NC_VECTOR_LEVELS.nc \
-      &OUTPUT_DIR;/regrid/regrid_data_plane_MET_NC_VECTOR_LEVELS.nc \
-      &CONFIG_DIR;/GridStatConfig_nc_vector_levels \
+      &OUTPUT_DIR;/regrid/regrid_data_plane_WIND_VECTOR_LEVELS.nc \
+      &DATA_DIR_MODEL;/grib2/gfsanl/gfsanl_4_20120409_1200_000.grb2 \
+      &CONFIG_DIR;/GridStatConfig_wind_vector_levels \
       -outdir &OUTPUT_DIR;/grid_stat -v 1
     </param>
     <output>
-      <stat>&OUTPUT_DIR;/grid_stat/grid_stat_MET_NC_VECTOR_LEVELS_240000L_20120410_120000V.stat</stat>
+      <stat>&OUTPUT_DIR;/grid_stat/grid_stat_WIND_VECTOR_LEVELS_120000L_20120409_120000V.stat</stat>
     </output>
   </test>
 

--- a/internal/test_unit/xml/unit_point2grid.xml
+++ b/internal/test_unit/xml/unit_point2grid.xml
@@ -129,7 +129,7 @@
       &DATA_DIR_OBS;/point_obs/prepbufr.gdas.2017060300.nc \
       G212 \
       &OUTPUT_DIR;/point2grid/pb2nc_TMP_big_input.nc \
-      -field 'name="TMP"; level="Z2";' \
+      -field 'name="TMP"; level="*";' \
       -v 1
     </param>
     <output>

--- a/internal/test_unit/xml/unit_regrid.xml
+++ b/internal/test_unit/xml/unit_regrid.xml
@@ -391,19 +391,19 @@
 
   <!-- Multiple U/V pressure levels -->
 
-  <test name="regrid_data_plane_MET_NC_VECTOR_LEVELS">
+  <test name="regrid_data_plane_WIND_VECTOR_LEVELS">
     <exec>&MET_BIN;/regrid_data_plane</exec>
     <param> \
       &DATA_DIR_MODEL;/grib2/gfs/gfs_2012040900_F012.grib2 \
       &DATA_DIR_MODEL;/grib2/gfs/gfs_2012040900_F012.grib2 \
-      &OUTPUT_DIR;/regrid/regrid_data_plane_MET_NC_VECTOR_LEVELS.nc \
+      &OUTPUT_DIR;/regrid/regrid_data_plane_WIND_VECTOR_LEVELS.nc \
       -field 'name="UGRD"; level="P500";' \
       -field 'name="VGRD"; level="P500";' \
       -field 'name="UGRD"; level="P850";' \
       -field 'name="VGRD"; level="P850";'
     </param>
     <output>
-      <grid_nc>&OUTPUT_DIR;/regrid/regrid_data_plane_MET_NC_VECTOR_LEVELS.nc</grid_nc>
+      <grid_nc>&OUTPUT_DIR;/regrid/regrid_data_plane_WIND_VECTOR_LEVELS.nc</grid_nc>
     </output>
   </test>
 

--- a/internal/test_unit/xml/unit_regrid.xml
+++ b/internal/test_unit/xml/unit_regrid.xml
@@ -389,4 +389,22 @@
     </output>
   </test>
 
+  <!-- Multiple U/V pressure levels -->
+
+  <test name="regrid_data_plane_MET_NC_VECTOR_LEVELS">
+    <exec>&MET_BIN;/regrid_data_plane</exec>
+    <param> \
+      &DATA_DIR_MODEL;/grib2/gfs/gfs_2012040900_F012.grib2 \
+      &DATA_DIR_MODEL;/grib2/gfs/gfs_2012040900_F012.grib2 \
+      &OUTPUT_DIR;/regrid/regrid_data_plane_MET_NC_VECTOR_LEVELS.nc \
+      -field 'name="UGRD"; level="P500";' \
+      -field 'name="VGRD"; level="P500";' \
+      -field 'name="UGRD"; level="P850";' \
+      -field 'name="VGRD"; level="P850";'
+    </param>
+    <output>
+      <grid_nc>&OUTPUT_DIR;/regrid/regrid_data_plane_MET_NC_VECTOR_LEVELS.nc</grid_nc>
+    </output>
+  </test>
+
 </met_test>

--- a/src/basic/vx_config/temp_file.cc
+++ b/src/basic/vx_config/temp_file.cc
@@ -65,7 +65,6 @@ ConcatString make_temp_file_name(const char *prefix, const char *suffix) {
 ////////////////////////////////////////////////////////////////////////
 
 void remove_temp_file(const ConcatString file_name) {
-   int errno;
 
    //
    // Attempt to remove the file and print out any error message

--- a/src/basic/vx_log/concat_string.cc
+++ b/src/basic/vx_log/concat_string.cc
@@ -27,11 +27,6 @@ using namespace std;
 
 ////////////////////////////////////////////////////////////////////////
 
-static StringArray env_name_list;
-static StringArray nested_env_name_list;
-
-////////////////////////////////////////////////////////////////////////
-
 
 inline int imin(int a, int b)  { return ( (a < b) ? a : b ); }
 
@@ -50,23 +45,8 @@ static bool is_empty(const char *);
 
 
 ConcatString::ConcatString()
-: Precision(0)
 {
-
-init_from_scratch();
-
-}
-
-
-////////////////////////////////////////////////////////////////////////
-
-
-ConcatString::ConcatString(int _alloc_inc)
-: Precision(0)
-{
-
-init_from_scratch();
-
+   init_from_scratch();
 }
 
 
@@ -74,12 +54,8 @@ init_from_scratch();
 
 
 ConcatString::~ConcatString()
-
 {
-
-clear();
-if (s) delete s;
-
+   clear();
 }
 
 
@@ -87,14 +63,10 @@ if (s) delete s;
 
 
 ConcatString::ConcatString(const ConcatString & c)
-: Precision(0)
-
 {
+   init_from_scratch();
 
-init_from_scratch();
-
-assign(c);
-
+   assign(c);
 }
 
 
@@ -102,14 +74,10 @@ assign(c);
 
 
 ConcatString::ConcatString(const std::string & Text)
-: Precision(0)
-
 {
+   init_from_scratch();
 
-init_from_scratch();
-
-add(Text);
-
+   add(Text);
 }
 
 
@@ -117,23 +85,16 @@ add(Text);
 
 
 ConcatString::ConcatString(const char * Text)
-: Precision(0)
-
 {
+   if (!Text) {
+      mlog << Error << "\nConcatString::ConcatString(const char *) -> "
+           << "null pointer!\n\n";
+      exit(1);
+   }
 
-if ( ! Text )  {
+   init_from_scratch();
 
-   mlog << Error << "\nConcatString::ConcatString(const char *) -> "
-        << "null pointer!\n\n";
-
-   exit ( 1 );
-
-}
-
-init_from_scratch();
-
-add(::string(Text));
-
+   add(::string(Text));
 }
 
 
@@ -141,29 +102,8 @@ add(::string(Text));
 
 
 ConcatString & ConcatString::operator=(const ConcatString & c)
-
 {
-
-if (this != &c) {
-   delete s;
-   init_from_scratch();
    assign(c);
-}
-
-return *this;
-
-}
-
-
-////////////////////////////////////////////////////////////////////////
-
-
-ConcatString & ConcatString::operator=(const std::string & Text)
-
-{
-   delete s;
-   init_from_scratch();
-   if (s) s->assign(Text);
 
    return *this;
 }
@@ -172,25 +112,39 @@ ConcatString & ConcatString::operator=(const std::string & Text)
 ////////////////////////////////////////////////////////////////////////
 
 
-ConcatString & ConcatString::operator=(const char * Text)
-
+ConcatString & ConcatString::operator=(const std::string & Text)
 {
+   s.assign(Text);
 
-
-if ( ! Text )  {
-
-   mlog << Error << "\nConcatString::operator=(const char *) -> "
-        << "null pointer!\n\n";
-
-   exit ( 1 );
-
+   return *this;
 }
 
-   std::string s2 = Text;
-   if ( s )  delete s;
-   init_from_scratch();
 
-   (*s) = s2;
+////////////////////////////////////////////////////////////////////////
+
+
+ConcatString & ConcatString::operator=(const char *Text)
+{
+   if (!Text)  {
+      mlog << Error << "\nConcatString::operator=(const char *) -> "
+           << "null pointer!\n\n";
+      exit ( 1 );
+   }
+
+   s = Text;
+
+   return *this;
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+ConcatString & ConcatString::operator=(const char c)
+{
+   s.erase();
+
+   add(c);
 
    return *this;
 }
@@ -201,7 +155,6 @@ if ( ! Text )  {
 
 void ConcatString::init_from_scratch()
 {
-   s = new std::string();
    set_precision(concat_string_default_precision);
 }
 
@@ -211,7 +164,7 @@ void ConcatString::init_from_scratch()
 
 void ConcatString::clear()
 {
-   s->clear();
+   s.clear();
 
    set_precision(concat_string_default_precision);
 }
@@ -224,7 +177,7 @@ char ConcatString::char_at(const int idx) const
 {
    if (0 > idx || length() <= idx ) return '\0';
 
-   return s->at(idx);
+   return s.at(idx);
 }
 
 
@@ -233,13 +186,8 @@ char ConcatString::char_at(const int idx) const
 
 void ConcatString::assign(const ConcatString & c)
 {
-   if (c.text()) s->assign(c.text());
-   else          s->clear();
-
-   int buf_size = sizeof(c.FloatFormat);
-   if (buf_size > concat_string_buf_size) buf_size = concat_string_buf_size;
-
-   memcpy(FloatFormat, c.FloatFormat, buf_size);
+   s = c.s;
+   FloatFormat = c.FloatFormat;
    Precision = c.Precision;
 }
 
@@ -249,7 +197,7 @@ void ConcatString::assign(const ConcatString & c)
 
 void ConcatString::add(const char c)
 {
-   (*s) += c;
+   s += c;
 }
 
 
@@ -258,7 +206,7 @@ void ConcatString::add(const char c)
 
 void ConcatString::add(const ConcatString & a)
 {
-   (*s) += (*a.s);
+   s += a.s;
 }
 
 
@@ -267,9 +215,8 @@ void ConcatString::add(const ConcatString & a)
 
 void ConcatString::add(const std::string & a)
 {
-   (*s) += a;
+   s += a;
 }
-
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -277,17 +224,13 @@ void ConcatString::add(const std::string & a)
 
 void ConcatString::add(const char * Text)
 {
+   if (!Text) {
+      mlog << Error << "\nConcatString::add(const char *) -> "
+           << "null pointer\n\n";
+      exit ( 1 );
+   }
 
-if ( !Text )  {
-
-   mlog << Error << "\nConcatString::add(const char *) -> "
-        << "null pointer\n\n";
-
-   exit ( 1 );
-
-}
-
-   (*s) += ::string(Text);
+   s += ::string(Text);
 }
 
 
@@ -295,13 +238,10 @@ if ( !Text )  {
 
 
 void ConcatString::chomp()
-
 {
+   chomp('\n');
 
-chomp('\n');
-
-return;
-
+   return;
 }
 
 
@@ -310,9 +250,9 @@ return;
 
 void ConcatString::chomp(const char c)
 {
-   size_t pos = s->find_last_not_of(c);
-   if (pos != string::npos) s->erase(pos + 1);
-   else                     s->clear();
+   size_t pos = s.find_last_not_of(c);
+   if (pos != string::npos) s.erase(pos + 1);
+   else                     s.clear();
 }
 
 
@@ -322,8 +262,8 @@ void ConcatString::chomp(const char c)
 void ConcatString::chomp(const char * suffix)
 {
    size_t limit = length() - m_strlen(suffix);
-   size_t pos = s->find(suffix, limit);
-   if (pos != string::npos) s->erase(pos);
+   size_t pos = s.find(suffix, limit);
+   if (pos != string::npos) s.erase(pos);
 }
 
 
@@ -331,30 +271,21 @@ void ConcatString::chomp(const char * suffix)
 
 
 void ConcatString::set_precision(int k)
-
 {
 
-if ( (k < 0) || (k > concat_string_max_precision) )  {
+   if ((k < 0) || (k > concat_string_max_precision)) {
+      mlog << Error << "\nConcatString::set_precision(int) -> "
+           << "bad value\n\n";
+      exit(1);
+   }
 
-   mlog << Error << "\nConcatString::set_precision(int) -> bad value\n\n";
+   if (Precision != k) {
+      Precision = k;
+      FloatFormat  = "%%.";
+      FloatFormat += Precision + "f";
+   }
 
-   exit ( 1 );
-
-}
-
-if (Precision != k) {
-   Precision = k;
-
-   int buf_size = sizeof(FloatFormat);
-   if (buf_size > concat_string_buf_size) buf_size = concat_string_buf_size;
-
-   memset(FloatFormat, 0, buf_size);
-
-   snprintf(FloatFormat, buf_size, "%%.%df", Precision);
-}
-
-return;
-
+   return;
 }
 
 
@@ -363,7 +294,7 @@ return;
 
 void ConcatString::erase()
 {
-   s->clear();
+   s.clear();
 }
 
 
@@ -372,7 +303,7 @@ void ConcatString::erase()
 
 void ConcatString::set_repeat(char c, int count)
 {
-   s->assign(count, c);
+   s.assign(count, c);
 }
 
 
@@ -382,7 +313,7 @@ void ConcatString::set_repeat(char c, int count)
 void ConcatString::elim_trailing_whitespace()
 {
    // This will work with the standard "C" locale. Others may require a different char set
-   s->erase(s->find_last_not_of(" \n\r\t\v\f") + 1);
+   s.erase(s.find_last_not_of(" \n\r\t\v\f") + 1);
 }
 
 
@@ -391,7 +322,7 @@ void ConcatString::elim_trailing_whitespace()
 
 bool ConcatString::startswith(const char * Text) const
 {
-   size_t pos = s->rfind(Text, m_strlen(Text));
+   size_t pos = s.rfind(Text, m_strlen(Text));
    return (pos != string::npos);
 }
 
@@ -401,7 +332,7 @@ bool ConcatString::startswith(const char * Text) const
 
 bool ConcatString::endswith(const char * Text) const
 {
-   size_t pos = s->find(Text, s->length() - m_strlen(Text));
+   size_t pos = s.find(Text, s.length() - m_strlen(Text));
    return (pos != string::npos);
 }
 
@@ -412,20 +343,17 @@ bool ConcatString::endswith(const char * Text) const
 StringArray ConcatString::split(const char * delim) const
 {
    StringArray a;
-   if (s->empty()) {
-       return a;
-   }
+   if (s.empty()) return a;
 
    size_t start = 0;
-   size_t end = s->find_first_of(delim);
+   size_t end = s.find_first_of(delim);
    while (end != string::npos) {
        if (start != end)
-           a.add(s->substr(start, end-start));
+           a.add(s.substr(start, end-start));
        start = end + 1;
-       end = s->find_first_of(delim, start);
+       end = s.find_first_of(delim, start);
    }
-   if (start < s->length())
-       a.add(s->substr(start));
+   if (start < s.length()) a.add(s.substr(start));
 
    return a;
 }
@@ -444,7 +372,7 @@ ConcatString ConcatString::dirname() const
 
    // Find last forward slash in the string
    size_t start = 0;
-   size_t end   = c.s->find_last_of("/");
+   size_t end   = c.s.find_last_of("/");
 
    // No forward slashes found
    if (end == string::npos)  {
@@ -452,7 +380,7 @@ ConcatString ConcatString::dirname() const
    }
    // Copy up to the last forward slash
    else  {
-      c = c.s->substr(start, end-start);
+      c = c.s.substr(start, end-start);
    }
 
    return c;
@@ -471,16 +399,16 @@ ConcatString ConcatString::basename() const
    c.chomp("/");
    
    // Find last forward slash in the string
-   size_t start = c.s->find_last_of("/");
-   size_t end   = c.s->length();
+   size_t start = c.s.find_last_of("/");
+   size_t end   = c.s.length();
 
    // No forward slashes found
    if (start == string::npos)  {
-      c = c.s->c_str();
+      c = c.s.c_str();
    }
    // Copy from the last forward slash to the end
    else  {
-      c = c.s->substr(start+1, end-start);
+      c = c.s.substr(start+1, end-start);
    }
 
    return c;
@@ -496,8 +424,8 @@ void ConcatString::ws_strip()
    // Other locales may require a different whitespace char set.
    const char * ws = " \n\r\t\v\f";
 
-   s->erase(0, s->find_first_not_of(ws));
-   s->erase(s->find_last_not_of(ws) + 1);
+   s.erase(0, s.find_first_not_of(ws));
+   s.erase(s.find_last_not_of(ws) + 1);
 }
 
 
@@ -506,9 +434,8 @@ void ConcatString::ws_strip()
 
 void ConcatString::strip_cpp_comment()
 {
-   size_t pos = s->find("//");
-   if (pos != string::npos)
-       s->erase(pos);
+   size_t pos = s.find("//");
+   if (pos != string::npos) s.erase(pos);
 }
 
 
@@ -517,9 +444,19 @@ void ConcatString::strip_cpp_comment()
 
 void ConcatString::strip_paren()
 {
-   size_t pos = s->find("(");
-   if (pos != string::npos)
-       s->erase(pos);
+   size_t pos = s.find("(");
+   if (pos != string::npos) s.erase(pos);
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+void ConcatString::strip_chars_from(const char *chars_to_remove)
+{
+   for (unsigned int i=0; i<m_strlen(chars_to_remove); ++i) {
+      s.erase(remove(s.begin(), s.end(), chars_to_remove[i]), s.end());
+   }
 }
 
 
@@ -536,13 +473,15 @@ int ConcatString::format(const char *fmt, ...)
    status = vasprintf(&tmp, fmt, vl);
 
    if (status == -1) {
-      mlog << Error << "\nConcatString::format() could not allocate a temporary buffer.\n\n";
+      mlog << Error << "\nConcatString::format() -> "
+           << "could not allocate a temporary buffer.\n\n";
       exit(1);
    }
 
-   s->assign(tmp);
+   s.assign(tmp);
    free(tmp);
    va_end(vl);
+
    return status;
 }
 
@@ -552,7 +491,7 @@ int ConcatString::format(const char *fmt, ...)
 
 void ConcatString::replace_char(int i, char c)
 {
-  s->replace(i, 1, 1, c);
+  s.replace(i, 1, 1, c);
 }
 
 
@@ -560,10 +499,9 @@ void ConcatString::replace_char(int i, char c)
 
 
 void ConcatString::replace(const char * target, const char * replacement,
-                          bool check_env)
+                           bool check_env)
 {
-   if (empty())
-       return;
+   if (empty()) return;
 
    if (::is_empty(target) || ::is_empty(replacement) ) {
       mlog << Error << "\nConcatString::replace(const char * target, const char * replacement, bool check_env) -> "
@@ -578,8 +516,8 @@ void ConcatString::replace(const char * target, const char * replacement,
    }
 
    size_t pos;
-   while ((pos = s->find(target)) != string::npos) {
-      s->replace(pos, m_strlen(target), replacement);
+   while ((pos = s.find(target)) != string::npos) {
+      s.replace(pos, m_strlen(target), replacement);
    }
 }
 
@@ -589,7 +527,7 @@ void ConcatString::replace(const char * target, const char * replacement,
 
 void ConcatString::set_upper()
 {
-   for (string::iterator c = s->begin(); s->end() != c; ++c)
+   for (auto c = s.begin(); s.end() != c; ++c)
       *c = toupper(*c);
 }
 
@@ -599,7 +537,7 @@ void ConcatString::set_upper()
 
 void ConcatString::set_lower()
 {
-   for (string::iterator c = s->begin(); s->end() != c; ++c)
+   for (auto c = s.begin(); s.end() != c; ++c)
       *c = tolower(*c);
 }
 
@@ -607,12 +545,12 @@ void ConcatString::set_lower()
 ////////////////////////////////////////////////////////////////////////
 
 
-const string ConcatString::contents(const char * str) const
+string ConcatString::contents(const char * str) const
 {
-   if (s->empty() || *s == "") {
+   if (s.empty() || s == "") {
       return (str ? str : "(nul)");
    } else {
-      return *s;
+      return s;
    }
 }
 
@@ -623,10 +561,10 @@ const string ConcatString::contents(const char * str) const
 bool ConcatString::read_line(istream & in)
 {
    erase();
-   getline(in, *s);
+   getline(in, s);
    if (!in) {
       // Check for end of file and non-empty line
-      if (in.eof() && (length() != 0))
+      if (in.eof() && !empty())
          return true;
       else
          return false;
@@ -687,7 +625,7 @@ char ConcatString::operator[](const int n) const
       exit ( 1 );
    }
 
-   return(s->at(n));
+   return(s.at(n));
 }
 
 
@@ -843,19 +781,15 @@ ConcatString & operator<<(ConcatString & a, const Indent & i)
 
 {
 
-int j, jmax;
+int jmax = (i.delta)*(i.depth);
 
 
-jmax = (i.delta)*(i.depth);
-
-
-for (j=0; j<jmax; ++j)  {
+for (int j=0; j<jmax; ++j)  {
 
    if ( (j%(i.delta)) == 0 )  a << i.on_char;
    else                       a << i.off_char;
 
 }
-
 
 return a;
 
@@ -885,7 +819,7 @@ bool ConcatString::operator==(const ConcatString & b) const
 if ( empty() )  return false;
 if ( b.empty() )  return false;
 
-int status = s->compare(*(b.s));
+int status = s.compare(b.s);
 
 return ( status == 0 );
 
@@ -901,7 +835,7 @@ bool ConcatString::operator==(const char * text) const
 
 if ( !text || empty() )  return false;
 
-int status = s->compare(text);
+int status = s.compare(text);
 
 return ( status == 0 );
 
@@ -1177,7 +1111,7 @@ return css;
 ////////////////////////////////////////////////////////////////////////
 
 
-bool is_empty(const char * text)
+static bool is_empty(const char * text)
 
 {
 
@@ -1193,6 +1127,8 @@ bool get_env(const char *env_name, ConcatString &env_value)
 
 {
 
+StringArray env_name_list;
+StringArray nested_env_name_list;
 const char *ptr;
 string str = env_name;
 static const char *method_name = "get_env() ";
@@ -1215,8 +1151,10 @@ if (!env_name_list.has(env_name)) {
 
 int count_replaced = 0;
 string nested_value;
-size_t pos, pos_end, pos_env, pos_env_end;
-pos = pos_env_end = 0;
+size_t pos = 0;
+size_t pos_end = 0;
+size_t pos_env = 0;
+size_t pos_env_end = 0;
 while ((pos = str.find('$', pos)) != string::npos) {
    string nested_name;
    pos_env = pos + 1;
@@ -1272,12 +1210,12 @@ return true;
 ////////////////////////////////////////////////////////////////////////
 
 
-int ConcatString::find(int c)
+int ConcatString::find(int c) const
 
 {
-  std::string::size_type position = s->rfind(c);
+  std::string::size_type position = s.rfind((char) c);
   if ( position != std::string::npos) {
-     return position;
+     return (int) position;
   }
   else {
      return -1;
@@ -1291,7 +1229,7 @@ int ConcatString::find(int c)
 int ConcatString::compare(size_t pos, size_t len, std::string str)
 
 {
-   return s->compare(pos, len, str);
+   return s.compare(pos, len, str);
 }
 
 
@@ -1301,7 +1239,7 @@ int ConcatString::compare(size_t pos, size_t len, std::string str)
 int ConcatString::comparecase(size_t pos, size_t len, std::string str)
 
 {
-   std::string lower_s = *s;
+   std::string lower_s = s;
    transform(lower_s.begin(), lower_s.end(), lower_s.begin(), ::tolower);
    std::string lower_str = str;
    transform(lower_str.begin(), lower_str.end(), lower_str.begin(), ::tolower);
@@ -1315,7 +1253,7 @@ int ConcatString::comparecase(size_t pos, size_t len, std::string str)
 int ConcatString::comparecase(const char * str)
 
 {
-  std::string lower_s = *s;
+  std::string lower_s = s;
   transform(lower_s.begin(), lower_s.end(), lower_s.begin(), ::tolower);
   std::string lower_str = str;
   transform(lower_str.begin(), lower_str.end(), lower_str.begin(), ::tolower);

--- a/src/basic/vx_log/concat_string.cc
+++ b/src/basic/vx_log/concat_string.cc
@@ -760,8 +760,8 @@ ConcatString & operator<<(ConcatString & a, CSInlineCommand c)
 
 switch ( c )  {
 
-   case CSInlineCommand::cs_erase:  a.erase();  break;
-   case CSInlineCommand::cs_clear:  a.clear();  break;
+   case cs_erase:  a.erase();  break;
+   case cs_clear:  a.clear();  break;
 
    default:
      mlog << Error << "\noperator<<(ostream &, CSInlineCommand) -> "
@@ -1228,7 +1228,7 @@ int ConcatString::find(int c) const
 ////////////////////////////////////////////////////////////////////////
 
 
-int ConcatString::compare(size_t pos, size_t len, std::string &str) const
+int ConcatString::compare(size_t pos, size_t len, const std::string &str) const
 
 {
    return s.compare(pos, len, str);
@@ -1238,7 +1238,7 @@ int ConcatString::compare(size_t pos, size_t len, std::string &str) const
 ////////////////////////////////////////////////////////////////////////
 
 
-int ConcatString::comparecase(size_t pos, size_t len, std::string &str) const
+int ConcatString::comparecase(size_t pos, size_t len, const std::string &str) const
 
 {
    std::string lower_s = s;

--- a/src/basic/vx_log/concat_string.cc
+++ b/src/basic/vx_log/concat_string.cc
@@ -527,8 +527,9 @@ void ConcatString::replace(const char * target, const char * replacement,
 
 void ConcatString::set_upper()
 {
-   for (auto c = s.begin(); s.end() != c; ++c)
-      *c = toupper(*c);
+   for_each(s.begin(), s.end(), [](char &c) {
+      c = (char) toupper(c);
+   });
 }
 
 
@@ -537,8 +538,9 @@ void ConcatString::set_upper()
 
 void ConcatString::set_lower()
 {
-   for (auto c = s.begin(); s.end() != c; ++c)
-      *c = tolower(*c);
+   for_each(s.begin(), s.end(), [](char &c) {
+      c = (char) tolower(c);
+   });
 }
 
 
@@ -758,8 +760,8 @@ ConcatString & operator<<(ConcatString & a, CSInlineCommand c)
 
 switch ( c )  {
 
-   case cs_erase:  a.erase();  break;
-   case cs_clear:  a.clear();  break;
+   case CSInlineCommand::cs_erase:  a.erase();  break;
+   case CSInlineCommand::cs_clear:  a.clear();  break;
 
    default:
      mlog << Error << "\noperator<<(ostream &, CSInlineCommand) -> "
@@ -1226,7 +1228,7 @@ int ConcatString::find(int c) const
 ////////////////////////////////////////////////////////////////////////
 
 
-int ConcatString::compare(size_t pos, size_t len, std::string str)
+int ConcatString::compare(size_t pos, size_t len, std::string &str) const
 
 {
    return s.compare(pos, len, str);
@@ -1236,7 +1238,7 @@ int ConcatString::compare(size_t pos, size_t len, std::string str)
 ////////////////////////////////////////////////////////////////////////
 
 
-int ConcatString::comparecase(size_t pos, size_t len, std::string str)
+int ConcatString::comparecase(size_t pos, size_t len, std::string &str) const
 
 {
    std::string lower_s = s;
@@ -1250,7 +1252,7 @@ int ConcatString::comparecase(size_t pos, size_t len, std::string str)
 ////////////////////////////////////////////////////////////////////////
 
 
-int ConcatString::comparecase(const char * str)
+int ConcatString::comparecase(const char * str) const
 
 {
   std::string lower_s = s;

--- a/src/basic/vx_log/concat_string.h
+++ b/src/basic/vx_log/concat_string.h
@@ -39,7 +39,7 @@ static const int concat_string_max_precision     = 12;
 ////////////////////////////////////////////////////////////////////////
 
 
-enum CSInlineCommand {
+enum class CSInlineCommand {
 
    cs_erase,
    cs_clear
@@ -69,8 +69,8 @@ class ConcatString {
       ConcatString();
      ~ConcatString();
       ConcatString(const ConcatString &);
-      ConcatString(const std::string &);
-      ConcatString(const char *);
+      explicit ConcatString(const std::string &);
+      explicit ConcatString(const char *);
       ConcatString & operator=(const ConcatString &);
       ConcatString & operator=(const std::string &);
       ConcatString & operator=(const char *);
@@ -169,9 +169,9 @@ class ConcatString {
       void set_lower();
 
       int find(int c) const;
-      int compare(size_t pos, size_t len, std::string str);
-      int comparecase(size_t pos, size_t len, std::string str);
-      int comparecase(const char *);
+      int compare(size_t pos, size_t len, std::string &str) const;
+      int comparecase(size_t pos, size_t len, std::string &str) const;
+      int comparecase(const char *) const;
 
 };
 

--- a/src/basic/vx_log/concat_string.h
+++ b/src/basic/vx_log/concat_string.h
@@ -29,25 +29,11 @@
 ////////////////////////////////////////////////////////////////////////
 
 
-   //
-   //  minimum and default allocation increment for the ConcatString class
-   //
+static const int max_str_len                     = 512;
 
-
-static const int min_cs_alloc_inc     =  32;
-
-static const int default_cs_alloc_inc = 128;
-
-static const int max_str_len          = 512;
-
-
-////////////////////////////////////////////////////////////////////////
-
-
-static const int concat_string_default_precision =  5;
+static const int concat_string_default_precision = 5;
 
 static const int concat_string_max_precision     = 12;
-static const int concat_string_buf_size          = concat_string_max_precision + 4;
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -74,14 +60,13 @@ class ConcatString {
 
       int Precision;
 
-      char FloatFormat[concat_string_buf_size];
+      std::string FloatFormat;
 
-      std::string *s;
+      std::string s;
 
    public:
 
       ConcatString();
-      ConcatString(int _alloc_inc);
      ~ConcatString();
       ConcatString(const ConcatString &);
       ConcatString(const std::string &);
@@ -89,6 +74,7 @@ class ConcatString {
       ConcatString & operator=(const ConcatString &);
       ConcatString & operator=(const std::string &);
       ConcatString & operator=(const char *);
+      ConcatString & operator=(const char);
       bool operator==(const ConcatString &) const;
       bool operator==(const char *) const;
 
@@ -109,17 +95,15 @@ class ConcatString {
 
       const char * c_str() const;
 
-      const std::string & string() const;
+      std::string string() const;
 
-      const std::string contents(const char *str = nullptr) const;   //  returns str or "(nul)" if the string is empty
+      std::string contents(const char *str = nullptr) const;   //  returns str or "(nul)" if the string is empty
 
       int length() const;   //  not including trailing nul
 
       int precision() const;
 
       const char * float_format() const;
-
-      int alloc_inc() const;
 
       bool empty() const;
       bool nonempty() const;
@@ -157,6 +141,8 @@ class ConcatString {
 
       void strip_paren();   //  strip contents of trailing parenthesis, if any
 
+      void strip_chars_from(const char *);   //  strip contents of characters specified, if any
+
       StringArray split(const char * delim) const;
 
       ConcatString dirname() const;
@@ -174,6 +160,7 @@ class ConcatString {
       bool read_line(std::istream &);   //  read a line from the input stream
 
       void replace_char(int i, char c);
+
       //  replace all occurences of target with replacement
       //  if "replacement" is an environment variable, use it's value
       void replace(const char * target, const char * replacement, bool check_env = true);
@@ -181,7 +168,7 @@ class ConcatString {
       void set_upper();
       void set_lower();
 
-      int find(int c);
+      int find(int c) const;
       int compare(size_t pos, size_t len, std::string str);
       int comparecase(size_t pos, size_t len, std::string str);
       int comparecase(const char *);
@@ -192,20 +179,20 @@ class ConcatString {
 ////////////////////////////////////////////////////////////////////////
 
 
-inline const char * ConcatString::text()          const { return ( s ? s->c_str() : nullptr); }
-inline const char * ConcatString::c_str()         const { return ( s ? s->c_str() : nullptr); }
-inline const std::string & ConcatString::string() const { return ( *s ); }
+inline const char * ConcatString::text()         const { return s.c_str(); }
+inline const char * ConcatString::c_str()        const { return s.c_str(); }
+inline std::string  ConcatString::string()       const { return s; }
 
-inline int          ConcatString::length()       const { return (int) (s ? s->length() : 0); }
+inline int          ConcatString::length()       const { return (int) s.length(); }
 
 inline int          ConcatString::precision()    const { return Precision; }
 
-inline const char * ConcatString::float_format() const { return FloatFormat; }
+inline const char * ConcatString::float_format() const { return FloatFormat.c_str(); }
 
-inline bool         ConcatString::empty()        const { return ( s ?  s->empty() : true ); }
-inline bool         ConcatString::nonempty()     const { return ( s ? !s->empty() : false ); }
+inline bool         ConcatString::empty()        const { return  s.empty(); }
+inline bool         ConcatString::nonempty()     const { return !s.empty(); }
 
-inline              ConcatString::operator std::string () const { return ( s ? *s : nullptr ); }
+inline              ConcatString::operator std::string () const { return s; }
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/basic/vx_log/concat_string.h
+++ b/src/basic/vx_log/concat_string.h
@@ -39,7 +39,7 @@ static const int concat_string_max_precision     = 12;
 ////////////////////////////////////////////////////////////////////////
 
 
-enum class CSInlineCommand {
+enum CSInlineCommand {
 
    cs_erase,
    cs_clear
@@ -69,8 +69,8 @@ class ConcatString {
       ConcatString();
      ~ConcatString();
       ConcatString(const ConcatString &);
-      explicit ConcatString(const std::string &);
-      explicit ConcatString(const char *);
+      ConcatString(const std::string &);
+      ConcatString(const char *);
       ConcatString & operator=(const ConcatString &);
       ConcatString & operator=(const std::string &);
       ConcatString & operator=(const char *);
@@ -169,8 +169,8 @@ class ConcatString {
       void set_lower();
 
       int find(int c) const;
-      int compare(size_t pos, size_t len, std::string &str) const;
-      int comparecase(size_t pos, size_t len, std::string &str) const;
+      int compare(size_t pos, size_t len, const std::string &str) const;
+      int comparecase(size_t pos, size_t len, const std::string &str) const;
       int comparecase(const char *) const;
 
 };

--- a/src/basic/vx_log/file_fxns.cc
+++ b/src/basic/vx_log/file_fxns.cc
@@ -58,7 +58,7 @@ ConcatString replace_path(const ConcatString path) {
 ////////////////////////////////////////////////////////////////////////
 
 ConcatString replace_path(const char * path) {
-  return replace_path((string)path);
+   return replace_path(ConcatString(path));
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -70,20 +70,20 @@ ConcatString replace_path(const char * path) {
 ////////////////////////////////////////////////////////////////////////
 
 int met_open(const char *path, int oflag) {
-  return open(replace_path(path).c_str(), oflag);
+   return open(replace_path(path).c_str(), oflag);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 void met_open(ifstream &in, const char *path) {
-  in.open(replace_path(path).c_str());
+   in.open(replace_path(path).c_str());
    return;
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 void met_open(ofstream &out, const char *path) {
-  out.open(replace_path(path).c_str());
+   out.open(replace_path(path).c_str());
    return;
 }
 

--- a/src/libcode/vx_data2d_nc_met/var_info_nc_met.cc
+++ b/src/libcode/vx_data2d_nc_met/var_info_nc_met.cc
@@ -160,16 +160,8 @@ void VarInfoNcMet::set_magic(const ConcatString &nstr, const ConcatString &lstr)
    set_req_name(nstr.c_str());
    set_name(nstr);
 
-   // If there's no level specification, assume (*, *)
-   if(strchr(lstr.c_str(), '(') == nullptr) {
-      Level.set_req_name("*,*");
-      Level.set_name("*,*");
-      Dimension.clear();
-      Dimension.add(vx_data2d_star);
-      Dimension.add(vx_data2d_star);
-   }
-   // Parse the level specification
-   else {
+   // Parse the level dimensions, if specified
+   if(lstr.string().find_first_of("(") != std::string::npos) {
 
       // Initialize the temp string
       tmp_str = lstr;
@@ -217,8 +209,23 @@ void VarInfoNcMet::set_magic(const ConcatString &nstr, const ConcatString &lstr)
          // Set ptr to nullptr for next call to strtok
          ptr = nullptr;
       } // end while
+   }
+   // Otherwise, assume (*,*) level dimensions
+   else {
 
-   } // end else
+      // MET #3087 Store the level string for U/V vector level matching
+      if(lstr.nonempty()) {
+         Level.set_req_name(lstr.c_str());
+         Level.set_name(lstr.c_str());
+      }
+      else {
+         Level.set_req_name("*,*");
+         Level.set_name("*,*");
+      }
+      Dimension.clear();
+      Dimension.add(vx_data2d_star);
+      Dimension.add(vx_data2d_star);
+   }
 
    // Check for "/PROB" to indicate a probability forecast
    if(strstr(MagicStr.c_str(), "/PROB") != nullptr) PFlag = 1;

--- a/src/libcode/vx_data2d_nc_met/var_info_nc_met.cc
+++ b/src/libcode/vx_data2d_nc_met/var_info_nc_met.cc
@@ -213,14 +213,16 @@ void VarInfoNcMet::set_magic(const ConcatString &nstr, const ConcatString &lstr)
    // Otherwise, assume (*,*) level dimensions
    else {
 
-      // MET #3087 Store the level string for U/V vector level matching
-      if(lstr.nonempty()) {
-         Level.set_req_name(lstr.c_str());
-         Level.set_name(lstr.c_str());
-      }
-      else {
+      // MET #3087 Set the level name string:
+      //   - If empty or '*' from Point2Grid, set to *,* to indicate gridded output
+      //   - If nonempty, use the input level string to support U/V vector level matching
+      if(lstr.empty() || lstr == "*") {
          Level.set_req_name("*,*");
          Level.set_name("*,*");
+      }
+      else {     
+         Level.set_req_name(lstr.c_str());
+         Level.set_name(lstr.c_str());
       }
       Dimension.clear();
       Dimension.add(vx_data2d_star);


### PR DESCRIPTION
## Expected Differences ##

The issue is that when reading data from MET NetCDF files, all of the level strings were basically being hard-coded as `(*,*)` regardless of how they were actually set in the config file. This causes the "multiple matches" warning constructing U/V pairs from MET NetCDF input files since all the level strings are the same.

The fix is to preserve the level strings that are set in the configuration file, so that the U's and V's can be matched up well using their level strings.

While addressing SonarQube code smells, I decided to modify the ConcatString class from using a *pointer* to a std::string to just using std::string directly. This simplifies the logic and minimizes the manual memory allocation/deallocation. I coordinated this change with other MET developers.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Ran locally to confirm the desired result.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Review code changes, inspect the newly generated unit test output files, and one minor diff in an existing unit test output file.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**
None needed.

- [x] Do these changes include sufficient testing updates? **[Yes]**
Adds 1 new test to `unit_regrid.xml` and 1 new test to `unit_grid_stat.xml` to demonstrate verifying multiple U/V levels read from a MET NetCDF file.

- [x] Will this PR result in changes to the MET test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>
Adds 2 new output files:
```
dir1: /data/output/met_test_truth contains 1178 files
dir2: /data/output/met_test_output contains 1180 files

ERROR: folder /data/output/met_test_truth missing 2 files
    grid_stat/grid_stat_WIND_VECTOR_LEVELS_120000L_20120409_120000V.stat 
    regrid/regrid_data_plane_WIND_VECTOR_LEVELS.nc 
```
Note that originally, this PR also modified one existing output file slightly: `pb2nc_TMP_big_input.nc`:
```
ERROR: NetCDF headers differ:
17,18c17,18
< 		TMP:long_name = "TMP(*,*)" ;
< 		TMP:level = "*,*" ;
---
> 		TMP:long_name = "TMP(Z2)" ;
> 		TMP:level = "Z2" ;
29c29
```
However I modified that existing test to switch from `level="Z2";` to `level="*";` which matches the usage of all the other similar unit tests. Also note that both of these `level` settings result in the same output. So setting `level="Z2";` DOES NOT have the impact you might expect.

- [x] Will this PR result in changes to existing METplus Use Cases? **[Probably Not]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.
Probably not, but it's possible depending on how existing point2grid calls are formatted in the METplus Use Cases.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:
I spent some time driving down the SonarQube findings in `concat_string.h` and `concat_string.cc`. While some code smells are flagged in newly touched code, the overall number is reduced by 31, from 17,516 in `develop` to 17,485 in this branch.

- [x] Please complete this pull request review by **[Fri 2/21/25]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **MET-X.Y.Z Development** project for official releases
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
