### PR TITLE
Bugfix #3266 develop empty_ascii2nc_input

### DIFF
--- a/internal/test_unit/xml/unit_ascii2nc.xml
+++ b/internal/test_unit/xml/unit_ascii2nc.xml
@@ -56,7 +56,7 @@
     </output>
   </test>
 
-    <test name="ascii2nc_GAGE_24hr_badfile">
+  <test name="ascii2nc_GAGE_24hr_badfile">
     <exec>&MET_BIN;/ascii2nc</exec>
     <retval>1</retval>
     <param> \
@@ -177,10 +177,10 @@
   <test name="ascii2nc_ndbc">
     <exec>&MET_BIN;/ascii2nc</exec>
     <param> \
-    -format ndbc_standard \
-    -inputrx '.txt$' \
-    &DATA_DIR_OBS;/ndbc \
-    &OUTPUT_DIR;/ascii2nc/ndbc.nc
+      -format ndbc_standard \
+      -inputrx '.txt$' \
+      &DATA_DIR_OBS;/ndbc \
+      &OUTPUT_DIR;/ascii2nc/ndbc.nc
     </param>
     <output>
       <point_nc>&OUTPUT_DIR;/ascii2nc/ndbc.nc</point_nc>
@@ -190,10 +190,10 @@
   <test name="ascii2nc_ismn_SNOTEL">
     <exec>&MET_BIN;/ascii2nc</exec>
     <param> \
-    -format ismn \
-    -inputrx '.stm$' \
-    &DATA_DIR_OBS;/ismn/SNOTEL \
-    &OUTPUT_DIR;/ascii2nc/ismn_SNOTEL_20220924_20220927.nc
+      -format ismn \
+      -inputrx '.stm$' \
+      &DATA_DIR_OBS;/ismn/SNOTEL \
+      &OUTPUT_DIR;/ascii2nc/ismn_SNOTEL_20220924_20220927.nc
     </param>
     <output>
       <point_nc>&OUTPUT_DIR;/ascii2nc/ismn_SNOTEL_20220924_20220927.nc</point_nc>
@@ -203,12 +203,12 @@
   <test name="ascii2nc_iabp">
     <exec>&MET_BIN;/ascii2nc</exec>
     <param> \
-    -format iabp \
-    -valid_beg 20140101 -valid_end 20140201 \
-    &DATA_DIR_OBS;/iabp/090629.dat \
-    &DATA_DIR_OBS;/iabp/109320.dat \
-    &DATA_DIR_OBS;/iabp/109499.dat \
-    &OUTPUT_DIR;/ascii2nc/iabp_20140101_20140201.nc
+      -format iabp \
+      -valid_beg 20140101 -valid_end 20140201 \
+      &DATA_DIR_OBS;/iabp/090629.dat \
+      &DATA_DIR_OBS;/iabp/109320.dat \
+      &DATA_DIR_OBS;/iabp/109499.dat \
+      &OUTPUT_DIR;/ascii2nc/iabp_20140101_20140201.nc
     </param>
     <output>
       <point_nc>&OUTPUT_DIR;/ascii2nc/iabp_20140101_20140201.nc</point_nc>
@@ -227,14 +227,26 @@
                 > &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_file_list; \
           &MET_BIN;/ascii2nc</exec>
     <param> \
-    -format uscrn \
-    -valid_beg 20240801 -valid_end 20240801 \
-    &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_file_list \
-    &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_20240801.nc
+      -format uscrn \
+      -valid_beg 20240801 -valid_end 20240801 \
+      &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_file_list \
+      &OUTPUT_DIR;/ascii2nc/USCRN_Boulder_20240801.nc
     </param>
     <output>
       <point_nc>&OUTPUT_DIR;/ascii2nc/USCRN_Boulder_20240801.nc</point_nc>
     </output>
   </test>
+
+  <test name="ascii2nc_empty_input">
+    <exec>touch &OUTPUT_DIR;/ascii2nc/empty.txt; \
+          &MET_BIN;/ascii2nc</exec>
+    <retval>1</retval>
+    <param> \
+      &OUTPUT_DIR;/ascii2nc/empty.txt \
+      &OUTPUT_DIR;/ascii2nc/empty.nc
+    </param>
+    <output>
+    </output>
+  </test>  
 
 </met_test>

--- a/src/tools/other/ascii2nc/ascii2nc.cc
+++ b/src/tools/other/ascii2nc/ascii2nc.cc
@@ -52,6 +52,8 @@
 //   023    11/28/23  Halley Gotway  MET #2701 Add ISMN soil moisture data
 //   024    01/06/25  Halley Gotway  MET #1019 Add USCRN quality controlled data
 //   025    06/23/25  Halley Gotway  MET #3148 Search input directories
+//   026    10/17/25  Halley Gotway  MET #3266 Fix IABP/ISMN infinite loops
+//                                   for empty input files
 //
 ////////////////////////////////////////////////////////////////////////
 

--- a/src/tools/other/ascii2nc/iabp_handler.cc
+++ b/src/tools/other/ascii2nc/iabp_handler.cc
@@ -62,7 +62,9 @@ bool IabpHandler::isFileType(LineDataFile &ascii_file) const {
 
    // Read the header line
    DataLine dl;
-   while(dl.n_items() == 0) ascii_file >> dl;
+   while(ascii_file >> dl) {
+      if(dl.n_items() > 0) break;
+   }
 
    // Check the minimum number of header columns
    if(dl.n_items() < MIN_NUM_HDR_COLS) {

--- a/src/tools/other/ascii2nc/ismn_handler.cc
+++ b/src/tools/other/ascii2nc/ismn_handler.cc
@@ -77,7 +77,9 @@ bool IsmnHandler::isFileType(LineDataFile &ascii_file) const {
 
    // Read the header line
    DataLine dl;
-   while(dl.n_items() == 0) ascii_file >> dl;
+   while(ascii_file >> dl) {
+      if(dl.n_items() > 0) break;
+   }
 
    // Check the minimum number of header columns
    if(dl.n_items() < MIN_NUM_HDR_COLS) is_file_type = false;
@@ -224,7 +226,9 @@ bool IsmnHandler::_readHeaderInfo(LineDataFile &ascii_file) {
 
    // Read the header line
    DataLine dl;
-   while(dl.n_items() == 0) ascii_file >> dl;
+   while(ascii_file >> dl) {
+      if(dl.n_items() > 0) break;
+   }
 
    // Check the minimum number of header columns
    if(dl.n_items() < MIN_NUM_HDR_COLS) {


### PR DESCRIPTION
Same changes as PR #3267 but for the `develop` branch instead.
Extra `empty.txt` file will be flagged as a difference, but I'll update the truth dataset after merging.
Code compiled in `seneca:/d1/projects/MET/MET_pull_requests/met-13.0.0/beta1/MET-bugfix_3266_develop_empty_ascii2nc_input`.