### PR TITLE
Bugfix #3266 main_v12.1 empty_ascii2nc_input

### DIFF
--- a/internal/test_unit/xml/unit_ascii2nc.xml
+++ b/internal/test_unit/xml/unit_ascii2nc.xml
@@ -269,4 +269,16 @@
     </output>
   </test>
 
+  <test name="ascii2nc_empty_input">
+    <exec>touch &OUTPUT_DIR;/ascii2nc/empty.txt; \
+          &MET_BIN;/ascii2nc</exec>
+    <retval>1</retval>
+    <param> \
+      &OUTPUT_DIR;/ascii2nc/empty.txt \
+      &OUTPUT_DIR;/ascii2nc/empty.nc
+    </param>
+    <output>
+    </output>
+  </test>
+
 </met_test>

--- a/src/tools/other/ascii2nc/ascii2nc.cc
+++ b/src/tools/other/ascii2nc/ascii2nc.cc
@@ -51,6 +51,8 @@
 //   022    10/07/22  Dave Albo      MET #2276 Add NDBC buoy data
 //   023    11/28/23  Halley Gotway  MET #2701 Add ISMN soil moisture data
 //   024    01/06/25  Halley Gotway  MET #1019 Add USCRN quality controlled data
+//   026    10/17/25  Halley Gotway  MET #3266 Fix IABP/ISMN infinite loops
+//                                   for empty input files
 //
 ////////////////////////////////////////////////////////////////////////
 

--- a/src/tools/other/ascii2nc/iabp_handler.cc
+++ b/src/tools/other/ascii2nc/iabp_handler.cc
@@ -62,7 +62,9 @@ bool IabpHandler::isFileType(LineDataFile &ascii_file) const {
 
    // Read the header line
    DataLine dl;
-   while(dl.n_items() == 0) ascii_file >> dl;
+   while(ascii_file >> dl) {
+      if(dl.n_items() > 0) break;
+   }
 
    // Check the minimum number of header columns
    if(dl.n_items() < MIN_NUM_HDR_COLS) {

--- a/src/tools/other/ascii2nc/ismn_handler.cc
+++ b/src/tools/other/ascii2nc/ismn_handler.cc
@@ -77,7 +77,9 @@ bool IsmnHandler::isFileType(LineDataFile &ascii_file) const {
 
    // Read the header line
    DataLine dl;
-   while(dl.n_items() == 0) ascii_file >> dl;
+   while(ascii_file >> dl) {
+      if(dl.n_items() > 0) break;
+   }
 
    // Check the minimum number of header columns
    if(dl.n_items() < MIN_NUM_HDR_COLS) is_file_type = false;
@@ -224,7 +226,9 @@ bool IsmnHandler::_readHeaderInfo(LineDataFile &ascii_file) {
 
    // Read the header line
    DataLine dl;
-   while(dl.n_items() == 0) ascii_file >> dl;
+   while(ascii_file >> dl) {
+      if(dl.n_items() > 0) break;
+   }
 
    // Check the minimum number of header columns
    if(dl.n_items() < MIN_NUM_HDR_COLS) {


### PR DESCRIPTION
Same changes as PR #3267 but for the `main_v12.1` branch instead.
Extra `empty.txt` file will be flagged as a difference, but I'll update the truth dataset after merging.
Code compiled in `seneca:/d1/projects/MET/MET_pull_requests/met-12.1.2/MET-bugfix_3266_main_v12.1_empty_ascii2nc_input`.