### PR TITLE
Bugfix #3266 main_v12.2 empty_ascii2nc_input

### DIFF
--- a/internal/test_unit/xml/unit_ascii2nc.xml
+++ b/internal/test_unit/xml/unit_ascii2nc.xml
@@ -56,7 +56,7 @@
     </output>
   </test>
 
-    <test name="ascii2nc_GAGE_24hr_badfile">
+  <test name="ascii2nc_GAGE_24hr_badfile">
     <exec>&MET_BIN;/ascii2nc</exec>
     <retval>1</retval>
     <param> \
@@ -177,10 +177,10 @@
   <test name="ascii2nc_ndbc">
     <exec>&MET_BIN;/ascii2nc</exec>
     <param> \
-    -format ndbc_standard \
-    -inputrx '.txt$' \
-    &DATA_DIR_OBS;/ndbc \
-    &OUTPUT_DIR;/ascii2nc/ndbc.nc
+      -format ndbc_standard \
+      -inputrx '.txt$' \
+      &DATA_DIR_OBS;/ndbc \
+      &OUTPUT_DIR;/ascii2nc/ndbc.nc
     </param>
     <output>
       <point_nc>&OUTPUT_DIR;/ascii2nc/ndbc.nc</point_nc>
@@ -190,10 +190,10 @@
   <test name="ascii2nc_ismn_SNOTEL">
     <exec>&MET_BIN;/ascii2nc</exec>
     <param> \
-    -format ismn \
-    -inputrx '.stm$' \
-    &DATA_DIR_OBS;/ismn/SNOTEL \
-    &OUTPUT_DIR;/ascii2nc/ismn_SNOTEL_20220924_20220927.nc
+      -format ismn \
+      -inputrx '.stm$' \
+      &DATA_DIR_OBS;/ismn/SNOTEL \
+      &OUTPUT_DIR;/ascii2nc/ismn_SNOTEL_20220924_20220927.nc
     </param>
     <output>
       <point_nc>&OUTPUT_DIR;/ascii2nc/ismn_SNOTEL_20220924_20220927.nc</point_nc>
@@ -203,12 +203,12 @@
   <test name="ascii2nc_iabp">
     <exec>&MET_BIN;/ascii2nc</exec>
     <param> \
-    -format iabp \
-    -valid_beg 20140101 -valid_end 20140201 \
-    &DATA_DIR_OBS;/iabp/090629.dat \
-    &DATA_DIR_OBS;/iabp/109320.dat \
-    &DATA_DIR_OBS;/iabp/109499.dat \
-    &OUTPUT_DIR;/ascii2nc/iabp_20140101_20140201.nc
+      -format iabp \
+      -valid_beg 20140101 -valid_end 20140201 \
+      &DATA_DIR_OBS;/iabp/090629.dat \
+      &DATA_DIR_OBS;/iabp/109320.dat \
+      &DATA_DIR_OBS;/iabp/109499.dat \
+      &OUTPUT_DIR;/ascii2nc/iabp_20140101_20140201.nc
     </param>
     <output>
       <point_nc>&OUTPUT_DIR;/ascii2nc/iabp_20140101_20140201.nc</point_nc>
@@ -227,14 +227,26 @@
                 > &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_file_list; \
           &MET_BIN;/ascii2nc</exec>
     <param> \
-    -format uscrn \
-    -valid_beg 20240801 -valid_end 20240801 \
-    &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_file_list \
-    &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_20240801.nc
+      -format uscrn \
+      -valid_beg 20240801 -valid_end 20240801 \
+      &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_file_list \
+      &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_20240801.nc
     </param>
     <output>
       <point_nc>&OUTPUT_DIR;/ascii2nc/USCRN_Boulder_20240801.nc</point_nc>
     </output>
   </test>
+
+  <test name="ascii2nc_empty_input">
+    <exec>touch &OUTPUT_DIR;/ascii2nc/empty.txt; \
+          &MET_BIN;/ascii2nc</exec>
+    <retval>1</retval>
+    <param> \
+      &OUTPUT_DIR;/ascii2nc/empty.txt \
+      &OUTPUT_DIR;/ascii2nc/empty.nc
+    </param>
+    <output>
+    </output>
+  </test>  
 
 </met_test>

--- a/src/tools/other/ascii2nc/ascii2nc.cc
+++ b/src/tools/other/ascii2nc/ascii2nc.cc
@@ -52,6 +52,8 @@
 //   023    11/28/23  Halley Gotway  MET #2701 Add ISMN soil moisture data
 //   024    01/06/25  Halley Gotway  MET #1019 Add USCRN quality controlled data
 //   025    06/23/25  Halley Gotway  MET #3148 Search input directories
+//   026    10/17/25  Halley Gotway  MET #3266 Fix IABP/ISMN infinite loops
+//                                   for empty input files
 //
 ////////////////////////////////////////////////////////////////////////
 

--- a/src/tools/other/ascii2nc/iabp_handler.cc
+++ b/src/tools/other/ascii2nc/iabp_handler.cc
@@ -62,7 +62,9 @@ bool IabpHandler::isFileType(LineDataFile &ascii_file) const {
 
    // Read the header line
    DataLine dl;
-   while(dl.n_items() == 0) ascii_file >> dl;
+   while(ascii_file >> dl) {
+      if(dl.n_items() > 0) break;
+   }
 
    // Check the minimum number of header columns
    if(dl.n_items() < MIN_NUM_HDR_COLS) {

--- a/src/tools/other/ascii2nc/ismn_handler.cc
+++ b/src/tools/other/ascii2nc/ismn_handler.cc
@@ -77,7 +77,9 @@ bool IsmnHandler::isFileType(LineDataFile &ascii_file) const {
 
    // Read the header line
    DataLine dl;
-   while(dl.n_items() == 0) ascii_file >> dl;
+   while(ascii_file >> dl) {
+      if(dl.n_items() > 0) break;
+   }
 
    // Check the minimum number of header columns
    if(dl.n_items() < MIN_NUM_HDR_COLS) is_file_type = false;
@@ -224,7 +226,9 @@ bool IsmnHandler::_readHeaderInfo(LineDataFile &ascii_file) {
 
    // Read the header line
    DataLine dl;
-   while(dl.n_items() == 0) ascii_file >> dl;
+   while(ascii_file >> dl) {
+      if(dl.n_items() > 0) break;
+   }
 
    // Check the minimum number of header columns
    if(dl.n_items() < MIN_NUM_HDR_COLS) {


### PR DESCRIPTION
## Expected Differences ##
This is a small bugfix to ascii2nc IABP and ISMN file handlers. ascii2nc goes into an infinite loop when trying to determine the file type of an empty input file. The problem/solution are described in this [issue comment](https://github.com/dtcenter/MET/issues/3266#issuecomment-3416334301). Also adds a new ascii2nc unit test to ensure that it fails with non-zero return status when given an empty input file.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Tested on seneca to confirm the fix works.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
- Review code changes and new test.
- Confirm all GHA tests pass.
- Feel free to test this branch in `seneca:/d1/projects/MET/MET_pull_requests/met-12.2.0/rc2/MET-bugfix_3266_main_v12.2_empty_ascii2nc_input`:
```
touch empty.txt
# Hangs (use CTRL-C to kill it)
/d1/projects/MET/MET_regression/main_v12.2/latest/bin/ascii2nc empty.txt empty.nc
# Errors out well
/d1/projects/MET/MET_pull_requests/met-12.2.0/rc2/MET-bugfix_3266_main_v12.2_empty_ascii2nc_input/bin/ascii2nc emtpy.txt empty.nc
```

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**
None needed

- [x] Do these changes include sufficient testing updates? **[Yes]**
One new test added

- [x] Will this PR result in changes to the MET test suite? **[Yes]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>
The creation of `empty.txt` is flagged as a difference by GHA, but that's OK. Once this PR is merged, I'll update the truth dataset.

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:

- [x] Please complete this pull request review by **[Mon 10/20/25]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **METplus-X.Y Support** project for bugfix releases or **MET-X.Y Development** project for the next coordinated release
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
