### PR TITLE
Feature dtcenter/metplus-internal#64 develop

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           repository: 'dtcenter/metplus'
           ref: 'develop'
-          path: 'develop'
           sparse-checkout: metplus/component_versions.py
           sparse-checkout-cone-mode: false
 
@@ -47,23 +46,23 @@ jobs:
         id: get-versions
         run: |
           if [[ ${{ github.event_name }} == 'schedule' ]]; then
-            version_list="v12.0,v12.1"
+            version_string="v12.0,v12.1"
             update_latest="true"
           elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
-            version_list=${{ toJSON(inputs.release_version) }}
+            version_string=${{ toJSON(inputs.release_version) }}
             update_latest=${{ toJSON(inputs.update_latest) }}
           else
-            version_list=\"${{ toJSON(github.ref_name) }}\"
+            version_string=\"${{ toJSON(github.ref_name) }}\"
             update_latest="true"
           fi
           # Replace vX.Y with latest vX.Y.Z, as needed
-          IFS=',' read -a version_array <<< $version_list
+          IFS=',' read -a version_array <<< ${version_string}
           matrix="{\"version\": ["
           for version in "${version_array[@]}"; do
             if [[ "$version" =~ "^v[0-9]+.[0-9]+.[0-9]+$" ]]; then
               matrix+=${version}
             else
-              matrix+=$("${GITHUB_WORKSPACE}"/metplus/component_versions.py -v ${version} -i MET -o MET)
+              matrix+=$(${GITHUB_WORKSPACE}/metplus/component_versions.py -v ${version} -o MET)
             fi
             if [[ "$version" != "$version_array[-1]" ]]; then
               matrix+=","

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Comma-separated list of versions to build, e.g. "v12.0.3","v12.1.0"'
-        default: '"v12.1.0"'
+        description: 'Comma-separated list of versions to build, e.g. v12.0,v12.1'
+        default: 'v12.1'
         required: true
         type: string
       update_latest:
@@ -33,12 +33,21 @@ jobs:
     outputs:
       matrix: ${{ steps.get-versions.outputs.matrix }}
       update_latest: ${{ steps.get-versions.outputs.update_latest }}
+
     steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'dtcenter/metplus'
+          ref: 'develop'
+          path: 'develop'
+          sparse-checkout: metplus/component_versions.py
+          sparse-checkout-cone-mode: false
+
       - name: Get versions to build 
         id: get-versions
         run: |
           if [[ ${{ github.event_name }} == 'schedule' ]]; then
-            version_list="\"v12.0.3\",\"v12.1.0\""
+            version_list="v12.0,v12.1"
             update_latest="true"
           elif [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             version_list=${{ toJSON(inputs.release_version) }}
@@ -47,7 +56,22 @@ jobs:
             version_list=\"${{ toJSON(github.ref_name) }}\"
             update_latest="true"
           fi
-          echo "matrix={\"version\": [ ${version_list} ]}" >> $GITHUB_OUTPUT
+          # Replace vX.Y with latest vX.Y.Z, as needed
+          IFS=',' read -a version_array <<< $version_list
+          matrix="{\"version\": ["
+          for version in "${version_array[@]}"; do
+            if [[ "$version" =~ "^v[0-9]+.[0-9]+.[0-9]+$" ]]; then
+              matrix+=${version}
+            else
+              matrix+=$("${GITHUB_WORKSPACE}"/metplus/component_versions.py -v ${version} -i MET -o MET)
+            fi
+            if [[ "$version" != "$version_array[-1]" ]]; then
+              matrix+=","
+            fi
+          done
+          matrix+="]}"
+          echo "matrix=${matrix}"
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
           echo "update_latest=${update_latest}" >> $GITHUB_OUTPUT
 
   build_scan_and_push:

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -58,14 +58,16 @@ jobs:
           IFS=',' read -a version_array <<< ${version_string}
           matrix="{\"version\": ["
           for version in "${version_array[@]}"; do
+            echo "version = $version"
             if [[ "$version" =~ "^v[0-9]+.[0-9]+$" ]]; then
-              matrix+=$(${GITHUB_WORKSPACE}/metplus/component_versions.py -v ${version} -i MET -o MET)
+              matrix+=\"$(${GITHUB_WORKSPACE}/metplus/component_versions.py -v ${version} -i MET -o MET)\"
             else
-              matrix+=${version}
+              matrix+=\"${version}\"
             fi
             if [[ "$version" != "$version_array[-1]" ]]; then
               matrix+=","
             fi
+            echo "matrix = $matrix"
           done
           matrix+="]}"
           echo "matrix=${matrix}"

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -58,18 +58,13 @@ jobs:
           IFS=',' read -r -a version_array <<< "${version_string}"
           matrix="{\"version\": ["
           for version in "${version_array[@]}"; do
-            echo "version = $version"
             if [[ ${version} =~ ^v[0-9]+.[0-9]+$ ]]; then
-              echo "Expanding version..."
               matrix+=\"$(${GITHUB_WORKSPACE}/metplus/component_versions.py -v ${version} -i MET -o MET)\",
             else
-              echo "Not expanding version..."
               matrix+=\"${version}\",
             fi
-            echo "matrix = $matrix"
           done
           matrix+="]}"
-          echo "matrix=${matrix}"
           echo "matrix=${matrix}" >> $GITHUB_OUTPUT
           echo "update_latest=${update_latest}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
       update_latest:
-        description: 'Update the corresponding "X.Y-latest" images.'
+        description: 'Update "X.Y-latest" images.'
         default: false
         required: true
         type: boolean
@@ -59,13 +59,12 @@ jobs:
           matrix="{\"version\": ["
           for version in "${version_array[@]}"; do
             echo "version = $version"
-            if [[ "$version" =~ "^v[0-9]+.[0-9]+$" ]]; then
-              matrix+=\"$(${GITHUB_WORKSPACE}/metplus/component_versions.py -v ${version} -i MET -o MET)\"
+            if [[ "${version}" =~ "^v[0-9]+.[0-9]+$" ]]; then
+              echo "Expanding version..."
+              matrix+=\"$(${GITHUB_WORKSPACE}/metplus/component_versions.py -v ${version} -i MET -o MET)\",
             else
-              matrix+=\"${version}\"
-            fi
-            if [[ "$version" != "$version_array[-1]" ]]; then
-              matrix+=","
+              echo "Not expanding version..."
+              matrix+=\"${version}\",
             fi
             echo "matrix = $matrix"
           done

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -55,11 +55,11 @@ jobs:
             version_string=${{ toJSON(github.ref_name) }}
             update_latest="true"
           fi
-          IFS=',' read -a version_array <<< ${version_string}
+          IFS=',' read -r -a version_array <<< "${version_string}"
           matrix="{\"version\": ["
           for version in "${version_array[@]}"; do
             echo "version = $version"
-            if [[ "${version}" =~ "^v[0-9]+.[0-9]+$" ]]; then
+            if [[ ${version} =~ ^v[0-9]+.[0-9]+$ ]]; then
               echo "Expanding version..."
               matrix+=\"$(${GITHUB_WORKSPACE}/metplus/component_versions.py -v ${version} -i MET -o MET)\",
             else

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: string
       update_latest:
-        description: 'For "vX.Y.Z" versions, update the corresponding "X.Y-latest" images.'
+        description: 'Update the corresponding "X.Y-latest" images.'
         default: false
         required: true
         type: boolean
@@ -52,17 +52,16 @@ jobs:
             version_string=${{ toJSON(inputs.release_version) }}
             update_latest=${{ toJSON(inputs.update_latest) }}
           else
-            version_string=\"${{ toJSON(github.ref_name) }}\"
+            version_string=${{ toJSON(github.ref_name) }}
             update_latest="true"
           fi
-          # Replace vX.Y with latest vX.Y.Z, as needed
           IFS=',' read -a version_array <<< ${version_string}
           matrix="{\"version\": ["
           for version in "${version_array[@]}"; do
-            if [[ "$version" =~ "^v[0-9]+.[0-9]+.[0-9]+$" ]]; then
-              matrix+=${version}
+            if [[ "$version" =~ "^v[0-9]+.[0-9]+$" ]]; then
+              matrix+=$(${GITHUB_WORKSPACE}/metplus/component_versions.py -v ${version} -i MET -o MET)
             else
-              matrix+=$(${GITHUB_WORKSPACE}/metplus/component_versions.py -v ${version} -o MET)
+              matrix+=${version}
             fi
             if [[ "$version" != "$version_array[-1]" ]]; then
               matrix+=","

--- a/docs/Contributors_Guide/continuous_integration.rst
+++ b/docs/Contributors_Guide/continuous_integration.rst
@@ -8,21 +8,21 @@ are pushed to GitHub.
 GitHub Actions Workflows
 ========================
 
-GitHub Actions runs workflows defined by files in the *.github/workflows*
+GitHub Actions runs workflows defined by files in the :code:`.github/workflows`
 directory of a GitHub repository. Workflows that are run by multiple METplus
 components are documented in the `METplus Contributor's Guide
 <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html>`_.
 These common workflows include:
 
-- `Testing (testing.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#testing-testing-yml>_` to support regression testing.
-- `Documentation (documentation.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#documentation-documentation-yml>_` to check for problems building the documentation.
-- `SonarQube (sonarqube.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#sonarqube-sonarqube-yml>_` to perform static code analysis.
-- `Build Docker Image and Trigger METplus Workflow (build_docker_and_trigger_metplus.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#build-docker-image-and-trigger-metplus-workflow-build-docker-trigger-metplus-yml>_` to test that changes to METplus components do not break existing METplus use cases.
-- `Release Checksum (release-checksum.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#release-checksum-release-checksum-yml>_` to create and attach checksum file assets for each software release.
-- `Release Docker Images (release-docker-images.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#release-docker-images-release-docker-images-yml>_` to routinely recreate Docker images for recent software releases to minimize vulnerabilities.
-- `Update Truth (update_truth.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#update-reference-branch-update-reference-branch-yml>_` to update the reference truth data used by the testing workflow.
+- `Testing (testing.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#testing-testing-yml>`_ to perform regression testing.
+- `Documentation (documentation.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#documentation-documentation-yml>`_ to check for problems building the documentation.
+- `SonarQube (sonarqube.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#sonarqube-sonarqube-yml>`_ to perform static code analysis.
+- `Build Docker Image and Trigger METplus Workflow (build_docker_and_trigger_metplus.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#build-docker-image-and-trigger-metplus-workflow-build-docker-trigger-metplus-yml>`_ to confirm that changes to METplus components do not break existing METplus use cases.
+- `Release Checksum (release-checksum.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#release-checksum-release-checksum-yml>`_ to create and attach checksum file assets to software releases.
+- `Release Docker Images (release-docker-images.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#release-docker-images-release-docker-images-yml>`_ to routinely recreate Docker images for recent software releases to minimize vulnerabilities.
+- `Update Truth (update_truth.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#update-reference-branch-update-reference-branch-yml>`_ to update the reference truth data used by the testing workflow.
 
-.. _cg-ci-compilation_options
+.. _cg-ci-compilation_options:
 
 Compilation Options (compilation_options.yml)
 ---------------------------------------------

--- a/docs/Contributors_Guide/continuous_integration.rst
+++ b/docs/Contributors_Guide/continuous_integration.rst
@@ -2,16 +2,39 @@
 Continuous Integration
 **********************
 
-Coming Soon!
+MET utilizes GitHub Actions to run processes automatically when changes
+are pushed to GitHub.
 
-Overview
-========
+GitHub Actions Workflows
+========================
 
+GitHub Actions runs workflows defined by files in the *.github/workflows*
+directory of a GitHub repository. Workflows that are run by multiple METplus
+components are documented in the `METplus Contributor's Guide
+<https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html>`_.
+These common workflows include:
 
-Keywords
-========
+- `Testing (testing.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#testing-testing-yml>_` to support regression testing.
+- `Documentation (documentation.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#documentation-documentation-yml>_` to check for problems building the documentation.
+- `SonarQube (sonarqube.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#sonarqube-sonarqube-yml>_` to perform static code analysis.
+- `Build Docker Image and Trigger METplus Workflow (build_docker_and_trigger_metplus.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#build-docker-image-and-trigger-metplus-workflow-build-docker-trigger-metplus-yml>_` to test that changes to METplus components do not break existing METplus use cases.
+- `Release Checksum (release-checksum.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#release-checksum-release-checksum-yml>_` to create and attach checksum file assets for each software release.
+- `Release Docker Images (release-docker-images.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#release-docker-images-release-docker-images-yml>_` to routinely recreate Docker images for recent software releases to minimize vulnerabilities.
+- `Update Truth (update_truth.yml) <https://metplus.readthedocs.io/en/latest/Contributors_Guide/continuous_integration.html#update-reference-branch-update-reference-branch-yml>_` to update the reference truth data used by the testing workflow.
 
+.. _cg-ci-compilation_options
 
-Upstream Testing
-================
+Compilation Options (compilation_options.yml)
+---------------------------------------------
 
+MET supports multiple compile-time options which are specified as arguments to the
+"configure" script. The Compilation Options workflow compiles MET multiple times to
+confirm that each configuration results in a successful build. These configurations
+include compiling MET with:
+
+- All options enabled
+- All options disabled
+- Each individual option enabled by itself
+
+This workflow confirms that MET compiles successfully with a variety of configurations
+but does not run any unit tests or compare output against a truth dataset.


### PR DESCRIPTION
## Expected Differences ##

Update the `release-docker-images.yml` workflow to use `metplus/component_versions.py` script to convert MET "vX.Y" versions into "vX.Y.Z" for the latest bugfix release.

Note that once this approved, I'll just cherry-pick this change into the `main_v12.1` and `main_v12.2` branches.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Tested this `feature_internal_64_develop` branch via GHA. See this [workflow run](https://github.com/dtcenter/MET/actions/runs/18167069919) that I canceled before completion, but note that my input list of versions `v12.0.3,v12.0,v12.1.0,v12.1` was successfully converted into 4 jobs for `v12.0.3`, `v12.0.4`, `v12.1.0`, and `v12.1.1`. I used this to illustrate that only `vX.Y` inputs will converted to `vX.Y.Z`. All other input version strings will be processed as specificed.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
- Review edits and that workflow run linked above.
- Review doc updates at https://metplus--3251.org.readthedocs.build/projects/met/en/3251/Contributors_Guide/continuous_integration.html#continuous-integration

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**
Updated the MET Contributor's Guide info about continuous integration. However, I referenced some METplus CI links that don't exist yet but will soon.

- [x] Do these changes include sufficient testing updates? **[Yes]**
This is a testing update.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:

- [x] Please complete this pull request review by **[Thurs 10/2/25]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **METplus-X.Y Support** project for bugfix releases or **MET-X.Y Development** project for the next coordinated release
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
