### PR TITLE
Feature #3204 v12.0.3

### DIFF
--- a/.github/jobs/set_job_controls.sh
+++ b/.github/jobs/set_job_controls.sh
@@ -6,7 +6,7 @@ run_unit_tests=false
 run_diff=false
 run_update_truth=false
 met_base_repo=met-base
-met_base_tag=v3.3
+met_base_tag=v3.3.1
 input_data_version=develop
 truth_data_version=develop
 

--- a/.github/workflows/build_docker_and_trigger_metplus.yml
+++ b/.github/workflows/build_docker_and_trigger_metplus.yml
@@ -36,8 +36,8 @@ jobs:
         run: .github/jobs/push_docker_image.sh
         env:
           SOURCE_BRANCH: ${{ steps.get_branch_name.outputs.branch_name }}-lite
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: 'dtcenter'
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
 
   trigger_metplus:
     name: Trigger METplus testing workflow

--- a/.github/workflows/build_docker_and_trigger_metplus.yml
+++ b/.github/workflows/build_docker_and_trigger_metplus.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           SOURCE_BRANCH: ${{ steps.get_branch_name.outputs.branch_name }}-lite
           MET_BASE_REPO: met-base
-          MET_BASE_TAG: v3.3
+          MET_BASE_TAG: v3.3.1
 
       - name: Push Docker Image
         run: .github/jobs/push_docker_image.sh

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Comma-separated list of versions to build, e.g. "v12.0.2"'
-        default: '"v12.0.2"'
+        description: 'Comma-separated list of versions to build, e.g. "v12.0.3"'
+        default: '"v12.0.3"'
         required: true
         type: string
       update_latest:
@@ -38,7 +38,7 @@ jobs:
         id: get-versions
         run: |
           if [[ ${{ github.event_name }} == 'schedule' ]]; then
-            version_list="\"v12.0.2\""
+            version_list="\"v12.0.3\""
             update_latest="true"
           elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             version_list=${{ toJSON(inputs.release_version) }}

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -98,8 +98,8 @@ jobs:
         env:
           SOURCE_BRANCH: ${{ matrix.version }}
           UPDATE_LATEST: ${{ fromJSON(needs.define-matrix.outputs.update_latest) }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: 'dtcenter'
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Copy log files into logs directory
         if: always()

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -61,7 +61,7 @@ jobs:
         run: .github/jobs/build_sonarqube_image.sh
         env:
           MET_BASE_REPO: met-base
-          MET_BASE_TAG: v3.3
+          MET_BASE_TAG: v3.3.1
           SOURCE_BRANCH: ${{ steps.get_branch_name.outputs.branch_name }}
           WD_REFERENCE_BRANCH: ${{ github.event.inputs.reference_branch }}
           SONAR_SCANNER_VERSION: 5.0.1.3006

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -98,8 +98,8 @@ jobs:
         if: ${{ needs.job_control.outputs.run_push == 'true' }}
         env:
           SOURCE_BRANCH: ${{ needs.job_control.outputs.branch_name }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: 'dtcenter'
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Upload logs as artifact
         if: always()
@@ -117,8 +117,8 @@ jobs:
     steps:
       - uses: dtcenter/metplus-action-data-update@v3
         with:
-          docker_name: ${{ secrets.DOCKER_USERNAME }}
-          docker_pass: ${{ secrets.DOCKER_PASSWORD }}
+          docker_name: 'dtcenter'
+          docker_pass: ${{ secrets.DOCKER_TOKEN }}
           repo_name: ${{ github.repository }}
           data_prefix: unit_test
           branch_name: ${{ needs.job_control.outputs.truth_data_version }}
@@ -475,5 +475,5 @@ jobs:
         run: .github/jobs/create_docker_truth.sh
         env:
           TRUTH_DATA_VERSION: ${{ needs.job_control.outputs.truth_data_version }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: 'dtcenter'
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}

--- a/docs/Users_Guide/release-notes.rst
+++ b/docs/Users_Guide/release-notes.rst
@@ -9,6 +9,27 @@ When applicable, release notes are followed by the GitHub issue number which des
 enhancement, or new feature (`MET GitHub issues <https://github.com/dtcenter/MET/issues>`_).
 Important issues are listed **in bold** for emphasis.
 
+MET Version 12.0.3 Release Notes (20250721)
+-------------------------------------------
+
+  .. dropdown:: Bugfixes
+
+     * **Address Critical CVEs from Grype scans of the Docker images**
+       (`METplus-Internal#61 <https://github.com/dtcenter/METplus-Internal/issues/61>`_).
+     * Fix compilation script logic for successful dependent library compilations
+       (`#3092 <https://github.com/dtcenter/MET/issues/3092>`_).
+     * Fix ASCII2NC failure for tab-delimited input files
+       (`#3095 <https://github.com/dtcenter/MET/issues/3095>`_).
+     * Refine the MET GRIB2 library logic to find a single GRIB2 table match rather than multiple ones 
+       (`#3107 <https://github.com/dtcenter/MET/issues/3107>`_).
+     * Fix the MET NetCDF library to support variables with more that 4 dimensions
+       (`#3112 <https://github.com/dtcenter/MET/issues/3112>`_).
+
+  .. dropdown:: Enhancements
+
+     * Add CVE scanning to the release-docker-images.yml workflow
+       (`#3198 <https://github.com/dtcenter/MET/issues/3198>`_).
+
 MET Version 12.0.2 Release Notes (20250214)
 -------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,11 +20,11 @@ print(sys.path)
 project = 'MET'
 author = 'UCAR/NCAR, NOAA, CSU/CIRA, and CU/CIRES'
 author_list = 'Jensen, T., J. Prestopnik, H. Soh, L. Goodrich, B. Brown, R. Bullock, J. Halley Gotway, K. Newman, J. Opatz'
-version = '12.0.2'
+version = '12.0.3'
 verinfo = version
 release = f'{version}'
 release_year = '2025'
-release_date = f'{release_year}-02-14'
+release_date = f'{release_year}-07-21'
 copyright = f'{release_year}, {author}'
 
 # -- General configuration ---------------------------------------------------

--- a/internal/scripts/docker/Dockerfile
+++ b/internal/scripts/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG MET_BASE_REPO=met-base
-ARG MET_BASE_TAG=v3.3
+ARG MET_BASE_TAG=v3.3.1
 
 FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
 MAINTAINER John Halley Gotway <johnhg@ucar.edu>

--- a/internal/scripts/docker/Dockerfile.copy
+++ b/internal/scripts/docker/Dockerfile.copy
@@ -1,5 +1,5 @@
 ARG MET_BASE_REPO=met-base-unit-test
-ARG MET_BASE_TAG=v3.3
+ARG MET_BASE_TAG=v3.3.1
 
 FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
 MAINTAINER John Halley Gotway <johnhg@ucar.edu>

--- a/internal/scripts/docker/Dockerfile.sonarqube
+++ b/internal/scripts/docker/Dockerfile.sonarqube
@@ -1,5 +1,5 @@
 ARG MET_BASE_REPO=met-base
-ARG MET_BASE_TAG=v3.3
+ARG MET_BASE_TAG=v3.3.1
 
 FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
 MAINTAINER John Halley Gotway <johnhg@ucar.edu>

--- a/src/basic/vx_util/util_constants.h
+++ b/src/basic/vx_util/util_constants.h
@@ -18,6 +18,7 @@
 ////////////////////////////////////////////////////////////////////////
 
 // Released versions of MET
+static const char met_version_12_0_3[] = "V12.0.3";
 static const char met_version_12_0_2[] = "V12.0.2";
 static const char met_version_12_0_1[] = "V12.0.1";
 static const char met_version_12_0_0[] = "V12.0.0";
@@ -45,7 +46,7 @@ static const char met_version_1_1[]    = "V1.1";
 
 ////////////////////////////////////////////////////////////////////////
 
-static const char * const met_version    = met_version_12_0_2;
+static const char * const met_version    = met_version_12_0_3;
 static const char default_met_data_dir[] = "MET_BASE";
 static const char txt_file_ext[]         = ".txt";
 static const char stat_file_ext[]        = ".stat";


### PR DESCRIPTION
## Expected Differences ##

This PR includes the following changes:
1. Updates the MET version number from 12.0.2 to 12.0.3.
2. Adds release notes for 12.0.3.
3. Increases the METbaseimage version from v3.3 to v3.3.1.
4. Updates GHA workflows to use the new `$DOCKER_TOKEN` to authenticate with Docker Hub.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
After submitting this PR, GHA built/pushed this `dtcenter/met-dev:feature_3204_v12.0.3-PR` image. I used Workflow Dispatch to scan that image in[ this METbaseimage Workflow run](https://github.com/dtcenter/METbaseimage/actions/runs/16424640422/job/46411753278) and confirmed that it contains 0 critical CVEs:
```
RUNNING: grype dtcenter/met-dev:feature_3204_v12.0.3-PR
Found 758 CVEs for image dtcenter/met-dev:feature_3204_v12.0.3-PR: 0 Critical, 42 High, 75 Medium, 37 Low, 604 Negligible
```
- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Please review the small set of 12.0.3 release notes at [this link](https://metplus--3205.org.readthedocs.build/projects/met/en/3205/Users_Guide/release-notes.html#met-version-12-0-3-release-notes-20250721).

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**
Adds release notes.

- [x] Do these changes include sufficient testing updates? **[Yes]**
None needed.

- [x] Will this PR result in changes to the MET test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>
Differences may be flagged in the MET unit test output due to MTD output described in #2718. If they are flagged, review and validate them, and update `main_v12.0-ref` to move past them.

Note that differences are indeed flagged in this [GHA testing workflow run](https://github.com/dtcenter/MET/actions/runs/16424603246). All diffs appear in the output from MODE Time-Domain and the GSID2MPR utility:
```
> egrep -i "file1:|error" comp_dir.log  | egrep -B 1 -i Error | egrep file1
file1: /data/output/met_test_truth/gsi_tools/gsid2mpr/diag_amsua_n18_ges.mem001_mpr.txt
file1: /data/output/met_test_truth/gsi_tools/gsid2mpr/diag_amsua_n18_ges.mem002_mpr.txt
file1: /data/output/met_test_truth/gsi_tools/gsid2mpr/diag_conv_ges.mem001.stat
file1: /data/output/met_test_truth/gsi_tools/gsid2mpr/diag_conv_ges.mem001_DUP_mpr.txt
file1: /data/output/met_test_truth/mtd/mtd_BASIC_20100517_010000V_2d.txt
file1: /data/output/met_test_truth/mtd/mtd_BASIC_20100517_010000V_3d_pair_cluster.txt
file1: /data/output/met_test_truth/mtd/mtd_BASIC_20100517_010000V_3d_pair_simple.txt
file1: /data/output/met_test_truth/mtd/mtd_BASIC_20100517_010000V_3d_single_cluster.txt
file1: /data/output/met_test_truth/mtd/mtd_BASIC_20100517_010000V_3d_single_simple.txt
file1: /data/output/met_test_truth/mtd/mtd_CONV_TIME_20100517_010000V_2d.txt
file1: /data/output/met_test_truth/mtd/mtd_CONV_TIME_20100517_010000V_3d_pair_cluster.txt
file1: /data/output/met_test_truth/mtd/mtd_CONV_TIME_20100517_010000V_3d_pair_simple.txt
file1: /data/output/met_test_truth/mtd/mtd_CONV_TIME_20100517_010000V_3d_single_cluster.txt
file1: /data/output/met_test_truth/mtd/mtd_CONV_TIME_20100517_010000V_3d_single_simple.txt
file1: /data/output/met_test_truth/mtd/mtd_SINGLE_20100517_010000V_2d.txt
file1: /data/output/met_test_truth/mtd/mtd_SINGLE_20100517_010000V_3d_single_simple.txt
file1: /data/output/met_test_truth/python/mtd_PYTHON_20050807_120000V_2d.txt
file1: /data/output/met_test_truth/python/mtd_PYTHON_20050807_120000V_3d_pair_cluster.txt
file1: /data/output/met_test_truth/python/mtd_PYTHON_20050807_120000V_3d_pair_simple.txt
file1: /data/output/met_test_truth/python/mtd_PYTHON_20050807_120000V_3d_single_cluster.txt
file1: /data/output/met_test_truth/python/mtd_PYTHON_20050807_120000V_3d_single_simple.txt
```
However, these are all red-herrings. The issue is that `main_v6.0` still uses the R-based diffing logic which was never updated to handle diffs in MTD and GSID2MPR outputs. As long as nothing changes, they're handled by the Linux `diff` command, but when the version number changes from `12.0.2` to `12.0.3`, the Linux `diff` command reports that as a difference. These can be safely ignored, and I should recreate the `main_v12.0` truth data after the 12.0.3 bugfix release.

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.
I do not expect that changing the MET version from 12.0.2 to 12.0.3 will trigger diffs in the METplus use case output.

- [x] Do these changes introduce new SonarQube findings? **[Yes or No]**</br>
If **yes**, please describe:
None expected.

- [x] Please complete this pull request review by **[Fri 7/22/25]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **MET-X.Y.Z Development** project for official releases
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
