### PR TITLE
Bugfix #3235 develop climo segfault

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -65,7 +65,7 @@ jobs:
           SOURCE_BRANCH: ${{ steps.get_branch_name.outputs.branch_name }}
           WD_REFERENCE_BRANCH: ${{ github.event.inputs.reference_branch }}
           SONAR_SCANNER_VERSION: 5.0.1.3006
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: SonarQube Quality Gate check
@@ -75,7 +75,7 @@ jobs:
           scanMetadataReportFile: /tmp/scannerwork/report-task.txt
         timeout-minutes: 5
         env:
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Copy log files into logs directory

--- a/src/libcode/vx_data2d_nc_cf/data2d_nc_cf.cc
+++ b/src/libcode/vx_data2d_nc_cf/data2d_nc_cf.cc
@@ -163,6 +163,7 @@ int MetNcCFDataFile::add_data_planes_by_time(VarInfo &vinfo, const LevelInfo &le
    int n_rec = 0;
    const auto *vinfo_nc = (VarInfoNcCF *)&vinfo;
    const NcVarInfo *data_var = get_data_var(vinfo);
+   if (nullptr == data_var) return 0;
    LongArray dimension = vinfo_nc->dimension();
    static const string method_name
          = "MetNcCFDataFile::add_data_planes_by_time() -> ";
@@ -213,6 +214,7 @@ int MetNcCFDataFile::add_data_planes_by_z(VarInfo &vinfo, const LevelInfo &level
    int n_rec = 0;
    const auto *vinfo_nc = (VarInfoNcCF *)&vinfo;
    const NcVarInfo *data_var = get_data_var(vinfo);
+   if (nullptr == data_var) return 0;
    LongArray dimension = vinfo_nc->dimension();
    static const string method_name
          = "MetNcCFDataFile::add_data_planes_by_z() -> ";
@@ -400,6 +402,7 @@ int MetNcCFDataFile::data_plane_array(VarInfo &vinfo,
 
    auto vinfo_nc = (VarInfoNcCF *)&vinfo;
    const NcVarInfo *data_var = get_data_var(vinfo);
+   if (nullptr == data_var) return 0;
    int t_dim_slot = data_var->t_slot;
    int z_dim_slot = data_var->z_slot;
    LongArray dimension = vinfo_nc->dimension();
@@ -1042,7 +1045,9 @@ NcVarInfo *MetNcCFDataFile::get_data_var(VarInfo &vinfo) {
    if(vinfo.req_name() == na_str) {
       // Store the name of the first data variable
       data_var = find_first_data_var();
-      vinfo.set_req_name(data_var->name.c_str());
+      if (nullptr != data_var) {
+         vinfo.set_req_name(data_var->name.c_str());
+      }
    }
    else data_var = _file->find_var_name(vinfo.req_name().c_str());
 


### PR DESCRIPTION
Same changes as #3236 but for `develop` instead of `main_v12.1`. Please review these at the same time and find the code for this PR compiled in `seneca:/d1/projects/MET/MET_pull_requests/met-12.2.0/rc1/MET-bugfix_3235_develop_climo_segfault`.