### PR TITLE
Bugfix #3179 develop climo file type

### DIFF
--- a/src/basic/vx_config/config_util.cc
+++ b/src/basic/vx_config/config_util.cc
@@ -345,7 +345,7 @@ StringArray parse_conf_string_array(Dictionary *dict, const char *conf_key, cons
 
 ///////////////////////////////////////////////////////////////////////////////
 
-GrdFileType parse_conf_file_type(Dictionary *dict) {
+GrdFileType parse_conf_file_type(Dictionary *dict, bool search_parent) {
    GrdFileType t = FileType_None;
    int v;
 
@@ -356,7 +356,7 @@ GrdFileType parse_conf_file_type(Dictionary *dict) {
    }
 
    // Get the integer flag value for the current entry
-   v = dict->lookup_int(conf_key_file_type, false);
+   v = dict->lookup_int(conf_key_file_type, false, false, search_parent);
 
    if(dict->last_lookup_status()) {
       // Convert integer to enumerated GrdFileType

--- a/src/basic/vx_config/config_util.h
+++ b/src/basic/vx_config/config_util.h
@@ -35,7 +35,8 @@ extern ConcatString    parse_conf_string(
                           Dictionary *dict,
                           const char *,
                           bool check_empty=true);
-extern GrdFileType     parse_conf_file_type(Dictionary *dict);
+extern GrdFileType     parse_conf_file_type(Dictionary *dict,
+                          bool search_parent=default_dictionary_search_parent);
 extern std::map<STATLineType,STATOutputType>
                        parse_conf_output_flag(
                           Dictionary *dict,

--- a/src/libcode/vx_statistics/read_climo.cc
+++ b/src/libcode/vx_statistics/read_climo.cc
@@ -170,7 +170,10 @@ DataPlaneArray read_climo_data_plane_array(Dictionary *dict,
                   nint(hour_interval * sec_per_hour));
 
    // Check if file_type was specified
-   GrdFileType ctype = parse_conf_file_type(&i_dict);
+   // MET #3179 Only parse from the current dictionary rather than
+   //           searching the fcst or obs parent which can cause
+   //           unexpected behavior. 
+   GrdFileType ctype = parse_conf_file_type(&i_dict, false);
 
    // Search the files for the requested records
    for(int i=0; i<climo_files.n(); i++) {

--- a/src/libcode/vx_statistics/read_climo.cc
+++ b/src/libcode/vx_statistics/read_climo.cc
@@ -173,7 +173,8 @@ DataPlaneArray read_climo_data_plane_array(Dictionary *dict,
    // MET #3179 Only parse from the current dictionary rather than
    //           searching the fcst or obs parent which can cause
    //           unexpected behavior. 
-   GrdFileType ctype = parse_conf_file_type(&i_dict, false);
+   Dictionary *climo_dict = dict->lookup_dictionary(climo_name);
+   GrdFileType ctype = parse_conf_file_type(climo_dict, false);
 
    // Search the files for the requested records
    for(int i=0; i<climo_files.n(); i++) {


### PR DESCRIPTION
## Expected Differences ##

These are the same changes as PR #3180 but for the `develop` branch rather than `main_v12.1`.

@CPKalb has already reviewed/approved them there. Requesting a review from @georgemccabe to loop him in on these details.

You can find this branch compiled in `seneca:/d1/projects/MET/MET_pull_requests/met-12.2.0/rc1/MET-bugfix_3179_develop_climo_file_type` as the `met_test` user in case you'd like to do any testing.