### PR TITLE
Feature dtcenter/METbaseimage#32 main_v12.1 release docker

### DIFF
--- a/.github/jobs/bash_functions.sh
+++ b/.github/jobs/bash_functions.sh
@@ -30,5 +30,5 @@ function time_command {
 # replacing slashes with underscores in the branch name
 
 function get_dockerhub_tag {
-  echo ${DOCKERHUB_REPO}:$(echo ${SOURCE_BRANCH} | sed 's%/%_%g')
+  echo ${DOCKERHUB_REPO}:$(echo ${SOURCE_BRANCH} | sed 's%/%_%g' | sed 's%^v%%g' )
 }

--- a/.github/jobs/bash_functions.sh
+++ b/.github/jobs/bash_functions.sh
@@ -27,7 +27,8 @@ function time_command {
 }
 
 # utility function to construct the DockerHub tag name to be used,
-# replacing slashes with underscores in the branch name
+# replacing slashes with underscores in the branch name, and
+# omitting the leading 'v' from the DockerHub version
 
 function get_dockerhub_tag {
   echo ${DOCKERHUB_REPO}:$(echo ${SOURCE_BRANCH} | sed 's%/%_%g' | sed 's%^v%%g' )

--- a/.github/jobs/build_release_docker_image.sh
+++ b/.github/jobs/build_release_docker_image.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+source ${GITHUB_WORKSPACE}/.github/jobs/bash_functions.sh
+
+DOCKERHUB_TAG=$(get_dockerhub_tag)
+
+# Checked out by release-docker-images.yml workflow 
+DOCKERFILE_PATH=${GITHUB_WORKSPACE}/${SOURCE_BRANCH}/internal/scripts/docker/Dockerfile
+
+CMD_LOGFILE=${GITHUB_WORKSPACE}/docker_build_release.log
+
+time_command docker build -t ${DOCKERHUB_TAG} \
+    --build-arg SOURCE_BRANCH \
+    --build-arg MET_BASE_REPO \
+    --build-arg MET_BASE_TAG \
+    --build-arg MET_CONFIG_OPTS \
+    -f $DOCKERFILE_PATH ${GITHUB_WORKSPACE}
+if [ $? != 0 ]; then
+  cat ${CMD_LOGFILE}
+  exit 1
+fi
+
+# Copy the log directory from the image
+id=$(docker create ${DOCKERHUB_TAG})
+time_command docker cp $id:/met/logs met_logs
+mv met_logs/*.log ${GITHUB_WORKSPACE}/.
+docker rm -v $id

--- a/.github/jobs/push_release_docker_image.sh
+++ b/.github/jobs/push_release_docker_image.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+source ${GITHUB_WORKSPACE}/.github/jobs/bash_functions.sh
+
+DOCKERHUB_TAG=$(get_dockerhub_tag)
+
+# skip docker push if credentials are not set
+if [ -z ${DOCKER_USERNAME+x} ] || [ -z ${DOCKER_PASSWORD+x} ]; then
+    echo "DockerHub credentials not set. Skipping docker push"
+    exit 0
+fi
+
+echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+
+time_command docker push ${DOCKERHUB_TAG}
+
+# push X.Y-latest for vX.Y.Z versions
+if [[ "${UPDATE_LATEST}" == "true" && "${SOURCE_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then  
+    LATEST_TAG=$(echo ${SOURCE_BRANCH} | sed 's/^v//g' | cut -f1,2 -d'.')-latest
+    time_command docker tag ${DOCKERHUB_TAG} ${DOCKERHUB_REPO}:${LATEST_TAG}
+    time_command docker push ${DOCKERHUB_REPO}:${LATEST_TAG}
+fi

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -1,0 +1,94 @@
+name: Create Docker images for release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Comma-separated list of versions to build, e.g. "v12.0.2","v12.1.0"'
+        default: '"v12.0.2"'
+        required: true
+        type: string
+      update_latest:
+        description: 'For official "vX.Y.Z" versions, update the corresponding "X.Y-latest" images.'
+        default: false 
+        required: true
+        type: boolean
+  schedule:
+    - cron: "30 03 * * 0"
+
+env:
+  DOCKERHUB_REPO: dtcenter/met
+
+jobs:
+
+  define-matrix:
+    name: Define Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-versions.outputs.matrix }}
+      update_latest: ${{ steps.get-versions.outputs.update_latest }}
+    steps:
+      - name: Get versions to build 
+        id: get-versions
+        run: |
+          if [[ ${{ github.event_name }} == 'schedule' ]]; then
+            version_list="\"v12.0.2\""
+            update_latest="true"
+          elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
+            version_list=${{ toJSON(inputs.release_version) }}
+            update_latest=${{ toJSON(inputs.update_latest) }}
+          else
+            version_list=\"${{ toJSON(github.ref_name) }}\"
+            update_latest="true"
+          fi
+          echo "matrix={\"version\": [ ${version_list} ]}" >> $GITHUB_OUTPUT
+          echo "update_latest=${update_latest}" >> $GITHUB_OUTPUT
+
+  build_and_push:
+    name: Build and Push Images
+    runs-on: ubuntu-latest
+    needs: define-matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.version }}
+          path: ${{ matrix.version }}
+          sparse-checkout: internal/scripts/docker/Dockerfile
+          sparse-checkout-cone-mode: false
+
+      - name: Create directories to store output
+        run: mkdir -p ${RUNNER_WORKSPACE}/logs
+
+      - name: Build Release Docker Image
+        run: .github/jobs/build_release_docker_image.sh
+        env:
+          SOURCE_BRANCH: ${{ matrix.version }}
+          MET_CONFIG_OPTS: '--enable-all'
+
+      - name: Copy all build log files into logs directory
+        if: always()
+        run: cp ${GITHUB_WORKSPACE}/*.log ${RUNNER_WORKSPACE}/logs/
+
+      - name: Push Docker Image
+        run: .github/jobs/push_release_docker_image.sh
+        env:
+          SOURCE_BRANCH: ${{ matrix.version }}
+          UPDATE_LATEST: ${{ fromJSON(needs.define-matrix.outputs.update_latest) }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Upload logs as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs_${{ matrix.version }}
+          path: ${{ runner.workspace }}/logs
+          if-no-files-found: ignore


### PR DESCRIPTION
This PR contains the full set of changes I made to the `main_v12.0` branch to support MET building/pushing images to the Docker Hub dtcenter/MET repository for...
- New tagged versions (that begin with `v`)... will also push the `X.Y-latest` tag.
- Weekly rebuilds of existing tagged versions (currently only `v12.0.2`)... will also push the `X.Y-latest` tag.
- Manual workflow dispatch triggers for user-specified version with the `X.Y-latest` tag updating optional. 

When `main_v12.1` becomes the default branch, we'll need to update the list of weekly version rebuilds to include `v12.1.0`.

Direct testing of this functionality is not very feasible, but I can demonstrate how things work on the `main_v12.0` branch.