### PR TITLE
Bugfix #3206 main_v12.1 AW_MEAN

### DIFF
--- a/.github/jobs/set_job_controls.sh
+++ b/.github/jobs/set_job_controls.sh
@@ -6,7 +6,7 @@ run_unit_tests=false
 run_diff=false
 run_update_truth=false
 met_base_repo=met-base
-met_base_tag=v3.4
+met_base_tag=v3.4.1
 input_data_version=develop
 truth_data_version=develop
 

--- a/.github/workflows/build_docker_and_trigger_metplus.yml
+++ b/.github/workflows/build_docker_and_trigger_metplus.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           SOURCE_BRANCH: ${{ steps.get_branch_name.outputs.branch_name }}-lite
           MET_BASE_REPO: met-base
-          MET_BASE_TAG: v3.4
+          MET_BASE_TAG: v3.4.1
 
       - name: Push Docker Image
         run: .github/jobs/push_docker_image.sh

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -61,7 +61,7 @@ jobs:
         run: .github/jobs/build_sonarqube_image.sh
         env:
           MET_BASE_REPO: met-base
-          MET_BASE_TAG: v3.4
+          MET_BASE_TAG: v3.4.1
           SOURCE_BRANCH: ${{ steps.get_branch_name.outputs.branch_name }}
           WD_REFERENCE_BRANCH: ${{ github.event.inputs.reference_branch }}
           SONAR_SCANNER_VERSION: 5.0.1.3006

--- a/internal/scripts/docker/Dockerfile
+++ b/internal/scripts/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG MET_BASE_REPO=met-base
-ARG MET_BASE_TAG=v3.4
+ARG MET_BASE_TAG=v3.4.1
 
 FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
 MAINTAINER John Halley Gotway <johnhg@ucar.edu>

--- a/internal/scripts/docker/Dockerfile.copy
+++ b/internal/scripts/docker/Dockerfile.copy
@@ -1,5 +1,5 @@
 ARG MET_BASE_REPO=met-base-unit-test
-ARG MET_BASE_TAG=v3.4
+ARG MET_BASE_TAG=v3.4.1
 
 FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
 MAINTAINER John Halley Gotway <johnhg@ucar.edu>

--- a/internal/scripts/docker/Dockerfile.sonarqube
+++ b/internal/scripts/docker/Dockerfile.sonarqube
@@ -1,5 +1,5 @@
 ARG MET_BASE_REPO=met-base
-ARG MET_BASE_TAG=v3.4
+ARG MET_BASE_TAG=v3.4.1
 
 FROM dtcenter/${MET_BASE_REPO}:${MET_BASE_TAG}
 MAINTAINER John Halley Gotway <johnhg@ucar.edu>

--- a/src/libcode/vx_regrid/vx_regrid.cc
+++ b/src/libcode/vx_regrid/vx_regrid.cc
@@ -157,6 +157,11 @@ DataPlane met_regrid_area_weighted(const DataPlane & from_data,
    vector<double> to_data_sum(to_grid.nxy(), 0.0);
    vector<double> wt_data_sum(to_grid.nxy(), 0.0);
 
+   //
+   // MET #3206 Reduction of vectors needed to prevent data races
+   //           when updating to_data values 
+   //
+
 #pragma omp declare reduction(vec_dbl_plus : vector<double> :             \
                               transform(omp_out.begin(), omp_out.end(),   \
                                          omp_in.begin(), omp_out.begin(), \

--- a/src/libcode/vx_regrid/vx_regrid.cc
+++ b/src/libcode/vx_regrid/vx_regrid.cc
@@ -145,8 +145,6 @@ DataPlane met_regrid_area_weighted(const DataPlane & from_data,
                                    const Grid & from_grid,
                                    const Grid & to_grid,
                                    const RegridInfo & info) {
-   DataPlane to_data;
-   DataPlane wt_data;
 
    //
    //  The interpolation width and shape do not apply here.  The output
@@ -155,27 +153,33 @@ DataPlane met_regrid_area_weighted(const DataPlane & from_data,
    //  weights are determined by the area of the from_grid boxes.
    //
 
+   DataPlane to_data;
+   vector<double> to_data_sum(to_grid.nxy(), 0.0);
+   vector<double> wt_data_sum(to_grid.nxy(), 0.0);
+
+#pragma omp declare reduction(vec_dbl_plus : vector<double> :             \
+                              transform(omp_out.begin(), omp_out.end(),   \
+                                         omp_in.begin(), omp_out.begin(), \
+                                        plus<double>()))                  \
+                    initializer(omp_priv = decltype(omp_orig)(omp_orig.size()))
+
 #pragma omp parallel default(none) \
-   shared(from_data, from_grid, to_grid, info, to_data, wt_data) \
+   shared(from_data, from_grid, to_grid, info, to_data) \
+   shared(to_data_sum, wt_data_sum) \
    shared(bad_data_double)
    { 
 
 #pragma omp single
       {
          // Set the size and timinig info
-         to_data.set_size (to_grid.nx(), to_grid.ny());
-         wt_data.set_size (to_grid.nx(), to_grid.ny());
+         to_data.set_size (to_grid.nx(), to_grid.ny(), 0.0);
          to_data.set_times(from_data);
-
-         // Initialize the values
-         to_data.set_constant(0.0);
-         wt_data.set_constant(0.0);
-
       }
 
-      // loop over the from grid to accumulate sums and area weights
+      // Loop over the from grid to accumulate sums and area weights
 #pragma omp for schedule(static) \
-                collapse(2)
+                collapse(2) \
+                reduction(vec_dbl_plus : to_data_sum, wt_data_sum)
       for(int xf=0; xf<(from_grid.nx()); xf++) {
          for(int yf=0; yf<(from_grid.ny()); yf++) {
 
@@ -199,25 +203,28 @@ DataPlane met_regrid_area_weighted(const DataPlane & from_data,
                if(is_bad_data(value = from_data(xf, yf))) continue;
                double weight = from_grid.calc_area(xf, yf);
 
-               to_data.set(to_data(xt, yt) + value*weight, xt, yt);
-               wt_data.set(wt_data(xt, yt) + weight,       xt, yt);
+               int n = to_data.two_to_one(xt, yt);
+               to_data_sum[n] += value*weight;
+               wt_data_sum[n] += weight;
             }
          } // for yf
       } // for xf
 
-      // loop over the to grid to compute the area weighted average
-#pragma omp for schedule(static) \
-                collapse(2)
-      for(int xt=0; xt<(to_grid.nx()); xt++) {
-         for(int yt=0; yt<(to_grid.ny()); yt++) {
-            if(is_eq(wt_data(xt, yt), 0.0)) {
-               to_data.set(bad_data_double, xt, yt);
-            }
-            else {
-               to_data.set(to_data(xt, yt) / wt_data(xt, yt), xt, yt);
-            }
-         } // for yt
-      } // for xt
+      // Loop over the to grid to compute the area weighted average
+#pragma omp for schedule(static)
+      for(int n=0; n<to_data_sum.size(); n++) {
+
+         int xt;
+         int yt;
+         to_data.one_to_two(n, xt, yt);
+
+         if(is_eq(wt_data_sum[n], 0.0)) {
+            to_data.set(bad_data_double, xt, yt);
+         }
+         else {
+            to_data.set(to_data_sum[n] / wt_data_sum[n], xt, yt);
+         }
+      } // for n
    } // End of omp parallel
 
    return to_data;


### PR DESCRIPTION
## Expected Differences ##

This PR proposes two changes:
1. Switch from using METbaseimage v3.4 to v3.4.1 to eliminate critical CVEs in MET-12.1.0 Docker images.
2. Fix the AW_MEAN regridding bug by refining the OMP parallelization logic.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

1. Ran this [GHA Workflow](https://github.com/dtcenter/METbaseimage/actions/runs/16429440405/job/46427644229) to confirm that no critical CVEs are present in the Docker image for this PR:
```
RUNNING: grype dtcenter/met-dev:bugfix_3206_main_v12.1_aw_mean-PR
Found 753 CVEs for image dtcenter/met-dev:bugfix_3206_main_v12.1_aw_mean-PR: 0 Critical, 38 High, 75 Medium, 36 Low, 604 Negligible
```

2. Compiled the `bugfix_3206_main_v12.1_aw_mean` branch in seneca `/d1/projects/MET/MET_pull_requests/met-12.1.0/coordinated/MET-bugfix_3206_main_v12.1_aw_mean`.

4. Ran the following to confirm the bug is fixed:
```
cd /d1/projects/MET/MET_pull_requests/met-12.1.0/coordinated/MET-bugfix_3206_main_v12.1_aw_mean/test_rdp
./run_rdp.sh
grep "Range of input" run_*.log | cut -d':' -f2-3 | sort -u
# DEBUG 2: Range of input data (name="HGT"; level="P500";) is 4785.63 to 5913.42.
grep "Range of regridded" run_*.log | cut -d':' -f2-3 | sort -u
# DEBUG 2: Range of regridded data (name="HGT"; level="P500";) is 4791.42 to 5911.47.
```
This confirms that all runs produce the same regridded output values, regardless of how high OMP_NUM_THREADS is set (anywhere between 1 and 1024).
 
5. Ran the full set of MET unit tests using `OMP_NUM_THREADS=1024` and wrote output to the `/d1/projects/MET/MET_pull_requests/met-12.1.0/coordinated/MET-bugfix_3206_main_v12.1_aw_mean/test_output` directory. I diffed that data against the NB output and logged the result in `comp_dir_vs_nb.log`. Minor diffs are flagged in 5 files:
  - 4 have minor size diffs but I used `ncdump` to confirm that the actual data is the same:
```
file1: test_output/netcdf/regrid_data_plane_months_units_day2.nc
file1: test_output/netcdf/regrid_data_plane_months_units.nc
file1: test_output/netcdf/regrid_data_plane_months_units_to_next_month.nc
file1: test_output/netcdf/regrid_data_plane_years_units.nc
ERROR: NetCDF file size difference exceeds 1 %
```
  - 1 has a very minor difference in a value which has appeared previously with different OMP_NUM_THREADS values:
```
file1: test_output/tc_stat/DIAGNOSTICS_stat.out
```
`37.9953` changed to `37.99531`. I have previously debugged this behavior and it is the result of machine precision.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Review code changes and feel free to do any additional testing you'd like.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**
No doc updates needed.

- [x] Do these changes include sufficient testing updates? **[No]**
I made no changes to the unit tests. I don't think we need a test for this specific bugfix. Please see above for the testing I did to confirm that no other similar bugs are waiting to be revealed by our existing unit tests. Of course, other bugs could exist, but the existing tests don't reveal them.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:
I expect no.

- [x] Please complete this pull request review by **[Tues 7/22/25]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **METplus-X.Y Support** project for bugfix releases or **MET-X.Y Development** project for the next coordinated release
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
