### PR TITLE
Bugfix #3255 main_v12.2 shift_right

### DIFF
--- a/src/libcode/vx_data2d/data_class.cc
+++ b/src/libcode/vx_data2d/data_class.cc
@@ -434,7 +434,7 @@ if ( mlog.verbosity_level() >= 4 ) {
 
    mlog << Debug(4) << "\n"
         << "Grid information:\n   "
-        << Dest_Grid->serialize("\n   ") << "\n";
+        << (Dest_Grid ? Dest_Grid->serialize("\n   ") : "(nul)") << "\n";
 
    double min_v, max_v;
    dp.data_range(min_v, max_v);

--- a/src/libcode/vx_data2d/data_class.cc
+++ b/src/libcode/vx_data2d/data_class.cc
@@ -110,7 +110,8 @@ void Met2dDataFile::mtddf_init_from_scratch()
 Raw_Grid  = (Grid *) nullptr;
 Dest_Grid = (Grid *) nullptr;
 
-ShiftRight = 0;
+ShiftRight  = 0;
+GridShifted = false;
 
 return;
 
@@ -129,7 +130,8 @@ if ( Dest_Grid )  { delete Dest_Grid;  Dest_Grid = (Grid *) nullptr; }
 
 Filename.clear();
 
-ShiftRight = 0;
+ShiftRight  = 0;
+GridShifted = false;
 
 return;
 
@@ -172,6 +174,7 @@ if ( Dest_Grid )  {
 } else out << "(nul)\n";
 
 out << prefix << "ShiftRight = " << ShiftRight << '\n';
+out << prefix << "GridShifted = " << bool_to_string(GridShifted) << '\n';
 
    //
    //  done
@@ -410,8 +413,15 @@ if ( vinfo->grid_attr().nxy() > 0 )  {
 
 if ( ShiftRight != 0 )  {
 
-   if ( Dest_Grid )  Dest_Grid->shift_right(ShiftRight);
+   // Shift the grid, but only once
+   if ( Dest_Grid && !GridShifted )  {
 
+      Dest_Grid->shift_right(ShiftRight);
+      GridShifted = true;
+
+   }
+
+   // Shift the data
    dp.shift_right(ShiftRight);
 
 }

--- a/src/libcode/vx_data2d/data_class.cc
+++ b/src/libcode/vx_data2d/data_class.cc
@@ -434,9 +434,10 @@ if ( mlog.verbosity_level() >= 4 ) {
 
    mlog << Debug(4) << "\n"
         << "Grid information:\n   "
-        << Dest_Grid->serialize("\n   ") << "\n";
+        << (Dest_Grid ? Dest_Grid->serialize("\n   ") : "(nul)") << "\n";
 
-   double min_v, max_v;
+   double min_v;
+   double max_v;
    dp.data_range(min_v, max_v);
    mlog << Debug(4) << "\n"
         << "Data plane information:\n"

--- a/src/libcode/vx_data2d/data_class.cc
+++ b/src/libcode/vx_data2d/data_class.cc
@@ -235,8 +235,6 @@ void Met2dDataFile::set_shift_right(int N)
 
 ShiftRight = N;
 
-if ( Dest_Grid )  Dest_Grid->shift_right(ShiftRight);
-
 return;
 
 }
@@ -368,23 +366,6 @@ bool Met2dDataFile::process_data_plane(VarInfo *vinfo, DataPlane &dp)
 if ( ! vinfo )  return false;
 
    //
-   // Check for no valid input data
-   //
-
-if ( dp.is_all_bad_data() )  {
-
-   mlog << Warning << "\nThe field \"" << vinfo->magic_str()
-        << "\" contains no valid data!\n\n";
-
-}
-
-   //
-   // Apply shift to the right logic
-   //
-
-if ( ShiftRight != 0 )  dp.shift_right(ShiftRight);
-
-   //
    // Apply conversion logic
    //
 
@@ -395,6 +376,17 @@ dp.convert(vinfo->ConvertFx);
    //
 
 dp.censor(vinfo->censor_thresh(), vinfo->censor_val());
+
+   //
+   // Check for no valid input data
+   //
+
+if ( dp.is_all_bad_data() )  {
+
+   mlog << Warning << "\nThe field \"" << vinfo->magic_str()
+        << "\" contains no valid data!\n\n";
+
+}
 
    //
    // Update the metadata, if requested
@@ -409,6 +401,18 @@ set_attrs(vinfo, dp);
 if ( vinfo->grid_attr().nxy() > 0 )  {
 
    set_grid(vinfo->grid_attr());
+
+}
+
+   //
+   // Apply shift to the right logic
+   //
+
+if ( ShiftRight != 0 )  {
+
+   if ( Dest_Grid )  Dest_Grid->shift_right(ShiftRight);
+
+   dp.shift_right(ShiftRight);
 
 }
 

--- a/src/libcode/vx_data2d/data_class.h
+++ b/src/libcode/vx_data2d/data_class.h
@@ -97,6 +97,7 @@ class Met2dDataFile : public Met2dData {
       ConcatString Filename;
 
       int ShiftRight;
+      bool GridShifted;
 
    public:
 

--- a/src/libcode/vx_data2d/data_class.h
+++ b/src/libcode/vx_data2d/data_class.h
@@ -41,8 +41,6 @@ class Met2dData {
 
       void mtdd_init_from_scratch();
 
-      // void assign(const Met2dData &);   //  don't allow this
-
    public:
 
       Met2dData();
@@ -85,7 +83,7 @@ class Met2dDataFile : public Met2dData {
 
       void mtddf_init_from_scratch();
 
-      // void assign(const Met2dDataFile &);   //  don't allow this
+      bool GridShifted;
 
    protected:
 
@@ -97,16 +95,15 @@ class Met2dDataFile : public Met2dData {
       ConcatString Filename;
 
       int ShiftRight;
-      bool GridShifted;
 
    public:
 
       Met2dDataFile();
-      virtual ~Met2dDataFile();
+      ~Met2dDataFile() override;
 
       void mtddf_clear();
 
-      virtual void dump(std::ostream &, int depth = 0) const = 0;   //  dump grid and filename, etc., not data
+      void dump(std::ostream &, int depth = 0) const override = 0;   //  dump grid and filename, etc., not data
 
          //
          //  set stuff
@@ -121,11 +118,11 @@ class Met2dDataFile : public Met2dData {
 
       virtual const char * filename() const;
 
-      virtual const Grid & grid     () const;
+      const Grid & grid() const override;
       virtual const Grid & raw_grid () const;
 
-      virtual int nx() const;
-      virtual int ny() const;
+      int nx() const override;
+      int ny() const override;
 
       virtual int raw_nx() const;
       virtual int raw_ny() const;

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -184,10 +184,9 @@ void ModeExecutive::init_traditional(int n_files)
       exit(1);
    }
 
-   const int shift = engine.conf_info.shift_right;
-
-   fcst_mtddf->set_shift_right(shift);
-   obs_mtddf->set_shift_right(shift);
+   // Store the shift right setting
+   fcst_mtddf->set_shift_right(engine.conf_info.shift_right);
+   obs_mtddf->set_shift_right(engine.conf_info.shift_right);
 
    // List the input files
    mlog << Debug(1)

--- a/src/tools/core/mode/mode_exec.cc
+++ b/src/tools/core/mode/mode_exec.cc
@@ -184,9 +184,10 @@ void ModeExecutive::init_traditional(int n_files)
       exit(1);
    }
 
-   // Store the shift right setting
-   fcst_mtddf->set_shift_right(engine.conf_info.shift_right);
-   obs_mtddf->set_shift_right(engine.conf_info.shift_right);
+   const int shift = engine.conf_info.shift_right;
+
+   fcst_mtddf->set_shift_right(shift);
+   obs_mtddf->set_shift_right(shift);
 
    // List the input files
    mlog << Debug(1)


### PR DESCRIPTION
## Expected Differences ##

These changes to `data_class.h` and `data_class.cc` enable the grid shifting logic, currently only utilized by MODE, to work when `set_attr_grid` has been specified. The `ShiftRight` setting is applied to both the grid definition and all 2D fields of data (e.g. `DataPlane` objects) read from that file. The `GridShifted` boolean is added to make sure the grid is only shifted once, even if multiple calls to `data_plane()` are made. The order of the logic in `process_data_plane()` is updated to ensure that `set_attr_grid` is processed before the grid is shifted. Also note that the actual shifting of the grid is moved from `set_shift_right()` into `process_data_plane()`. 
Additional minor changes reduce SonarQube maintainability issues.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
See description of testing in this [issue comment](https://github.com/dtcenter/MET/issues/3255#issuecomment-3403093633).

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
  - Review the GHA runs to ensure all tests pass.
  - Review code changes.
  - Ideally, @hertneky would test with the actual problematic GRIB data that prompted this issue.
  - Please find code for this PR compiled and available for testing in `seneca:/d1/projects/MET/MET_pull_requests/met-12.2.0/rc2/MET-bugfix_3255_main_v12.2_shift_right`.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[No]**
None needed

- [x] Do these changes include sufficient testing updates? **[No]**
I'm not sure on this. I could use @hertneky's problematic GRIB file to add a test in a corresponding PR for the `develop` branch.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:
The overall number of maintainability SonarQube issues should be reduced by 8 (from 14,707 in `main_v12.2` to 14,699 for this PR).

- [x] Please complete this pull request review by **[Fri 10/17/25]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **METplus-X.Y Support** project for bugfix releases or **MET-X.Y Development** project for the next coordinated release
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
