### PR TITLE
Feature #3278 main_v12.2 exit_codes

### DIFF
--- a/docs/Users_Guide/overview.rst
+++ b/docs/Users_Guide/overview.rst
@@ -88,7 +88,8 @@ MET is the statistical component of the larger METplus system for which user sup
 
 .. note::
 
-  **-help** and **-version** command line options are available for all of the MET tools. Typing the name of the tool with no command line options also produces the usage statement.
+  **-help** and **-version** command line options are available for all of the MET tools, and the command returns a good status of 0.
+  Typing the name of the tool with no command line options also produces the usage statement, although the command returns a non-zero status of 1.
 
 Fortify and SonarQube
 =====================

--- a/internal/test_unit/xml/unit_ascii2nc.xml
+++ b/internal/test_unit/xml/unit_ascii2nc.xml
@@ -20,6 +20,29 @@
   <test_dir>&TEST_DIR;</test_dir>
   <exit_on_fail>true</exit_on_fail>
 
+  <!-- MET #3278 no arguments returns bad status of 1 -->
+
+  <test name="ascii2nc_NO_ARGS">
+    <exec>&MET_BIN;/ascii2nc</exec>
+    <retval>1</retval>
+    <param>
+    </param>
+    <output>
+    </output>
+  </test>
+
+  <!-- MET #3278 -help returns good status of 0 -->
+
+  <test name="ascii2nc_USAGE">
+    <exec>&MET_BIN;/ascii2nc</exec>
+    <retval>0</retval>
+    <param> \
+      -help
+    </param>
+    <output>
+    </output>
+  </test>
+
   <test name="ascii2nc_MET_POINT_TAB_DELIM">
     <exec>&MET_BIN;/ascii2nc</exec>
     <param> \
@@ -247,6 +270,6 @@
     </param>
     <output>
     </output>
-  </test>  
+  </test>
 
 </met_test>

--- a/internal/test_util/basic/vx_config/test_user_func.cc
+++ b/internal/test_util/basic/vx_config/test_user_func.cc
@@ -51,7 +51,7 @@ static CommandLine cline;
 
 static void set_do_dump(const StringArray &);
 
-static void usage();
+static void usage(int exit_code=1);
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -198,13 +198,13 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
 cerr << "\n\n   usage:  " << program_name << " config_file [ config_file2 ... ] : function_name arg1 [arg2 ...]\n\n";
 
-exit ( 1 );
+exit ( exit_code );
 
 
 return;

--- a/internal/test_util/basic/vx_config/test_user_func.cc
+++ b/internal/test_util/basic/vx_config/test_user_func.cc
@@ -198,16 +198,13 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) void usage(int exit_code)
 
 {
 
 cerr << "\n\n   usage:  " << program_name << " config_file [ config_file2 ... ] : function_name arg1 [arg2 ...]\n\n";
 
 exit ( exit_code );
-
-
-return;
 
 }
 

--- a/internal/test_util/basic/vx_log/test_reg_exp.cc
+++ b/internal/test_util/basic/vx_log/test_reg_exp.cc
@@ -77,13 +77,11 @@ void set_test(const StringArray & a) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) void usage(int exit_code) {
    mlog << Error
         << "\nusage:  " << program_name
         << " -regex string -test string\n\n";
    exit(exit_code);
-
-   return;
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/test_util/basic/vx_log/test_reg_exp.cc
+++ b/internal/test_util/basic/vx_log/test_reg_exp.cc
@@ -24,7 +24,7 @@ using namespace std;
 static void set_regex (const StringArray &);
 static void set_test  (const StringArray &);
 
-static void usage();
+static void usage(int exit_code=1);
 
 static ConcatString RegexCS;
 static ConcatString TestCS;
@@ -77,11 +77,11 @@ void set_test(const StringArray & a) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
    mlog << Error
         << "\nusage:  " << program_name
         << " -regex string -test string\n\n";
-   exit(1);
+   exit(exit_code);
 
    return;
 }

--- a/internal/test_util/basic/vx_util/test_ascii_header.cc
+++ b/internal/test_util/basic/vx_util/test_ascii_header.cc
@@ -87,7 +87,7 @@ int main(int argc, char * argv []) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) void usage(int exit_code) {
 
    mlog << Error
         << "\nUsage: " << program_name << "\n"
@@ -98,8 +98,6 @@ void usage(int exit_code) {
         << "\t[-name   str]\n"
         << "\t[-offset beg [end]]\n\n";
    exit(exit_code);
-
-   return;
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/test_util/basic/vx_util/test_ascii_header.cc
+++ b/internal/test_util/basic/vx_util/test_ascii_header.cc
@@ -20,7 +20,7 @@ using namespace std;
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage();
+static void usage(int exit_code=1);
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -87,7 +87,7 @@ int main(int argc, char * argv []) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    mlog << Error
         << "\nUsage: " << program_name << "\n"
@@ -97,7 +97,7 @@ void usage() {
         << "\t[-dim    n]\n"
         << "\t[-name   str]\n"
         << "\t[-offset beg [end]]\n\n";
-   exit(1);
+   exit(exit_code);
 
    return;
 }

--- a/internal/test_util/basic/vx_util/test_command_line.cc
+++ b/internal/test_util/basic/vx_util/test_command_line.cc
@@ -129,15 +129,13 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 
 mlog << Error << "\nusage:  " << program_name << " [ -xyz x y z ] [ -verbose ] file_list\n\n";
 
 exit ( exit_code );
-
-return;
 
 }
 

--- a/internal/test_util/basic/vx_util/test_command_line.cc
+++ b/internal/test_util/basic/vx_util/test_command_line.cc
@@ -27,7 +27,7 @@ using namespace std;
 static void set_xyz     (const StringArray &);
 static void set_verbose (const StringArray &);
 
-static void usage();
+static void usage(int exit_code=1);
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -129,13 +129,13 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
 mlog << Error << "\nusage:  " << program_name << " [ -xyz x y z ] [ -verbose ] file_list\n\n";
 
-exit ( 1 );
+exit ( exit_code );
 
 return;
 

--- a/src/basic/vx_util/command_line.cc
+++ b/src/basic/vx_util/command_line.cc
@@ -839,7 +839,11 @@ void CommandLine::do_help() const
 
 {
 
-if ( Usage )  Usage();
+   //
+   //  MET #3278 print usage with good exit status
+   //
+
+if ( Usage )  Usage(0);
 else {
 
    mlog << Error << "\n" << ProgramName
@@ -888,7 +892,11 @@ version_file = replace_path("MET_BASE/version.txt");
 
 cout << "\n";
 
-exit ( 1 );
+   //
+   //  MET #3278 print version with good exit status
+   //
+
+exit(0);
 
 }
 
@@ -984,7 +992,7 @@ while ( (j = next_option(index)) >= 0 )  {
 
       mlog << Error << "\n" << ProgramName << ": unrecognized command-line switch: \"" << args[j] << "\"\n\n";
 
-      if ( Usage )  Usage();
+      if ( Usage )  Usage(1);
 
       exit ( 1 );
 

--- a/src/basic/vx_util/command_line.h
+++ b/src/basic/vx_util/command_line.h
@@ -34,7 +34,7 @@ static const char log_option       [] = "-log";
 
 typedef void (*CLSetFunction)(const StringArray &);   //  command-line set function
 
-typedef void (*UsageFunction)();   //  usage function
+typedef void (*UsageFunction)(int);   //  usage function
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/ensemble_stat/ensemble_stat.cc
+++ b/src/tools/core/ensemble_stat/ensemble_stat.cc
@@ -2897,7 +2897,7 @@ static void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/core/ensemble_stat/ensemble_stat.cc
+++ b/src/tools/core/ensemble_stat/ensemble_stat.cc
@@ -176,7 +176,7 @@ static void add_var_att_local(VarInfo *, NcVar *, bool is_int,
 static void finish_txt_files();
 static void clean_up();
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_grid_obs(const StringArray &);
 static void set_point_obs(const StringArray &);
@@ -2897,7 +2897,7 @@ static void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage() {
+static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -2956,7 +2956,7 @@ static void usage() {
         << "\t\t\"-compress level\" overrides the compression level of NetCDF variable ("
         << conf_info.get_compression_level() << ") (optional).\n\n" << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/grid_stat/grid_stat.cc
+++ b/src/tools/core/grid_stat/grid_stat.cc
@@ -3278,7 +3278,7 @@ void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/core/grid_stat/grid_stat.cc
+++ b/src/tools/core/grid_stat/grid_stat.cc
@@ -195,7 +195,7 @@ static void finish_txt_files();
 
 static void clean_up();
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_outdir(const StringArray &);
 static void set_compress(const StringArray &);
 static bool read_data_plane(VarInfo *info, DataPlane &dp, Met2dDataFile *mtddf,
@@ -3278,7 +3278,7 @@ void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -3321,7 +3321,7 @@ void usage() {
         << "\t\t\"-compress level\" overrides the compression level of NetCDF variable ("
         << conf_info.get_compression_level() << ") (optional).\n\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/mode/mode.cc
+++ b/src/tools/core/mode/mode.cc
@@ -133,6 +133,14 @@ int met_main(int argc, char * argv [])
    string s;
    const char * user_config_filename = 0;
 
+   //
+   // MET #3278 parse global command line options
+   //
+   CommandLine cline;
+   cline.set(argc, argv);
+   cline.set_usage(both_usage);
+   cline.parse();
+
    for (j=0,n=0; j<argc; ++j)  {
 
       //

--- a/src/tools/core/mode/mode.cc
+++ b/src/tools/core/mode/mode.cc
@@ -139,6 +139,7 @@ int met_main(int argc, char * argv [])
    CommandLine cline;
    cline.set(argc, argv);
    cline.set_usage(both_usage);
+   cline.allow_unrecognized_switches();
    cline.parse();
 
    for (j=0,n=0; j<argc; ++j)  {

--- a/src/tools/core/mode/mode_usage.cc
+++ b/src/tools/core/mode/mode_usage.cc
@@ -36,7 +36,7 @@ static void print_multivar_usage();
 ////////////////////////////////////////////////////////////////////////
 
 
-void both_usage(int exit_code)
+__attribute__((noreturn)) static void both_usage(int exit_code)
 
 {
 
@@ -61,7 +61,7 @@ void both_usage(int exit_code)
 ////////////////////////////////////////////////////////////////////////
 
 
-void singlevar_usage(int exit_code)
+__attribute__((noreturn)) static void singlevar_usage(int exit_code)
 
 {
 
@@ -76,7 +76,7 @@ void singlevar_usage(int exit_code)
 ////////////////////////////////////////////////////////////////////////
 
 
-void multivar_usage(int exit_code)
+__attribute__((noreturn)) static void multivar_usage(int exit_code)
 
 {
 
@@ -90,7 +90,7 @@ void multivar_usage(int exit_code)
 ////////////////////////////////////////////////////////////////////////
 
 
-void print_singlevar_usage()
+static void print_singlevar_usage()
 
 {
 
@@ -143,7 +143,7 @@ void print_singlevar_usage()
 ////////////////////////////////////////////////////////////////////////
 
 
-void print_multivar_usage()
+static void print_multivar_usage()
 
 {
 

--- a/src/tools/core/mode/mode_usage.cc
+++ b/src/tools/core/mode/mode_usage.cc
@@ -36,7 +36,7 @@ static void print_multivar_usage();
 ////////////////////////////////////////////////////////////////////////
 
 
-__attribute__((noreturn)) static void both_usage(int exit_code)
+__attribute__((noreturn)) void both_usage(int exit_code)
 
 {
 
@@ -61,7 +61,7 @@ __attribute__((noreturn)) static void both_usage(int exit_code)
 ////////////////////////////////////////////////////////////////////////
 
 
-__attribute__((noreturn)) static void singlevar_usage(int exit_code)
+__attribute__((noreturn)) void singlevar_usage(int exit_code)
 
 {
 
@@ -76,7 +76,7 @@ __attribute__((noreturn)) static void singlevar_usage(int exit_code)
 ////////////////////////////////////////////////////////////////////////
 
 
-__attribute__((noreturn)) static void multivar_usage(int exit_code)
+__attribute__((noreturn)) void multivar_usage(int exit_code)
 
 {
 

--- a/src/tools/core/mode/mode_usage.cc
+++ b/src/tools/core/mode/mode_usage.cc
@@ -28,11 +28,15 @@ extern const char * const program_name;
 
 extern ModeExecutive mode_exec;
 
+static void print_singlevar_usage();
+
+static void print_multivar_usage();
+
 
 ////////////////////////////////////////////////////////////////////////
 
 
-void both_usage()
+void both_usage(int exit_code)
 
 {
 
@@ -42,14 +46,14 @@ void both_usage()
    cout << "Single Variable MODE:\n"
       "=====================\n";
 
-   singlevar_usage();
+   print_singlevar_usage();
 
    cout << "Multi Variable MODE:\n"
         << "====================\n";
 
-   multivar_usage();
+   print_multivar_usage();
 
-   exit ( 1 );
+   exit ( exit_code );
 
 }
 
@@ -57,7 +61,36 @@ void both_usage()
 ////////////////////////////////////////////////////////////////////////
 
 
-void singlevar_usage()
+void singlevar_usage(int exit_code)
+
+{
+
+   print_singlevar_usage();
+
+   exit ( exit_code );
+
+}
+
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+void multivar_usage(int exit_code)
+
+{
+
+   print_multivar_usage();
+
+   exit ( exit_code );
+
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+
+void print_singlevar_usage()
 
 {
 
@@ -110,7 +143,7 @@ void singlevar_usage()
 ////////////////////////////////////////////////////////////////////////
 
 
-void multivar_usage()
+void print_multivar_usage()
 
 {
 
@@ -152,3 +185,4 @@ void multivar_usage()
 
 
 ////////////////////////////////////////////////////////////////////////
+

--- a/src/tools/core/mode/mode_usage.h
+++ b/src/tools/core/mode/mode_usage.h
@@ -17,11 +17,11 @@
 ////////////////////////////////////////////////////////////////////////
 
 
-extern void both_usage();
+extern void both_usage(int exit_code=1);
 
-extern void singlevar_usage();
+extern void singlevar_usage(int exit_code=1);
 
-extern void multivar_usage();
+extern void multivar_usage(int exit_code=1);
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/mode_analysis/mode_analysis.cc
+++ b/src/tools/core/mode_analysis/mode_analysis.cc
@@ -330,7 +330,7 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/core/mode_analysis/mode_analysis.cc
+++ b/src/tools/core/mode_analysis/mode_analysis.cc
@@ -81,7 +81,7 @@ static ofstream * outfile  = (ofstream *) nullptr;
 
 static void parse_command_line(int, char **);
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_lookin_path(const StringArray &);
 static void set_summary_jobtype(const StringArray &);
@@ -330,7 +330,7 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
@@ -390,7 +390,7 @@ cout << "\n*** Model Evaluation Tools (MET" << met_version
 
 mode_atts_usage(cout);
 
-exit (1);
+exit (exit_code);
 
 }
 

--- a/src/tools/core/pair_stat/pair_stat.cc
+++ b/src/tools/core/pair_stat/pair_stat.cc
@@ -87,7 +87,7 @@ static void finish_txt_files();
 
 static void clean_up();
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_pairs(const StringArray &);
 static void set_format(const StringArray &);
@@ -1503,7 +1503,7 @@ static void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage() {
+static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -1536,7 +1536,7 @@ static void usage() {
         << "\t\t\"-v level\" overrides the default level of logging ("
         << mlog.verbosity_level() << ") (optional).\n\n" << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/pair_stat/pair_stat.cc
+++ b/src/tools/core/pair_stat/pair_stat.cc
@@ -1503,7 +1503,7 @@ static void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/core/pcp_combine/pcp_combine.cc
+++ b/src/tools/core/pcp_combine/pcp_combine.cc
@@ -191,7 +191,7 @@ static void close_nc();
 static ConcatString parse_config_str(const char *);
 static bool is_timestring(const char *);
 
-[[noreturn]] static void usage();
+[[noreturn]] static void usage(int exit_code=1);
 static void set_sum(const StringArray &);
 static void set_add(const StringArray &);
 static void set_subtract(const StringArray &);
@@ -1652,7 +1652,7 @@ static bool is_timestring(const char * text) {
 
 ////////////////////////////////////////////////////////////////////////
 
-[[noreturn]] static void usage() {
+[[noreturn]] static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -1772,7 +1772,7 @@ static bool is_timestring(const char * text) {
 
         << "\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/pcp_combine/pcp_combine.cc
+++ b/src/tools/core/pcp_combine/pcp_combine.cc
@@ -191,7 +191,7 @@ static void close_nc();
 static ConcatString parse_config_str(const char *);
 static bool is_timestring(const char *);
 
-[[noreturn]] static void usage(int exit_code=1);
+static void usage(int exit_code=1);
 static void set_sum(const StringArray &);
 static void set_add(const StringArray &);
 static void set_subtract(const StringArray &);
@@ -1652,7 +1652,7 @@ static bool is_timestring(const char * text) {
 
 ////////////////////////////////////////////////////////////////////////
 
-[[noreturn]] static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/core/point_stat/point_stat.cc
+++ b/src/tools/core/point_stat/point_stat.cc
@@ -178,7 +178,7 @@ static void finish_txt_files();
 
 static void clean_up();
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_point_obs(const StringArray &);
 static void set_ncfile(const StringArray &);
 static void set_obs_valid_beg_time(const StringArray &);
@@ -2276,7 +2276,7 @@ static void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage() {
+static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -2327,7 +2327,7 @@ static void usage() {
         << "\t\t\"-v level\" overrides the default level of logging ("
         << mlog.verbosity_level() << ") (optional).\n\n" << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/point_stat/point_stat.cc
+++ b/src/tools/core/point_stat/point_stat.cc
@@ -2276,7 +2276,7 @@ static void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/core/series_analysis/series_analysis.cc
+++ b/src/tools/core/series_analysis/series_analysis.cc
@@ -166,7 +166,7 @@ static void set_pair_dims(vector<PairDataPoint> &, int, int);
 
 static void clean_up();
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_fcst_files(const StringArray &);
 static void set_obs_files(const StringArray &);
 static void set_both_files(const StringArray &);
@@ -2617,7 +2617,7 @@ static void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-__attribute__((noreturn)) static void usage() {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -2683,7 +2683,7 @@ __attribute__((noreturn)) static void usage() {
         << R"("-compress level" overrides the compression level of NetCDF variable ()"
         << conf_info.get_compression_level() << ") (optional).\n\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/stat_analysis/stat_analysis.cc
+++ b/src/tools/core/stat_analysis/stat_analysis.cc
@@ -746,7 +746,7 @@ void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/core/stat_analysis/stat_analysis.cc
+++ b/src/tools/core/stat_analysis/stat_analysis.cc
@@ -86,7 +86,7 @@ static const char * python_target_string = "python";
 
 static void parse_command_line(int &argc, char **argv);
 static void sanity_check();
-static void usage();
+static void usage(int exit_code=1);
 static void set_lookin_path(const StringArray &);
 static void set_out_filename(const StringArray &);
 static void set_tmp_dir(const StringArray &);
@@ -746,7 +746,7 @@ void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -787,7 +787,7 @@ void usage() {
 
         << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/core/wavelet_stat/wavelet_stat.cc
+++ b/src/tools/core/wavelet_stat/wavelet_stat.cc
@@ -2982,7 +2982,7 @@ static void render_tile(PSfile *p, const double *data, int n,
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/core/wavelet_stat/wavelet_stat.cc
+++ b/src/tools/core/wavelet_stat/wavelet_stat.cc
@@ -133,7 +133,7 @@ static void draw_tiles(PSfile *, const Box &, int, int, int);
 static void render_image(PSfile *, const DataPlane &, const Box &, int);
 static void render_tile(PSfile *, const double *, int, int, const Box &);
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_outdir(const StringArray &);
 static void set_compress(const StringArray &);
 
@@ -2982,7 +2982,7 @@ static void render_tile(PSfile *p, const double *data, int n,
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage() {
+static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -3017,7 +3017,7 @@ static void usage() {
         << "\t\t\"-compress level\" overrides the compression level of NetCDF variable ("
         << conf_info.get_compression_level() << ") (optional).\n\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/dev_utils/chk4copyright.cc
+++ b/src/tools/dev_utils/chk4copyright.cc
@@ -63,7 +63,7 @@ static bool output_info = true;
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_top_dir(const StringArray &);
 static void set_copyright_notice_filename(const StringArray &);
@@ -164,13 +164,13 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 {
    mlog << Error << "\nUsage: " << program_name << "\n"
         << "          -dir DirectoryPath\n"
         << "          [-notice CopyrightNoticeFilename ]\n"
         << "          [-quiet ]\n\n";
-   exit (1);
+   exit (exit_code);
 
 }
 

--- a/src/tools/dev_utils/chk4copyright.cc
+++ b/src/tools/dev_utils/chk4copyright.cc
@@ -164,7 +164,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 {
    mlog << Error << "\nUsage: " << program_name << "\n"
         << "          -dir DirectoryPath\n"

--- a/src/tools/dev_utils/gen_climo_bin.cc
+++ b/src/tools/dev_utils/gen_climo_bin.cc
@@ -441,7 +441,7 @@ void set_var_name  (const StringArray & a) { var_name   = a[0];       return; }
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/dev_utils/gen_climo_bin.cc
+++ b/src/tools/dev_utils/gen_climo_bin.cc
@@ -87,7 +87,7 @@ static void set_field_str(const StringArray & a);
 static void set_var_name(const StringArray & a);
 static void my_memcpy(void * to, unsigned char * & from, int n_bytes);
 
-static void usage();
+static void usage(int exit_code);
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -441,7 +441,7 @@ void set_var_name  (const StringArray & a) { var_name   = a[0];       return; }
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -471,7 +471,7 @@ void usage() {
         << "\tNOTE: Either \"-bin\" or \"-mean\", \"-stdev\", and \"-field\" must be specified.\n\n"
         << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/dev_utils/gen_climo_bin.cc
+++ b/src/tools/dev_utils/gen_climo_bin.cc
@@ -87,7 +87,7 @@ static void set_field_str(const StringArray & a);
 static void set_var_name(const StringArray & a);
 static void my_memcpy(void * to, unsigned char * & from, int n_bytes);
 
-static void usage(int exit_code);
+static void usage(int exit_code=1);
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/src/tools/dev_utils/nceptab_to_flat.cc
+++ b/src/tools/dev_utils/nceptab_to_flat.cc
@@ -55,7 +55,7 @@ static int table_number = 0;
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_table_number(const StringArray &);
 
@@ -113,13 +113,13 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
 cerr << "\n\n   usage: " << program_name << " nceptab_source_file.c [ more such files ...]\n\n";
 
-exit ( 1 );
+exit ( exit_code );
 
 }
 

--- a/src/tools/dev_utils/nceptab_to_flat.cc
+++ b/src/tools/dev_utils/nceptab_to_flat.cc
@@ -113,7 +113,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/dev_utils/shapefiles/make_mapfiles.cc
+++ b/src/tools/dev_utils/shapefiles/make_mapfiles.cc
@@ -84,7 +84,7 @@ static const char sq = '\'';   //  single quote
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_outdir         (const StringArray &);
 static void set_separate_files (const StringArray &);
@@ -196,7 +196,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
@@ -204,7 +204,7 @@ cerr << "\nusage: " << program_name << ' '
      << "[-outdir path] [-separate_files] "
      << "shp_file shx_file dbf_file country_field admin_field\n\n";
 
-exit ( 1 );
+exit ( exit_code );
 
 }
 

--- a/src/tools/dev_utils/shapefiles/make_mapfiles.cc
+++ b/src/tools/dev_utils/shapefiles/make_mapfiles.cc
@@ -196,7 +196,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/dev_utils/swinging_door.cc
+++ b/src/tools/dev_utils/swinging_door.cc
@@ -68,7 +68,7 @@ static string station_id_arg;
 static bool process_file();
 static bool run_algorithm(const vector< SDObservation > &obs,
                           vector< SDObservation > &compressed_obs);
-static void usage();
+static void usage(int exit_code=1);
 static bool write_observations(const vector< SDObservation > &observations,
                                const string &file_path);
 static bool write_ramps(const vector< SDObservation > &observations,
@@ -190,7 +190,7 @@ bool run_algorithm(const vector< SDObservation > &observations,
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage()
+void usage(int exit_code)
 {
   cout << "\nUsage: "
        << program_name << "\n"
@@ -217,7 +217,7 @@ void usage()
 
        << flush;
 
-  exit(1);
+  exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/dev_utils/swinging_door.cc
+++ b/src/tools/dev_utils/swinging_door.cc
@@ -190,7 +190,7 @@ bool run_algorithm(const vector< SDObservation > &observations,
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 {
   cout << "\nUsage: "
        << program_name << "\n"

--- a/src/tools/other/ascii2nc/ascii2nc.cc
+++ b/src/tools/other/ascii2nc/ascii2nc.cc
@@ -161,7 +161,7 @@ static FileHandler *create_file_handler(const ASCIIFormat,
 static FileHandler *determine_ascii_format(const ConcatString &,
                                            ConcatString &);
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_inputrx(const StringArray &);
 static void set_format(const StringArray &);
 static void set_config(const StringArray &);
@@ -182,7 +182,7 @@ int met_main(int argc, char *argv[]) {
    //
    // Check for zero arguments
    //
-   if(argc == 1) { usage(); return 0; }
+   if(argc == 1) usage();
 
    // Initialize time range
    valid_beg_ut = valid_end_ut = (unixtime) 0;
@@ -219,7 +219,7 @@ int met_main(int argc, char *argv[]) {
    // Check for error. There should be at least two arguments left:
    // the ascii input filenames and the netCDF output filename
    //
-   if(cline.n() < 2) { usage(); return 0; }
+   if(cline.n() < 2) usage();
 
    //
    // Store the input ASCII file names
@@ -619,7 +619,7 @@ static FileHandler *determine_ascii_format(const ConcatString &ascii_filename,
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage() {
+static void usage(int exit_code) {
 
    cout << "\nUsage: "
         << program_name << "\n"
@@ -721,6 +721,7 @@ static void usage() {
 
         << flush;
 
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/ascii2nc/ascii2nc.cc
+++ b/src/tools/other/ascii2nc/ascii2nc.cc
@@ -619,7 +619,7 @@ static FileHandler *determine_ascii_format(const ConcatString &ascii_filename,
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\nUsage: "
         << program_name << "\n"

--- a/src/tools/other/gen_ens_prod/gen_ens_prod.cc
+++ b/src/tools/other/gen_ens_prod/gen_ens_prod.cc
@@ -84,7 +84,7 @@ static void add_var_att_local(GenEnsProdVarInfo *, NcVar *, bool is_int,
                               const DataPlane &, const char *, const char *);
 
 static void clean_up();
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_ens_files  (const StringArray &);
 static void set_out_file   (const StringArray &);
@@ -1297,7 +1297,7 @@ static void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage() {
+static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -1331,7 +1331,7 @@ static void usage() {
         << "\t\t\"-v level\" overrides the default level of logging ("
         << mlog.verbosity_level() << ") (optional).\n\n";
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/gen_ens_prod/gen_ens_prod.cc
+++ b/src/tools/other/gen_ens_prod/gen_ens_prod.cc
@@ -1297,7 +1297,7 @@ static void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/other/gen_vx_mask/gen_vx_mask.cc
+++ b/src/tools/other/gen_vx_mask/gen_vx_mask.cc
@@ -1772,7 +1772,7 @@ const char * masktype_to_description(const MaskType t) {
 
 ////////////////////////////////////////////////////////////////////////
 
-__attribute__((noreturn)) static void usage() {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -1892,7 +1892,7 @@ __attribute__((noreturn)) static void usage() {
 
         << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/gen_vx_mask/gen_vx_mask.h
+++ b/src/tools/other/gen_vx_mask/gen_vx_mask.h
@@ -157,7 +157,7 @@ static void      apply_lat_lon_mask(DataPlane &dp);
 static DataPlane combine(const DataPlane &dp_data,
                     const DataPlane &dp_mask, SetLogic);
 static void      write_netcdf(const DataPlane &dp);
-static void      usage();
+static void      usage(int exit_code=1);
 static void      set_type(const StringArray &);
 static void      set_input_field(const StringArray &);
 static void      set_mask_field(const StringArray &);

--- a/src/tools/other/gis_utils/gis_dump_dbf.cc
+++ b/src/tools/other/gis_utils/gis_dump_dbf.cc
@@ -177,7 +177,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/other/gis_utils/gis_dump_dbf.cc
+++ b/src/tools/other/gis_utils/gis_dump_dbf.cc
@@ -43,7 +43,7 @@ static unsigned char buf[buf_size];
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -55,12 +55,21 @@ int met_main(int argc, char * argv [])
 
 program_name = get_short_name(argv[0]);
 
-if ( argc != 2 )  usage();
+CommandLine cline;
+
+cline.set(argc, argv);
+
+cline.set_usage(usage);
+
+cline.parse();
+
+if ( cline.n() != 1 )  usage();
+
+ConcatString input_filename = (string)cline[0];
 
 int fd = -1;
 int j;
 size_t n_read, bytes;
-ConcatString input_filename = (string)argv[1];
 DbfHeader h;
 DbfSubRecord sr;
 
@@ -168,14 +177,14 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
 mlog << Error
      << "\n\n  usage:  " << program_name << " dbf_filename\n\n";
 
-exit ( 1 );
+exit ( exit_code );
 
 }
 

--- a/src/tools/other/gis_utils/gis_dump_shp.cc
+++ b/src/tools/other/gis_utils/gis_dump_shp.cc
@@ -164,7 +164,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/other/gis_utils/gis_dump_shp.cc
+++ b/src/tools/other/gis_utils/gis_dump_shp.cc
@@ -61,7 +61,7 @@ static CommandLine cline;
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_header_only(const StringArray &);
 
@@ -164,14 +164,14 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
 mlog << Error 
      << "\n\n  usage:  " << program_name << " [ -h ] shp_filename\n\n";
 
-exit ( 1 );
+exit ( exit_code );
 
 }
 

--- a/src/tools/other/gis_utils/gis_dump_shx.cc
+++ b/src/tools/other/gis_utils/gis_dump_shx.cc
@@ -151,7 +151,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/other/gis_utils/gis_dump_shx.cc
+++ b/src/tools/other/gis_utils/gis_dump_shx.cc
@@ -43,7 +43,7 @@ static unsigned char buf[buf_size];
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -55,12 +55,21 @@ int met_main(int argc, char * argv [])
 
 program_name = get_short_name(argv[0]);
 
-if ( argc != 2 )  usage();
+CommandLine cline;
+
+cline.set(argc, argv);
+
+cline.set_usage(usage);
+
+cline.parse();
+
+if ( cline.n() != 1 )  usage();
+
+ConcatString input_filename = (string)cline[0];
 
 int fd = -1;
 int n_read, bytes;
 int count;
-ConcatString input_filename = (string)argv[1];
 ShxFileHeader h;
 ShxRecord r;
 
@@ -142,14 +151,14 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
 mlog << Error
      << "\n\n  usage:  " << program_name << " shx_filename\n\n";
 
-exit ( 1 );
+exit ( exit_code );
 
 }
 

--- a/src/tools/other/grid_diag/grid_diag.cc
+++ b/src/tools/other/grid_diag/grid_diag.cc
@@ -821,7 +821,7 @@ void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/other/grid_diag/grid_diag.cc
+++ b/src/tools/other/grid_diag/grid_diag.cc
@@ -70,7 +70,7 @@ static void clean_up();
 
 static Met2dDataFile *get_mtddf(const StringArray &, const int);
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_data_files(const StringArray &);
 static void set_out_file(const StringArray &);
 static void set_config_file(const StringArray &);
@@ -821,7 +821,7 @@ void clean_up() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -858,7 +858,7 @@ void usage() {
 
         << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/gsi_tools/gsid2mpr.cc
+++ b/src/tools/other/gsi_tools/gsid2mpr.cc
@@ -57,7 +57,7 @@ static void write_mpr_row_rad (AsciiTable &at, int row, const RadData  &d);
 
 static bool is_dup(const char *);
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_swap(const StringArray &);
 static void set_no_check_dup(const StringArray &);
 static void set_channel(const StringArray &);
@@ -523,7 +523,7 @@ bool is_dup(const char *key) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -559,7 +559,7 @@ void usage() {
         << mlog.verbosity_level() << ") (optional).\n\n"
         << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/gsi_tools/gsid2mpr.cc
+++ b/src/tools/other/gsi_tools/gsid2mpr.cc
@@ -523,7 +523,7 @@ bool is_dup(const char *key) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/other/gsi_tools/gsidens2orank.cc
+++ b/src/tools/other/gsi_tools/gsidens2orank.cc
@@ -834,7 +834,7 @@ void check_dbl(double d1, double d2, const char *col, const ConcatString &key) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/other/gsi_tools/gsidens2orank.cc
+++ b/src/tools/other/gsi_tools/gsidens2orank.cc
@@ -66,7 +66,7 @@ static bool has_key(const ConcatString &key, int & index);
 static void check_int(int i1, int i2, const char *col, const ConcatString &key);
 static void check_dbl(double d1, double d2, const char *col, const ConcatString &key);
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_out(const StringArray &);
 static void set_ens_mean(const StringArray &);
 static void set_swap(const StringArray &);
@@ -834,7 +834,7 @@ void check_dbl(double d1, double d2, const char *col, const ConcatString &key) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -876,7 +876,7 @@ void usage() {
         << mlog.verbosity_level() << ") (optional).\n\n"
         << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/ioda2nc/ioda2nc.cc
+++ b/src/tools/other/ioda2nc/ioda2nc.cc
@@ -146,7 +146,7 @@ static bool keep_message_type(const char *);
 static bool keep_station_id(const char *);
 static bool keep_valid_time(const unixtime, const unixtime, const unixtime);
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_compress(const StringArray &);
 static void set_config(const StringArray &);
 static void set_ioda_files(const StringArray &);
@@ -1053,7 +1053,7 @@ static bool get_obs_data_double(NcFile *f_in, const ConcatString &var_name,
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage() {
+static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -1108,7 +1108,7 @@ static void usage() {
 
         << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/ioda2nc/ioda2nc.cc
+++ b/src/tools/other/ioda2nc/ioda2nc.cc
@@ -1053,7 +1053,7 @@ static bool get_obs_data_double(NcFile *f_in, const ConcatString &var_name,
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/other/lidar2nc/lidar2nc.cc
+++ b/src/tools/other/lidar2nc/lidar2nc.cc
@@ -161,7 +161,7 @@ const string get_tool_name() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
 cout << "\nUsage: "
      << program_name << "\n"

--- a/src/tools/other/lidar2nc/lidar2nc.cc
+++ b/src/tools/other/lidar2nc/lidar2nc.cc
@@ -90,7 +90,7 @@ static int compress_level = -1;
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_outfile   (const StringArray &);
 static void set_compress  (const StringArray &);
@@ -161,7 +161,7 @@ const string get_tool_name() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
 cout << "\nUsage: "
      << program_name << "\n"
@@ -187,7 +187,7 @@ cout << "\nUsage: "
 
      << flush;
 
-exit (1);
+exit (exit_code);
 
 }
 

--- a/src/tools/other/madis2nc/madis2nc.cc
+++ b/src/tools/other/madis2nc/madis2nc.cc
@@ -124,7 +124,7 @@ static void process_madis_maritime(NcFile *&f_in);
 static void process_madis_mesonet(NcFile *&f_in);
 static void process_madis_acarsProfiles(NcFile *&f_in);
 
-static void usage();
+static void usage(int exit_code=1);
 static void set_type(const StringArray &);
 static void set_qc_dd(const StringArray &);
 static void set_lvl_dim(const StringArray &);
@@ -3554,7 +3554,7 @@ void process_madis_acarsProfiles(NcFile *&f_in) {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage() {
+static void usage(int exit_code) {
 
    cout << "\nUsage: "
         << program_name << "\n"
@@ -3621,7 +3621,7 @@ static void usage() {
 
         << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/madis2nc/madis2nc.cc
+++ b/src/tools/other/madis2nc/madis2nc.cc
@@ -3554,7 +3554,7 @@ void process_madis_acarsProfiles(NcFile *&f_in) {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\nUsage: "
         << program_name << "\n"

--- a/src/tools/other/mode_graphics/plot_mode_field.cc
+++ b/src/tools/other/mode_graphics/plot_mode_field.cc
@@ -157,7 +157,7 @@ static ConcatString config_filename;   //  no default ... must be set on command
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_config    (const StringArray &);
 
@@ -597,7 +597,7 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage()
+static void usage(int exit_code)
 
 {
 
@@ -630,7 +630,7 @@ cout << "\n*** Model Evaluation Tools (MET" << met_version
      << "\t\t\"-v level\" overrides the default level of logging ("
      << mlog.verbosity_level() << ") (optional).\n\n" << flush;
 
- exit (1);
+ exit (exit_code);
 }
 
 

--- a/src/tools/other/mode_graphics/plot_mode_field.cc
+++ b/src/tools/other/mode_graphics/plot_mode_field.cc
@@ -597,7 +597,7 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/other/mode_time_domain/mtd.cc
+++ b/src/tools/other/mode_time_domain/mtd.cc
@@ -83,7 +83,7 @@ static ConcatString local_config_filename;
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_fcst      (const StringArray &);
 static void set_obs       (const StringArray &);
@@ -891,7 +891,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
@@ -939,7 +939,7 @@ cout << "\n*** Model Evaluation Tools (MET" << met_version
      << "\t\t\"-v level\" overrides the default level of logging ("
      << mlog.verbosity_level() << ") (optional).\n\n" << flush;
 
-exit ( 1 );
+exit ( exit_code );
 
 }
 

--- a/src/tools/other/mode_time_domain/mtd.cc
+++ b/src/tools/other/mode_time_domain/mtd.cc
@@ -891,7 +891,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/other/modis_regrid/modis_regrid.cc
+++ b/src/tools/other/modis_regrid/modis_regrid.cc
@@ -73,7 +73,7 @@ static void set_offset    (const StringArray &);
 static void set_fillvalue (const StringArray &);
 static void set_compress  (const StringArray &);
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void get_grid();
 
@@ -223,7 +223,7 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
@@ -255,7 +255,7 @@ cout << "\n"
 
      << "\n";
 
-exit ( 1 );
+exit ( exit_code );
 
 }
 

--- a/src/tools/other/modis_regrid/modis_regrid.cc
+++ b/src/tools/other/modis_regrid/modis_regrid.cc
@@ -223,7 +223,7 @@ return;
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -428,7 +428,7 @@ static void   merge_records(float *first_pqtzuv, map<float, float*> pqtzuv_map_p
                             map<float, float*> pqtzuv_map_aux,
                             map<float, float*> &pqtzuv_map_merged);
 
-static void   usage();
+static void   usage(int exit_code=1);
 static void   set_pbfile(const StringArray &);
 static void   set_valid_beg_time(const StringArray &);
 static void   set_valid_end_time(const StringArray &);
@@ -3574,7 +3574,7 @@ void log_pbl_input(int pbl_level, const char *method_name) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -3639,7 +3639,7 @@ void usage() {
 
         << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/pb2nc/pb2nc.cc
+++ b/src/tools/other/pb2nc/pb2nc.cc
@@ -3574,7 +3574,7 @@ void log_pbl_input(int pbl_level, const char *method_name) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/other/plot_data_plane/plot_data_plane.cc
+++ b/src/tools/other/plot_data_plane/plot_data_plane.cc
@@ -287,7 +287,7 @@ void process_command_line(int argc, char **argv) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/other/plot_data_plane/plot_data_plane.cc
+++ b/src/tools/other/plot_data_plane/plot_data_plane.cc
@@ -81,7 +81,7 @@ static double PlotRangeMax = 0.0;
 ////////////////////////////////////////////////////////////////////////
 
 static void process_command_line(int, char **);
-static void usage();
+static void usage(int exit_code=1);
 static void set_colortable_name(const StringArray &);
 static void set_plot_range(const StringArray &);
 static void set_title_string(const StringArray &);
@@ -287,7 +287,7 @@ void process_command_line(int argc, char **argv) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -328,7 +328,7 @@ void usage() {
         << "\t\t\"-v level\" overrides the default level of logging ("
         << mlog.verbosity_level() << ") (optional).\n\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 
 }
 

--- a/src/tools/other/plot_point_obs/plot_point_obs.cc
+++ b/src/tools/other/plot_point_obs/plot_point_obs.cc
@@ -57,7 +57,7 @@ using namespace std;
 
 ////////////////////////////////////////////////////////////////////////
 
-[[noreturn]] static void usage();
+[[noreturn]] static void usage(int exit_code=1);
 static void process_point_obs(const char *);
 static void create_plot();
 static void add_colorbar(PSfile &, const Box &, const ColorTable &);
@@ -613,7 +613,7 @@ static void add_colorbar(PSfile &plot, const Box &box, const ColorTable &ct) {
 
 ////////////////////////////////////////////////////////////////////////
 
-[[noreturn]] static void usage() {
+[[noreturn]] static void usage(int exit_code) {
 
    cout << "\nUsage: " << program_name << "\n"
         << "\tnc_file\n"
@@ -656,7 +656,7 @@ static void add_colorbar(PSfile &plot, const Box &box, const ColorTable &ct) {
         << mlog.verbosity_level() << ") (optional).\n\n"
         << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/plot_point_obs/plot_point_obs.cc
+++ b/src/tools/other/plot_point_obs/plot_point_obs.cc
@@ -57,7 +57,7 @@ using namespace std;
 
 ////////////////////////////////////////////////////////////////////////
 
-[[noreturn]] static void usage(int exit_code=1);
+static void usage(int exit_code=1);
 static void process_point_obs(const char *);
 static void create_plot();
 static void add_colorbar(PSfile &, const Box &, const ColorTable &);
@@ -613,7 +613,7 @@ static void add_colorbar(PSfile &plot, const Box &box, const ColorTable &ct) {
 
 ////////////////////////////////////////////////////////////////////////
 
-[[noreturn]] static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\nUsage: " << program_name << "\n"
         << "\tnc_file\n"

--- a/src/tools/other/point2grid/point2grid.cc
+++ b/src/tools/other/point2grid/point2grid.cc
@@ -162,7 +162,7 @@ static void write_nc(const DataPlane &dp, const Grid &grid,
 static void write_nc_int(const DataPlane &dp, const Grid &grid,
                          const VarInfo *vinfo, const char *vname);
 static void close_nc();
-static void usage();
+static void usage(int exit_code=1);
 static void set_field(const StringArray &);
 static void set_method(const StringArray &);
 static void set_prob_cat_thresh(const StringArray &);
@@ -2927,7 +2927,7 @@ static bool has_lat_lon_vars(const NcFile *nc) {
 
 ////////////////////////////////////////////////////////////////////////
 
-__attribute__((noreturn)) static void usage() {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -3004,7 +3004,7 @@ __attribute__((noreturn)) static void usage() {
 
         << "\t\t\"-compress level\" overrides the compression level of NetCDF variable (optional).\n\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/regrid_data_plane/regrid_data_plane.cc
+++ b/src/tools/other/regrid_data_plane/regrid_data_plane.cc
@@ -431,7 +431,7 @@ void close_nc() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    GridTemplateFactory gtf;
    cout << "\n*** Model Evaluation Tools (MET" << met_version

--- a/src/tools/other/regrid_data_plane/regrid_data_plane.cc
+++ b/src/tools/other/regrid_data_plane/regrid_data_plane.cc
@@ -92,7 +92,7 @@ static void open_nc(const Grid &grid, const ConcatString run_cs);
 static void write_nc(const DataPlane &dp, const Grid &grid,
                      const VarInfo *vinfo, const char *vname);
 static void close_nc();
-static void usage();
+static void usage(int exit_code=1);
 static void set_field(const StringArray &);
 static void set_method(const StringArray &);
 static void set_shape(const StringArray &);
@@ -431,7 +431,7 @@ void close_nc() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    GridTemplateFactory gtf;
    cout << "\n*** Model Evaluation Tools (MET" << met_version
@@ -515,7 +515,7 @@ void usage() {
         << "\t\t\"-compress level\" overrides the compression level of "
         << "NetCDF variable (optional).\n\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/shift_data_plane/shift_data_plane.cc
+++ b/src/tools/other/shift_data_plane/shift_data_plane.cc
@@ -366,7 +366,7 @@ void write_netcdf(const DataPlane &dp, const Grid &grid,
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/other/shift_data_plane/shift_data_plane.cc
+++ b/src/tools/other/shift_data_plane/shift_data_plane.cc
@@ -87,7 +87,7 @@ static void process_command_line(int, char **);
 static void process_data_file();
 static void write_netcdf(const DataPlane &dp, const Grid &grid,
                          const VarInfo *vinfo, const GrdFileType& ftype);
-static void usage();
+static void usage(int exit_code=1);
 static void set_from(const StringArray &);
 static void set_to(const StringArray &);
 static void set_method(const StringArray &);
@@ -366,7 +366,7 @@ void write_netcdf(const DataPlane &dp, const Grid &grid,
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -418,7 +418,7 @@ void usage() {
 
         << "\t\t\"-compress level\" overrides the compression level of NetCDF variable (optional).\n\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/other/wwmca_tool/wwmca_plot.cc
+++ b/src/tools/other/wwmca_tool/wwmca_plot.cc
@@ -178,7 +178,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/other/wwmca_tool/wwmca_plot.cc
+++ b/src/tools/other/wwmca_tool/wwmca_plot.cc
@@ -90,7 +90,7 @@ static double scale;
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_outdir(const StringArray &);
 
@@ -178,7 +178,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
@@ -199,7 +199,7 @@ cout << "\nUsage: " << program_name << "\n"
      << "\t\t\"wwmca_cloud_pct_file_list\" is a list of one or "
      << "more wwmca cloud percent files to plot.\n\n";
 
-exit ( 1 );
+exit ( exit_code );
 
 }
 

--- a/src/tools/other/wwmca_tool/wwmca_regrid.cc
+++ b/src/tools/other/wwmca_tool/wwmca_regrid.cc
@@ -66,7 +66,7 @@ static ConcatString config_filename;
 ////////////////////////////////////////////////////////////////////////
 
 
-static void usage();
+static void usage(int exit_code=1);
 
 static void set_nh_filename (const StringArray &);
 static void set_sh_filename (const StringArray &);
@@ -181,7 +181,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage()
+void usage(int exit_code)
 
 {
 
@@ -210,7 +210,7 @@ cout << "\nUsage: " << program_name << "\n"
      << "\t\t\"-compress level\" overrides the compression level of NetCDF variable (optional).\n\n";
 
 
-exit ( 1 );
+exit ( exit_code );
 
 }
 

--- a/src/tools/other/wwmca_tool/wwmca_regrid.cc
+++ b/src/tools/other/wwmca_tool/wwmca_regrid.cc
@@ -181,7 +181,7 @@ const string get_tool_name() {
 ////////////////////////////////////////////////////////////////////////
 
 
-void usage(int exit_code)
+__attribute__((noreturn)) static void usage(int exit_code)
 
 {
 

--- a/src/tools/tc_utils/rmw_analysis/rmw_analysis.cc
+++ b/src/tools/tc_utils/rmw_analysis/rmw_analysis.cc
@@ -76,7 +76,7 @@ const string get_tool_name() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
        << ") ***\n\n"

--- a/src/tools/tc_utils/rmw_analysis/rmw_analysis.cc
+++ b/src/tools/tc_utils/rmw_analysis/rmw_analysis.cc
@@ -32,7 +32,7 @@ using namespace netCDF;
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage();
+static void usage(int exit_code=1);
 static void process_command_line(int, char**);
 static void set_data_files(const StringArray&);
 static void set_config(const StringArray&);
@@ -76,7 +76,7 @@ const string get_tool_name() {
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage() {
+static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
        << ") ***\n\n"
@@ -103,7 +103,7 @@ static void usage() {
        << "\t\t\"-v level\" overrides the default level of logging ("
        << mlog.verbosity_level() << ") (optional).\n\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/tc_utils/tc_diag/tc_diag.cc
+++ b/src/tools/tc_utils/tc_diag/tc_diag.cc
@@ -57,7 +57,7 @@ using namespace netCDF;
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage();
+static void usage(int exit_code=1);
 static void process_command_line(int, char**);
 static void get_file_type();
 
@@ -142,7 +142,7 @@ const string get_tool_name() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -176,7 +176,7 @@ void usage() {
         << "\t\t\"-v level\" overrides the default level of logging ("
         << mlog.verbosity_level() << ") (optional).\n\n" << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/tc_utils/tc_diag/tc_diag.cc
+++ b/src/tools/tc_utils/tc_diag/tc_diag.cc
@@ -142,7 +142,7 @@ const string get_tool_name() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/tc_utils/tc_dland/tc_dland.cc
+++ b/src/tools/tc_utils/tc_dland/tc_dland.cc
@@ -95,7 +95,7 @@ static int compress_level = -1;
 static void process_command_line(int, char **);
 static void process_land_data();
 static void process_distances();
-static void usage();
+static void usage(int exit_code=1);
 static void set_grid(const StringArray &);
 static void set_noll(const StringArray &);
 static void set_land(const StringArray &);
@@ -307,7 +307,7 @@ void process_distances() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
              << ") ***\n\n"
@@ -345,7 +345,7 @@ void usage() {
 
         << flush;
 
-   exit (1);
+   exit (exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/tc_utils/tc_dland/tc_dland.cc
+++ b/src/tools/tc_utils/tc_dland/tc_dland.cc
@@ -307,7 +307,7 @@ void process_distances() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
              << ") ***\n\n"

--- a/src/tools/tc_utils/tc_gen/tc_gen.cc
+++ b/src/tools/tc_utils/tc_gen/tc_gen.cc
@@ -148,7 +148,7 @@ static void   finish_txt_files     ();
 
 static ConcatString string_to_basin_abbr(ConcatString);
 
-static void   usage                ();
+static void   usage                (int exit_code=1);
 static void   set_source           (const StringArray &, const char *,
                                     StringArray &, StringArray &);
 static void   set_genesis          (const StringArray &);
@@ -2570,7 +2570,7 @@ ConcatString string_to_basin_abbr(ConcatString cs) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -2619,7 +2619,7 @@ void usage() {
         << "\t\t\"-v level\" overrides the default level of logging ("
         << mlog.verbosity_level() << ") (optional).\n\n";
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/tc_utils/tc_gen/tc_gen.cc
+++ b/src/tools/tc_utils/tc_gen/tc_gen.cc
@@ -2570,7 +2570,7 @@ ConcatString string_to_basin_abbr(ConcatString cs) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/tc_utils/tc_pairs/tc_pairs.cc
+++ b/src/tools/tc_utils/tc_pairs/tc_pairs.cc
@@ -2227,7 +2227,7 @@ void setup_table(AsciiTable &at) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"

--- a/src/tools/tc_utils/tc_pairs/tc_pairs.cc
+++ b/src/tools/tc_utils/tc_pairs/tc_pairs.cc
@@ -156,7 +156,7 @@ static void   process_watch_warn   (TrackPairInfoArray &);
 static void   write_tracks         (const TrackPairInfoArray &);
 static void   write_prob_rirw      (const ProbRIRWPairInfoArray &);
 static void   setup_table          (AsciiTable &);
-static void   usage                ();
+static void   usage                (int exit_code=1);
 static void   set_adeck            (const StringArray &);
 static void   set_edeck            (const StringArray &);
 static void   set_bdeck            (const StringArray &);
@@ -2227,7 +2227,7 @@ void setup_table(AsciiTable &at) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
         << ") ***\n\n"
@@ -2279,7 +2279,7 @@ void usage() {
         << "may include \"suffix=string\" to modify the model names "
         << "from that path.\n\n";
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/tc_utils/tc_rmw/tc_rmw.cc
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw.cc
@@ -58,7 +58,7 @@ using namespace netCDF;
 
 ////////////////////////////////////////////////////////////////////////
 
-static void usage();
+static void usage(int exit_code=1);
 static void process_command_line(int, char**);
 
 static GrdFileType get_file_type(const StringArray &, const GrdFileType);
@@ -111,7 +111,7 @@ const string get_tool_name() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
     cout << "\n*** Model Evaluation Tools (MET" << met_version
          << ") ***\n\n"
@@ -142,7 +142,7 @@ void usage() {
          << "\t\t\"-v level\" overrides the default level of logging ("
          << mlog.verbosity_level() << ") (optional).\n\n" << flush;
 
-    exit(1);
+    exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/tc_utils/tc_rmw/tc_rmw.cc
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw.cc
@@ -111,7 +111,7 @@ const string get_tool_name() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
     cout << "\n*** Model Evaluation Tools (MET" << met_version
          << ") ***\n\n"

--- a/src/tools/tc_utils/tc_stat/tc_stat.cc
+++ b/src/tools/tc_utils/tc_stat/tc_stat.cc
@@ -56,7 +56,7 @@ using namespace std;
 static void   process_command_line(int, char **);
 static void   process_search_dirs ();
 static void   process_jobs        ();
-static void   usage               ();
+static void   usage               (int exit_code=1);
 static void   set_lookin          (const StringArray &);
 static void   set_out             (const StringArray &);
 static void   set_config          (const StringArray &);
@@ -315,7 +315,7 @@ void close_out_file() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage() {
+void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
              << ") ***\n\n"
@@ -352,7 +352,7 @@ void usage() {
 
         << flush;
 
-   exit(1);
+   exit(exit_code);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/tools/tc_utils/tc_stat/tc_stat.cc
+++ b/src/tools/tc_utils/tc_stat/tc_stat.cc
@@ -315,7 +315,7 @@ void close_out_file() {
 
 ////////////////////////////////////////////////////////////////////////
 
-void usage(int exit_code) {
+__attribute__((noreturn)) static void usage(int exit_code) {
 
    cout << "\n*** Model Evaluation Tools (MET" << met_version
              << ") ***\n\n"


### PR DESCRIPTION
> [!Note]
> These changes also need to be committed to the `develop` branch.

## Expected Differences ##

The changes for this PR propose the following changes:
- Update the `CommandLine` class to require that usage statements has a single integer argument to specify the exit code.
- When `-help`, `--help`, `-version`, or `--version` appears on the command line, print the usage statement or version information and exit with a "good" return value of 0.
- Update the usage statements throughout the MET application code to specify an exit code, with a default value of 1.
- Fix more complex usage statement logic for MODE to work as expected.
- Add the usage of `CommandLine` to a handful of applications where it was missing.
- Add 2 new ascii2nc unit tests to demonstrate this updated functionality.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Ran the following commands on `main_12.2` and my feature branch to check the return status of each executable when run with (1) no args, (2) the `-help` option, and (3) the `-version` option. (1) should return a bad exit code of 1 while (2) and (3) should return good exit codes of 0. So we want `1 0 0` after each executable name.
```
for exe in `ls -1 bin/*`; do
  $exe >& /dev/null; status_noargs=$?;
  $exe --help >& /dev/null; status_help=$?;
  $exe --version >& /dev/null; status_version=$?;
  echo $exe $status_noargs $status_help $status_version;
done
```
Here's the results for `seneca:/d1/projects/MET/MET_regression/main_v12.2/NB20251022/MET-main_v12.2`:
```
bin/ascii2nc 0 1 1
bin/chk4copyright 1 1 1
bin/ensemble_stat 1 1 1
bin/enum_to_string 1 1 1
bin/gen_climo_bin 1 1 1
bin/gen_ens_prod 1 1 1
bin/gen_vx_mask 1 1 1
bin/gis_dump_dbf 1 1 1
bin/gis_dump_shp 1 1 1
bin/gis_dump_shx 1 1 1
bin/gribtab_dat_to_flat 1 1 1
bin/grid_diag 1 1 1
bin/grid_stat 1 1 1
bin/gsid2mpr 1 1 1
bin/gsidens2orank 1 1 1
bin/insitu_nc_to_ascii 1 1 1
bin/ioda2nc 1 1 1
bin/lidar2nc 1 1 1
bin/madis2nc 1 1 1
bin/make_mapfiles 1 1 1
bin/mode 1 1 1
bin/mode_analysis 1 1 1
bin/modis_regrid 1 1 1
bin/mtd 1 1 1
bin/nceptab_to_flat 1 1 1
bin/pair_stat 1 1 1
bin/pb2nc 1 1 1
bin/pbtime 1 1 1
bin/pcp_combine 1 1 1
bin/plot_data_plane 1 1 1
bin/plot_mode_field 1 1 1
bin/plot_point_obs 1 1 1
bin/point2grid 1 1 1
bin/point_stat 1 1 1
bin/reformat_county_data 1 1 1
bin/reformat_map_data 1 1 1
bin/regrid_data_plane 1 1 1
bin/rmw_analysis 1 1 1
bin/series_analysis 1 1 1
bin/shift_data_plane 1 1 1
bin/stat_analysis 1 1 1
bin/swinging_door 1 1 1
bin/tc_diag 1 1 1
bin/tc_dland 1 1 1
bin/tc_gen 1 1 1
bin/tc_pairs 1 1 1
bin/tc_rmw 1 1 1
bin/tc_stat 1 1 1
bin/wavelet_stat 1 1 1
bin/wwmca_plot 1 1 1
bin/wwmca_regrid 1 1 1
```
And here's the results for
```
bin/ascii2nc 1 0 0
bin/chk4copyright 1 0 0
bin/ensemble_stat 1 0 0
bin/enum_to_string 1 1 1
bin/gen_climo_bin 1 0 0
bin/gen_ens_prod 1 0 0
bin/gen_vx_mask 1 0 0
bin/gis_dump_dbf 1 0 0
bin/gis_dump_shp 1 0 0
bin/gis_dump_shx 1 0 0
bin/gribtab_dat_to_flat 1 1 1
bin/grid_diag 1 0 0
bin/grid_stat 1 0 0
bin/gsid2mpr 1 0 0
bin/gsidens2orank 1 0 0
bin/insitu_nc_to_ascii 1 1 1
bin/ioda2nc 1 0 0
bin/lidar2nc 1 0 0
bin/madis2nc 1 0 0
bin/make_mapfiles 1 0 0
bin/mode 1 0 0
bin/mode_analysis 1 0 0
bin/modis_regrid 1 0 0
bin/mtd 1 0 0
bin/nceptab_to_flat 1 0 0
bin/pair_stat 1 0 0
bin/pb2nc 1 0 0
bin/pbtime 1 1 1
bin/pcp_combine 1 0 0
bin/plot_data_plane 1 0 0
bin/plot_mode_field 1 0 0
bin/plot_point_obs 1 0 0
bin/point2grid 1 0 0
bin/point_stat 1 0 0
bin/reformat_county_data 1 1 1
bin/reformat_map_data 1 1 1
bin/regrid_data_plane 1 0 0
bin/rmw_analysis 1 0 0
bin/series_analysis 1 0 0
bin/shift_data_plane 1 0 0
bin/stat_analysis 1 0 0
bin/swinging_door 1 0 0
bin/tc_diag 1 0 0
bin/tc_dland 1 0 0
bin/tc_gen 1 0 0
bin/tc_pairs 1 0 0
bin/tc_rmw 1 0 0
bin/tc_stat 1 0 0
bin/wavelet_stat 1 0 0
bin/wwmca_plot 1 0 0
bin/wwmca_regrid 1 0 0
```
> [!IMPORTANT]
> Note that the ones that still report `1 1 1` are development utilities in [src/tools/dev_utils](https://github.com/dtcenter/MET/tree/main_v12.2/src/tools/dev_utils) that do NOT currently use the `CommandLine` class to parse command line options and arguments. **Do these also need to be updated?** Which executables will Conda check to validate successful linking?

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Review code changes.
Test in `seneca:/d1/projects/MET/MET_pull_requests/met-12.2.0/rc2/MET-feature_3278_main_v12.2_exit_codes` as you see fit.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**
Added a note in the overview chapter about return status.

- [x] Do these changes include sufficient testing updates? **[Yes]**
Added 2 ascii2nc unit tests to demonstrate the different exit codes.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:
Some existing maintainability issues will be flagged as being in `New Code`, but overall number should be reduced due to consistent use of `__attribute__((noreturn))` and `static`.

14641 is reduced to 14583.

- [x] Please complete this pull request review by **[Thurs 10/23/25]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **METplus-X.Y Support** project for bugfix releases or **MET-X.Y Development** project for the next coordinated release
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [x] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [x] Close the linked issue and delete your feature or bugfix branch from GitHub.
