### PR TITLE
Feature #3270 main_v12.2 message_type_group_map

### DIFF
--- a/data/config/EnsembleStatConfig_default
+++ b/data/config/EnsembleStatConfig_default
@@ -117,7 +117,11 @@ message_type_group_map = [
    { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET";               },
    { key = "ANYAIR";  val = "AIRCAR,AIRCFT";                      },
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
-   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      }
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/data/config/PointStatConfig_default
+++ b/data/config/PointStatConfig_default
@@ -112,7 +112,9 @@ message_type_group_map = [
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
    { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
    { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
-   { key = "WATERSF"; val = "SFCSHP";                             }
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/docs/Users_Guide/config_options.rst
+++ b/docs/Users_Guide/config_options.rst
@@ -667,11 +667,27 @@ message_type_group_map
 The "message_type_group_map" entry is an array of dictionaries, each
 containing a "key" string and "val" string. This defines a mapping of
 message type group names to a comma-separated list of values. This map is
-defined in the config files for PB2NC, Point-Stat, or Ensemble-Stat. Modify
-this map to define sets of message types that should be processed together as
-a group. The "SURFACE" entry defines message types for which surface verification
-logic should be applied. If not defined, the default values listed below are
-used.
+defined in the config files for PB2NC, IODA2NC, Point-Stat, and Ensemble-Stat.
+Modify this map to define sets of message types that should be processed
+together as a group.
+
+Beyond defining groups of message types, the following entries have special meaning:
+
+  * The "SURFACE" entry defines message types for which surface verification
+    logic should be applied.
+
+  * The "LANDSF" and "WATERSF" entries differentiate between point observations
+    over land and water, as described in "land_mask" below.
+
+  * The "LAPSERT" entry defines the message types for which surface temperature
+    lapse rate correction logic should be applied, as described in
+    "lapse_rate_correction" below.
+
+  * The "MSLAGL" entry defines the message types for which MSL/AGL height
+    conversion logic should be applied, as described in "msl_agl_conversion"
+    below.
+
+If not defined, the default values listed below are used.
 
 .. code-block:: none
 
@@ -679,7 +695,11 @@ used.
      { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET";               },
      { key = "ANYAIR";  val = "AIRCAR,AIRCFT";                      },
      { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
-     { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      }
+     { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+     { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
+     { key = "WATERSF"; val = "SFCSHP";                             },
+     { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+     { key = "MSLAGL";  val = "";                                   }
   ];
 
 obtype_as_group_val_flag
@@ -2258,17 +2278,31 @@ land_mask
 
 The "land_mask" dictionary defines the land/sea mask field used when
 verifying at the surface. The "flag" entry enables/disables this logic.
-When enabled, the "message_type_group_map" dictionary must contain entries
-for "LANDSF" and "WATERSF". For point observations whose message type
-appears in the "LANDSF" entry, only use forecast grid points where land =
-TRUE. For point observations whose message type appears in the "WATERSF"
-entry, only use forecast grid points where land = FALSE. If the "file_name"
-entry is left empty, the land/sea is assumed to exist in the input forecast
-file. Otherwise, the specified file(s) are searched for the data specified
-in the "field" entry. The "regrid" settings specify how this field should be
-regridded to the verification domain. Lastly, the "thresh" entry is the
-threshold which defines land (threshold is true) and water (threshold is false).
+If the "file_name" entry is empty, the land/sea mask field is assumed
+to exist in the input forecast file. Otherwise, the specified file(s)
+are searched for the data specified in the "field" entry.
+The "regrid" settings specify how this field should be regridded to the
+verification domain. Lastly, the "thresh" entry is the threshold which
+defines land (threshold is true) and water (threshold is false).
 
+The "message_type_group_map" dictionary entries for "LANDSF" and "WATERSF" specify
+comma-separated lists of message types whose observations exist on land or water,
+respectively. For point observations whose message type appears in the "LANDSF"
+entry, only interpolate using forecast grid points where land = TRUE. For point
+observations whose message type appears in the "WATERSF" entry, only interpolate
+using forecast grids points where land = FALSE. By default, "ADPSFC" and "MSONET"
+message types exist over land while the "SFCSHP" message type exists over water.
+
+.. code-block:: none
+
+  message_type_group_map = [
+    ...
+    { key = "LANDSF";  val = "ADPSFC,MSONET"; },
+    { key = "WATERSF"; val = "SFCSHP";        },
+    ...
+  ];
+
+The "topo_mask.flag", "topo_mask.use_obs_thresh", and "topo_mask.interp_fcst_thresh"
 The "land_mask.flag" entry may be set separately in each "obs.field" entry.
 
 .. code-block:: none
@@ -2286,11 +2320,9 @@ topo_mask
 
 The "topo_mask" dictionary defines the model topography field used when
 verifying at the surface. The flag entry enables/disables this logic.
-When enabled, the "message_type_group_map" dictionary must contain an entry
-for "SURFACE". This logic is applied to point observations whose message type
-appears in the "SURFACE" entry. Only use point observations where the
-topo minus station elevation difference meets the "use_obs_thresh" threshold
-entry. For the observations kept, when interpolating forecast data to the
+Only use point observations where the model topography minus station elevation
+elevation difference meets the "use_obs_thresh" threshold entry.
+For the observations kept, when interpolating forecast data to the
 observation location, only use forecast grid points where the topo minus station
 difference meets the "interp_fcst_thresh" threshold entry.  If the "file_name"
 is left empty, the topography data is assumed to exist in the input forecast file(s).
@@ -2298,6 +2330,20 @@ Otherwise, the specified file(s) are searched for the data specified in the "fie
 entry. The "regrid" settings specify how this field should be regridded to
 the verification domain. The "interp" settings specify how this field should be
 interpolated to point observation locations.
+
+The "message_type_group_map" dictionary entry for "SURFACE" specifies a comma-separated
+list of message types whose observations exist at the surface. The topography filtering
+logic is only applied to observations whose message type appears in this list.
+By default, the topography filtering logic is applied to observations for message types
+"ADPSFC", "SFCSHP", and "MSONET".
+
+.. code-block:: none
+
+  message_type_group_map = [
+    ...
+    { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET"; },
+    ...
+  ];
 
 The "topo_mask.flag", "topo_mask.use_obs_thresh", and "topo_mask.interp_fcst_thresh"
 entries can be set separately in each "obs.field" entry.

--- a/docs/Users_Guide/config_options.rst
+++ b/docs/Users_Guide/config_options.rst
@@ -2324,9 +2324,6 @@ for this correction.
 The "apply_to" option can be set to "NONE" (default) to disable this correction
 logic, "FCST" to correct the forecast value, or "OBS" to correct the observation
 value, but not "BOTH".
-The "message_type_group_map" dictionary entry for "LAPSERT" specifies a comma-separated
-list of message types for which this correction should be enabled. If set to an
-empty string, the correction will be applied for all message types.
 The "value" entry is a constant number that defines the lapse rate for correcting
 temperatures based on the difference of the model topography height and station
 elevation. By default, "value" is set to bad data and must be explicitly defined
@@ -2334,6 +2331,19 @@ when "apply_to" is not set to NONE.
 The lapse rate correction fails when the model topography or observation height
 values are bad data and that matched pair is excluded from the computation of
 statistics.
+
+The "message_type_group_map" dictionary entry for "LAPSERT" specifies a comma-separated
+list of message types for which this correction should be applied. By default, the
+correction logic is applied to observations for message types "ADPSFC" and "MSONET".
+If set to an empty list, the correction would be applied for all message types.
+
+.. code-block:: none
+
+  message_type_group_map = [
+    ...
+    { key = "LAPSERT"; val = "ADPSFC,MSONET"; },
+    ...
+  ];
 
 The environmental lapse rate values for 2-meter temperature and dewpoint temperature
 used by the World Meteorological Organization (WMO) can be found in "ConfigConstants".
@@ -2373,9 +2383,6 @@ The "apply_from" option can be set to "FCST" to convert using the model topograp
 height, "OBS" to convert using the station elevation, or "BOTH" to convert the
 forecast value using the model topography height and convert the observation
 value using the station elevation.
-The "message_type_group_map" dictionary entry for "MSLAGL" specifies a comma-separated
-list of message types for which this conversion should be enabled. If set to an
-empty string, the conversion will be applied for all message types.
 The "thresh" option specifies the valid range of values to be converted. Values not
 meeting this threshold criteria are left unchanged. The default threshold of "NA"
 always evaulates to true, but it can be set to avoid converting flag values. For example,
@@ -2387,6 +2394,19 @@ elevation correction is added to the height value to convert from AGL to MSL.
 The MSL/AGL conversion fails when the model topography or observation height
 values are bad data and that matched pair is excluded from the computation of
 statistics.
+
+The "message_type_group_map" dictionary entry for "MSLAGL" specifies a comma-separated
+list of message types for which this conversion should be applied. By default, the
+conversion logic is applied to observations for message types since it is set to an
+empty list.
+
+.. code-block:: none
+
+  message_type_group_map = [
+    ...
+    { key = "MSLAGL"; val = ""; },
+    ...
+  ];
 
 All "msl_agl_conversion" entries can be set separately in each "obs.field" entry.
 

--- a/docs/Users_Guide/config_options.rst
+++ b/docs/Users_Guide/config_options.rst
@@ -2324,9 +2324,9 @@ for this correction.
 The "apply_to" option can be set to "NONE" (default) to disable this correction
 logic, "FCST" to correct the forecast value, or "OBS" to correct the observation
 value, but not "BOTH".
-When enabled, the "message_type_group_map" dictionary must contain an entry for
-"SURFACE". This correction is only applied when the verifying point observation
-message type appears in the "SURFACE" entry.
+The "message_type_group_map" dictionary entry for "LAPSERT" specifies a comma-separated
+list of message types for which this correction should be enabled. If set to an
+empty string, the correction will be applied for all message types.
 The "value" entry is a constant number that defines the lapse rate for correcting
 temperatures based on the difference of the model topography height and station
 elevation. By default, "value" is set to bad data and must be explicitly defined
@@ -2373,6 +2373,9 @@ The "apply_from" option can be set to "FCST" to convert using the model topograp
 height, "OBS" to convert using the station elevation, or "BOTH" to convert the
 forecast value using the model topography height and convert the observation
 value using the station elevation.
+The "message_type_group_map" dictionary entry for "MSLAGL" specifies a comma-separated
+list of message types for which this conversion should be enabled. If set to an
+empty string, the conversion will be applied for all message types.
 The "thresh" option specifies the valid range of values to be converted. Values not
 meeting this threshold criteria are left unchanged. The default threshold of "NA"
 always evaulates to true, but it can be set to avoid converting flag values. For example,

--- a/docs/Users_Guide/config_options.rst
+++ b/docs/Users_Guide/config_options.rst
@@ -2443,7 +2443,7 @@ statistics.
 
 The "message_type_group_map" dictionary entry for "MSLAGL" specifies a comma-separated
 list of message types for which this conversion should be applied. By default, the
-conversion logic is applied to observations for message types since it is set to an
+conversion logic is applied to observations for all message types since it is set to an
 empty list.
 
 .. code-block:: none

--- a/internal/test_unit/config/EnsembleStatConfig_LAND_TOPO_MASK
+++ b/internal/test_unit/config/EnsembleStatConfig_LAND_TOPO_MASK
@@ -135,7 +135,9 @@ message_type_group_map = [
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
    { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
    { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
-   { key = "WATERSF"; val = "SFCSHP";                             }
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/internal/test_unit/config/EnsembleStatConfig_LAPSE_RATE_MSL_AGL
+++ b/internal/test_unit/config/EnsembleStatConfig_LAPSE_RATE_MSL_AGL
@@ -149,7 +149,12 @@ message_type_group_map = [
    { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET";               },
    { key = "ANYAIR";  val = "AIRCAR,AIRCFT";                      },
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
-   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      }
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/internal/test_unit/config/EnsembleStatConfig_python
+++ b/internal/test_unit/config/EnsembleStatConfig_python
@@ -116,7 +116,12 @@ message_type_group_map = [
    { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET";               },
    { key = "ANYAIR";  val = "AIRCAR,AIRCFT";                      },
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
-   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      }
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/internal/test_unit/config/EnsembleStatConfig_single_file_grib
+++ b/internal/test_unit/config/EnsembleStatConfig_single_file_grib
@@ -128,7 +128,12 @@ message_type_group_map = [
    { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET";               },
    { key = "ANYAIR";  val = "AIRCAR,AIRCFT";                      },
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
-   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      }
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/internal/test_unit/config/EnsembleStatConfig_single_file_nc
+++ b/internal/test_unit/config/EnsembleStatConfig_single_file_nc
@@ -134,7 +134,11 @@ message_type_group_map = [
    { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET";               },
    { key = "ANYAIR";  val = "AIRCAR,AIRCFT";                      },
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
-   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      }
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/internal/test_unit/config/PointStatConfig_LAND_TOPO_MASK
+++ b/internal/test_unit/config/PointStatConfig_LAND_TOPO_MASK
@@ -78,7 +78,9 @@ message_type_group_map = [
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
    { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
    { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
-   { key = "WATERSF"; val = "SFCSHP";                             }
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/internal/test_unit/config/PointStatConfig_LAPSE_RATE_MSL_AGL
+++ b/internal/test_unit/config/PointStatConfig_LAPSE_RATE_MSL_AGL
@@ -101,7 +101,9 @@ message_type_group_map = [
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
    { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
    { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
-   { key = "WATERSF"; val = "SFCSHP";                             }
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/internal/test_unit/config/PointStatConfig_MPR_OBTYPE
+++ b/internal/test_unit/config/PointStatConfig_MPR_OBTYPE
@@ -48,7 +48,9 @@ message_type_group_map = [
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
    { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
    { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
-   { key = "WATERSF"; val = "SFCSHP";                             }
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = TRUE;

--- a/internal/test_unit/config/PointStatConfig_WINDS
+++ b/internal/test_unit/config/PointStatConfig_WINDS
@@ -49,6 +49,8 @@ message_type_group_map = [
    { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
    { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
    { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   },
    { key = "USERSF";  val = "ADPSFC,SFCSHP";                      }
 ];
 

--- a/internal/test_unit/config/PointStatConfig_airnow
+++ b/internal/test_unit/config/PointStatConfig_airnow
@@ -89,7 +89,9 @@ message_type_group_map = [
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
    { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
    { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
-   { key = "WATERSF"; val = "SFCSHP";                             }
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/internal/test_unit/config/PointStatConfig_range_azimuth
+++ b/internal/test_unit/config/PointStatConfig_range_azimuth
@@ -87,7 +87,9 @@ message_type_group_map = [
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
    { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
    { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
-   { key = "WATERSF"; val = "SFCSHP";                             }
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/scripts/config/EnsembleStatConfig
+++ b/scripts/config/EnsembleStatConfig
@@ -121,7 +121,12 @@ message_type_group_map = [
    { key = "SURFACE"; val = "ADPSFC,SFCSHP,MSONET";               },
    { key = "ANYAIR";  val = "AIRCAR,AIRCFT";                      },
    { key = "ANYSFC";  val = "ADPSFC,SFCSHP,ADPUPA,PROFLR,MSONET"; },
-   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      }
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "ONLYSF";  val = "ADPSFC,SFCSHP";                      },
+   { key = "LANDSF";  val = "ADPSFC,MSONET";                      },
+   { key = "WATERSF"; val = "SFCSHP";                             },
+   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
+   { key = "MSLAGL";  val = "";                                   }
 ];
 
 obtype_as_group_val_flag = FALSE;

--- a/src/basic/vx_util/util_constants.h
+++ b/src/basic/vx_util/util_constants.h
@@ -85,11 +85,15 @@ static const int n_vld_msg_typ =
 static const char surface_msg_typ_group_str [] = "SURFACE"; // Surface message type group
 static const char landsf_msg_typ_group_str  [] = "LANDSF";  // Surface land message type group
 static const char watersf_msg_typ_group_str [] = "WATERSF"; // Surface water message type group
+static const char lapsert_msg_typ_group_str [] = "LAPSERT"; // Lapse rate correction message type group
+static const char mslagl_msg_typ_group_str  [] = "MSLAGL";  // MSL/AGL conversion message type groupe
 
 // Default message type group values
 static const char default_msg_typ_group_surface [] = "ADPSFC,SFCSHP,MSONET";
 static const char default_msg_typ_group_landsf  [] = "ADPSFC,MSONET";
 static const char default_msg_typ_group_watersf [] = "SFCSHP";
+static const char default_msg_typ_group_lapsert [] = "ADPSFC,MSONET";
+static const char default_msg_typ_group_mslagl  [] = "";    // Convert all types
 
 // Commonly used regular expressions
 static const char yyyymmdd_hhmmss_reg_exp[] =

--- a/src/libcode/vx_statistics/pair_base.cc
+++ b/src/libcode/vx_statistics/pair_base.cc
@@ -1463,27 +1463,27 @@ void VxPairBase::set_msg_typ_groups(const map<ConcatString,StringArray> &m) {
 
    // Surface message types
    cs = surface_msg_typ_group_str;
-   if(m.count(cs) > 0) msg_typ_sfc = m[cs];
+   if(m.count(cs) > 0) msg_typ_sfc = m.at(cs);
    else                msg_typ_sfc.parse_css(default_msg_typ_group_surface);
 
    // Land surface message types
    cs = landsf_msg_typ_group_str;
-   if(m.count(cs) > 0) msg_typ_lnd = m[cs];
+   if(m.count(cs) > 0) msg_typ_lnd = m.at(cs);
    else                msg_typ_lnd.parse_css(default_msg_typ_group_landsf);
 
    // Water surface message types
    cs = watersf_msg_typ_group_str;
-   if(m.count(cs) > 0) msg_typ_wtr = m[cs];
+   if(m.count(cs) > 0) msg_typ_wtr = m.at(cs);
    else                msg_typ_wtr.parse_css(default_msg_typ_group_watersf);
 
    // Lapse rate correction message types
    cs = lapsert_msg_typ_group_str;
-   if(m.count(cs) > 0) msg_typ_lapsert = m[cs];
+   if(m.count(cs) > 0) msg_typ_lapsert = m.at(cs);
    else                msg_typ_lapsert.parse_css(default_msg_typ_group_lapsert);
 
    // MSL/AGL conversion message types
    cs = mslagl_msg_typ_group_str;
-   if(m.count(cs) > 0) msg_typ_mslagl = m[cs];
+   if(m.count(cs) > 0) msg_typ_mslagl = m.at(cs);
    else                msg_typ_mslagl.parse_css(default_msg_typ_group_mslagl);
 
    return;

--- a/src/libcode/vx_statistics/pair_base.cc
+++ b/src/libcode/vx_statistics/pair_base.cc
@@ -982,6 +982,8 @@ void VxPairBase::clear() {
    msg_typ_sfc.clear();
    msg_typ_lnd.clear();
    msg_typ_wtr.clear();
+   msg_typ_lapsert.clear();
+   msg_typ_mslagl.clear();
 
    sfc_info.clear();
 
@@ -1048,9 +1050,11 @@ void VxPairBase::assign(const VxPairBase &vx_pb) {
    mpr_str_inc_map = vx_pb.mpr_str_inc_map;
    mpr_str_exc_map = vx_pb.mpr_str_exc_map;
 
-   msg_typ_sfc = vx_pb.msg_typ_sfc;
-   msg_typ_lnd = vx_pb.msg_typ_lnd;
-   msg_typ_wtr = vx_pb.msg_typ_wtr;
+   msg_typ_sfc     = vx_pb.msg_typ_sfc;
+   msg_typ_lnd     = vx_pb.msg_typ_lnd;
+   msg_typ_wtr     = vx_pb.msg_typ_wtr;
+   msg_typ_lapsert = vx_pb.msg_typ_lapsert;
+   msg_typ_mslagl  = vx_pb.msg_typ_mslagl;
 
    sfc_info = vx_pb.sfc_info;
 
@@ -1454,27 +1458,33 @@ void VxPairBase::set_climo_cdf_info_ptr(const ClimoCDFInfo *info) {
 
 ////////////////////////////////////////////////////////////////////////
 
-void VxPairBase::set_msg_typ_sfc(const StringArray &sa) {
+void VxPairBase::set_msg_typ_groups(const map<ConcatString,StringArray> &m) {
+   ConcatString cs;
 
-   msg_typ_sfc = sa;
+   // Surface message types
+   cs = surface_msg_typ_group_str;
+   if(m.count(cs) > 0) msg_typ_sfc = m[cs];
+   else                msg_typ_sfc.parse_css(default_msg_typ_group_surface);
 
-   return;
-}
+   // Land surface message types
+   cs = landsf_msg_typ_group_str;
+   if(m.count(cs) > 0) msg_typ_lnd = m[cs];
+   else                msg_typ_lnd.parse_css(default_msg_typ_group_landsf);
 
-////////////////////////////////////////////////////////////////////////
+   // Water surface message types
+   cs = watersf_msg_typ_group_str;
+   if(m.count(cs) > 0) msg_typ_wtr = m[cs];
+   else                msg_typ_wtr.parse_css(default_msg_typ_group_watersf);
 
-void VxPairBase::set_msg_typ_lnd(const StringArray &sa) {
+   // Lapse rate correction message types
+   cs = lapsert_msg_typ_group_str;
+   if(m.count(cs) > 0) msg_typ_lapsert = m[cs];
+   else                msg_typ_lapsert.parse_css(default_msg_typ_group_lapsert);
 
-   msg_typ_lnd = sa;
-
-   return;
-}
-
-////////////////////////////////////////////////////////////////////////
-
-void VxPairBase::set_msg_typ_wtr(const StringArray &sa) {
-
-   msg_typ_wtr = sa;
+   // MSL/AGL conversion message types
+   cs = mslagl_msg_typ_group_str;
+   if(m.count(cs) > 0) msg_typ_mslagl = m[cs];
+   else                msg_typ_mslagl.parse_css(default_msg_typ_group_mslagl);
 
    return;
 }

--- a/src/libcode/vx_statistics/pair_base.h
+++ b/src/libcode/vx_statistics/pair_base.h
@@ -299,11 +299,13 @@ class VxPairBase {
 
       //////////////////////////////////////////////////////////////////
 
-      StringArray msg_typ_sfc;   // List of surface message types
-      StringArray msg_typ_lnd;   // List of surface land message types
-      StringArray msg_typ_wtr;   // List of surface water message types
+      StringArray msg_typ_sfc;     // Surface message types
+      StringArray msg_typ_lnd;     // Surface land message types
+      StringArray msg_typ_wtr;     // Surface water message types
+      StringArray msg_typ_lapsert; // Lapse rate correction message types
+      StringArray msg_typ_mslagl;  // MSL/AGL conversion message types
 
-      SurfaceInfo sfc_info;      // Land/sea mask and topography info
+      SurfaceInfo sfc_info;        // Land/sea mask and topography info
 
       //////////////////////////////////////////////////////////////////
 
@@ -392,9 +394,7 @@ class VxPairBase {
 
       void set_climo_cdf_info_ptr(const ClimoCDFInfo *);
 
-      void set_msg_typ_sfc(const StringArray &);
-      void set_msg_typ_lnd(const StringArray &);
-      void set_msg_typ_wtr(const StringArray &);
+      void set_msg_typ_groups(const std::map<ConcatString,StringArray> &);
 
       int  get_n_pair() const;
 

--- a/src/libcode/vx_statistics/pair_data_ensemble.cc
+++ b/src/libcode/vx_statistics/pair_data_ensemble.cc
@@ -1456,7 +1456,7 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
                // MET #3174 Apply MSL/AGL height conversion
                if(sfc_info.msl_agl_conversion_apply_to != FieldType::None &&
                   (msg_typ_mslagl.n() == 0 ||
-                   msg_typ_mslgagl.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
+                   msg_typ_mslagl.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
                   !convert_msl_agl(topo_elv, it->elv_na[i_obs], fcst_v, obs_v, member == 0)) {
 
                   // Skip by resetting to bad data

--- a/src/libcode/vx_statistics/pair_data_ensemble.cc
+++ b/src/libcode/vx_statistics/pair_data_ensemble.cc
@@ -1444,7 +1444,8 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
 
                // MET #3174 Apply lapse rate surface temperature correction
                if(sfc_info.lapse_rate_correction_apply_to != FieldType::None &&
-                  msg_typ_sfc.reg_exp_match(it->typ_sa[i_obs].c_str()) &&
+                  (msg_typ_lapsert.n() == 0 ||
+                   msg_typ_lapsert.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
                   !correct_lapse_rate(topo_elv, it->elv_na[i_obs], fcst_v, obs_v)) {
 
                   // Skip by resetting to bad data
@@ -1454,6 +1455,8 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
 
                // MET #3174 Apply MSL/AGL height conversion
                if(sfc_info.msl_agl_conversion_apply_to != FieldType::None &&
+                  (msg_typ_mslagl.n() == 0 ||
+                   msg_typ_mslgagl.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
                   !convert_msl_agl(topo_elv, it->elv_na[i_obs], fcst_v, obs_v, member == 0)) {
 
                   // Skip by resetting to bad data

--- a/src/libcode/vx_statistics/pair_data_ensemble.cc
+++ b/src/libcode/vx_statistics/pair_data_ensemble.cc
@@ -1444,7 +1444,7 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
 
                // MET #3174 Apply lapse rate surface temperature correction
                if(sfc_info.lapse_rate_correction_apply_to != FieldType::None &&
-                  (msg_typ_lapsert.n() == 0 ||
+                  (msg_typ_lapsert.all_empty() ||
                    msg_typ_lapsert.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
                   !correct_lapse_rate(topo_elv, it->elv_na[i_obs], fcst_v, obs_v)) {
 
@@ -1455,7 +1455,7 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
 
                // MET #3174 Apply MSL/AGL height conversion
                if(sfc_info.msl_agl_conversion_apply_to != FieldType::None &&
-                  (msg_typ_mslagl.n() == 0 ||
+                  (msg_typ_mslagl.all_empty() ||
                    msg_typ_mslagl.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
                   !convert_msl_agl(topo_elv, it->elv_na[i_obs], fcst_v, obs_v, member == 0)) {
 

--- a/src/libcode/vx_statistics/pair_data_point.cc
+++ b/src/libcode/vx_statistics/pair_data_point.cc
@@ -623,7 +623,8 @@ void VxPairDataPoint::add_point_obs(const float *hdr_arr,
 
             // MET #3174 Apply lapse rate surface temperature correction
             if(sfc_info.lapse_rate_correction_apply_to != FieldType::None &&
-               msg_typ_sfc.reg_exp_match(hdr_typ_str) &&
+               (msg_typ_lapsert.n() == 0 ||
+                msg_typ_lapsert.reg_exp_match(hdr_typ_str)) &&
                !correct_lapse_rate(topo_elv, hdr_elv, fcst_v, obs_v)) {
                inc_count(rej_mpr, i_msg_typ, i_mask, i_interp);
                continue;
@@ -631,6 +632,8 @@ void VxPairDataPoint::add_point_obs(const float *hdr_arr,
 
             // MET #3174 Apply MSL/AGL height conversion
             if(sfc_info.msl_agl_conversion_apply_to != FieldType::None &&
+               (msg_typ_mslagl.n() == 0 ||
+                msg_typ_mslagl.reg_exp_match(hdr_typ_str)) &&
                !convert_msl_agl(topo_elv, hdr_elv, fcst_v, obs_v)) {
                inc_count(rej_mpr, i_msg_typ, i_mask, i_interp);
                continue;

--- a/src/libcode/vx_statistics/pair_data_point.cc
+++ b/src/libcode/vx_statistics/pair_data_point.cc
@@ -623,7 +623,7 @@ void VxPairDataPoint::add_point_obs(const float *hdr_arr,
 
             // MET #3174 Apply lapse rate surface temperature correction
             if(sfc_info.lapse_rate_correction_apply_to != FieldType::None &&
-               (msg_typ_lapsert.n() == 0 ||
+               (msg_typ_lapsert.all_empty() ||
                 msg_typ_lapsert.reg_exp_match(hdr_typ_str)) &&
                !correct_lapse_rate(topo_elv, hdr_elv, fcst_v, obs_v)) {
                inc_count(rej_mpr, i_msg_typ, i_mask, i_interp);
@@ -632,7 +632,7 @@ void VxPairDataPoint::add_point_obs(const float *hdr_arr,
 
             // MET #3174 Apply MSL/AGL height conversion
             if(sfc_info.msl_agl_conversion_apply_to != FieldType::None &&
-               (msg_typ_mslagl.n() == 0 ||
+               (msg_typ_mslagl.all_empty() ||
                 msg_typ_mslagl.reg_exp_match(hdr_typ_str)) &&
                !convert_msl_agl(topo_elv, hdr_elv, fcst_v, obs_v)) {
                inc_count(rej_mpr, i_msg_typ, i_mask, i_interp);

--- a/src/tools/core/ensemble_stat/ensemble_stat_conf_info.cc
+++ b/src/tools/core/ensemble_stat/ensemble_stat_conf_info.cc
@@ -167,15 +167,6 @@ void EnsembleStatConfInfo::process_config(GrdFileType etype,
    // Conf: message_type_group_map
    msg_typ_group_map = parse_conf_message_type_group_map(&conf);
 
-   // Conf: message_type_group_map(SURFACE)
-   ConcatString cs = surface_msg_typ_group_str;
-   if(msg_typ_group_map.count(cs) > 0) {
-      msg_typ_sfc = msg_typ_group_map[cs];
-   }
-   else {
-      msg_typ_sfc.parse_css(default_msg_typ_group_surface);
-   }
-
    // Conf: obtype_as_group_val_flag
    obtype_as_group_val_flag =
       conf.lookup_bool(conf_key_obtype_as_group_val_flag);
@@ -524,18 +515,6 @@ void EnsembleStatConfInfo::process_geog(const Grid &grid,
             DataPlane geog_dp(parse_geog_data(dict, grid, input_files));
             geog_dp.threshold(dict->lookup_thresh(conf_key_thresh));
             land_mask = geog_dp.mask_plane();
-
-            // Conf: message_type_group_map for LANDSF and WATERSF
-            if(msg_typ_group_map.count((string)landsf_msg_typ_group_str) == 0 ||
-               msg_typ_group_map.count((string)watersf_msg_typ_group_str) == 0 ) {
-               mlog << Error << "\n" << method_name
-                    << "when \"" << conf_key_land_mask_flag << "\" is true, \""
-                    << conf_key_message_type_group_map
-                    << "\" must contain entries for \""
-                    << landsf_msg_typ_group_str << "\" and \""
-                    << watersf_msg_typ_group_str << "\".\n\n";
-               exit(1);
-            }
          }
 
          // Store pointer to the land mask data
@@ -549,16 +528,6 @@ void EnsembleStatConfInfo::process_geog(const Grid &grid,
          if(topo_dp.is_empty()) {
             Dictionary *dict = conf.lookup_dictionary(conf_key_topo_mask);
             topo_dp = parse_geog_data(dict, grid, input_files);
-
-            // Conf: message_type_group_map for SURFACE
-            if(msg_typ_group_map.count((string)surface_msg_typ_group_str) == 0) {
-               mlog << Error << "\n" << method_name
-                    << "when \"" << conf_key_topo_mask_flag << "\" is true, \""
-                    << conf_key_message_type_group_map
-                    << "\" must contain an entry for \""
-                    << surface_msg_typ_group_str << "\".\n\n";
-               exit(1);
-            }
          }
 
          // Store pointer to the topo data
@@ -1069,7 +1038,7 @@ void EnsembleStatVxOpt::set_vx_pd(EnsembleStatConfInfo *conf_info, int ctrl_inde
    vx_pd.set_climo_cdf_info_ptr(&cdf_info);
 
    // Store the list of surface message types
-   vx_pd.set_msg_typ_sfc(conf_info->msg_typ_sfc);
+   vx_pd.set_msg_typ_groups(conf_info->msg_typ_group_map);
 
    // Define the verifying message type name and values
    for(int i=0; i<n_msg_typ; i++) {

--- a/src/tools/core/point_stat/point_stat_conf_info.cc
+++ b/src/tools/core/point_stat/point_stat_conf_info.cc
@@ -519,18 +519,6 @@ void PointStatConfInfo::process_geog(const Grid &grid,
             DataPlane geog_dp(parse_geog_data(dict, grid, input_files));
             geog_dp.threshold(dict->lookup_thresh(conf_key_thresh));
             land_mask = geog_dp.mask_plane();
-
-            // Conf: message_type_group_map for LANDSF and WATERSF
-            if(msg_typ_group_map.count((string)landsf_msg_typ_group_str) == 0 ||
-               msg_typ_group_map.count((string)watersf_msg_typ_group_str) == 0 ) {
-               mlog << Error << "\n" << method_name
-                    << "when \"" << conf_key_land_mask_flag << "\" is true, \""
-                    << conf_key_message_type_group_map
-                    << "\" must contain entries for \""
-                    << landsf_msg_typ_group_str << "\" and \""
-                    << watersf_msg_typ_group_str << "\".\n\n";
-               exit(1);
-            }
          }
 
          // Store pointer to the land mask data
@@ -544,16 +532,6 @@ void PointStatConfInfo::process_geog(const Grid &grid,
          if(topo_dp.is_empty()) {
             Dictionary *dict = conf.lookup_dictionary(conf_key_topo_mask);
             topo_dp = parse_geog_data(dict, grid, input_files);
-
-            // Conf: message_type_group_map for SURFACE
-            if(msg_typ_group_map.count((string)surface_msg_typ_group_str) == 0) {
-               mlog << Error << "\n" << method_name
-                    << "when \"" << conf_key_topo_mask_flag << "\" is true, \""
-                    << conf_key_message_type_group_map
-                    << "\" must contain an entry for \""
-                    << surface_msg_typ_group_str << "\".\n\n";
-               exit(1);
-            }
          }
 
          // Store pointer to the topo data
@@ -1145,35 +1123,8 @@ void PointStatVxOpt::set_vx_pd(PointStatConfInfo *conf_info) {
    // Store the climo CDF info
    vx_pd.set_climo_cdf_info_ptr(&cdf_info);
 
-   // Store the surface message type group
-   cs = surface_msg_typ_group_str;
-   if(conf_info->msg_typ_group_map.count(cs) > 0) {
-      vx_pd.set_msg_typ_sfc(conf_info->msg_typ_group_map[cs]);
-   }
-   else {
-      sa.parse_css(default_msg_typ_group_surface);
-      vx_pd.set_msg_typ_sfc(sa);
-   }
-
-   // Store the surface land message type group
-   cs = landsf_msg_typ_group_str;
-   if(conf_info->msg_typ_group_map.count(cs) > 0) {
-      vx_pd.set_msg_typ_lnd(conf_info->msg_typ_group_map[cs]);
-   }
-   else {
-      sa.parse_css(default_msg_typ_group_landsf);
-      vx_pd.set_msg_typ_lnd(sa);
-   }
-
-   // Store the surface water message type group
-   cs = watersf_msg_typ_group_str;
-   if(conf_info->msg_typ_group_map.count(cs) > 0) {
-      vx_pd.set_msg_typ_wtr(conf_info->msg_typ_group_map[cs]);
-   }
-   else {
-      sa.parse_css(default_msg_typ_group_watersf);
-      vx_pd.set_msg_typ_wtr(sa);
-   }
+   // Store message type groups
+   vx_pd.set_msg_typ_groups(conf_info->msg_typ_group_map);
 
    // Define the verifying message type name and values
    for(int i=0; i<n_msg_typ; i++) {


### PR DESCRIPTION
> [!IMPORTANT]
> These changes are also needed in the `develop` branch.

This is a second PR for issue #3270. It does contain more changes than I originally expected because I found some opportunities to move common logic from the Point-Stat and Ensemble-Stat application code into the `vx_statistics` library. This PR proposes changes in 22 files:
- [1] Update documentation in `config_options.rst`.
- [2] Default config files for Point-Stat and Ensemble-Stat. Add new `message_type_group_map` entries for `LAPSERT` and `MSLAGL` to define the message types whose observations should be used for the correction/conversion operations. In Ensemble-Stat, also add entries for `LANDSF` and `WATERSF` which were missing.
- [12] Update test config files similarly.
- [1] `util_constants.h` defines new expected group names for `LAPSERT` and `MSLAGL` and also defines default values, as is done for `SURFACE`, `LANDSF`, and `WATERSF`. So I'm seeking consistency here.
- [2] `pair_base.h/.cc` adds variables to store the `LAPSERT` and `MSLAGL` message types. And the parsing of these message types is moved into a common library utility.
- [2] `pair_data_point.cc` and `pair_data_ensemble.cc` are updated to check the message type before calling `correct_lapse_rate()` and `convert_msl_agl()`.
- [2] `point_stat_conf_info.cc` and `ensmble_stat_conf_info.cc` moves parsing of specialized message types groups into common library code. Note that ERROR checks about those settings being required are removed since hard-coded default values are used when they are not specified by the configuration file.

## Expected Differences ##

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[Yes]**</br>
If **yes**, please describe:</br>
Adds default settings for new `LAPSERT` and `MSLAGL` entries in the existing `message_type_group_map` entry.

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
- Ran existing Point-Stat and Ensemble-Stat use cases at verbosity level 8 (`-v 8`) with default settings:
```
   { key = "LAPSERT"; val = "ADPSFC,MSONET";                      },
   { key = "MSLAGL";  val = "";                                   }
```
And then reran with bad message types:
```
   { key = "LAPSERT"; val = "BADTYP";                             },
   { key = "MSLAGL";  val = "BADTYP";                             }
```
See the differences in the log messages by searching for "correcting" and "converting":
```
cd /d1/projects/MET/MET_pull_requests/met-12.2.0/rc2/MET-feature_3270_main_v12.2_message_type_group_map/internal/test_unit
vimdiff run_ps_DEFAULT.log run_ps_BADTYP.log
vimdiff run_es_DEFAULT.log run_es_BADTYP.log
```
Can also grep to see that those "correcting/converting" log messages do not appear when requesting the `BADTYP` message type:
```
egrep "correcting|converting" *DEFAULT.log | wc -l
250
egrep "correcting|converting" *BADTYP.log | wc -l
0
```

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
  - Please confirm answers to the following assumptions:
  1. `LAPSERT` should be set to `ADPSFC,MSONET` by default.
  2. `MSLAGL` should be set to an empty string by default, so that the conversion is applied when requested, regardless of message type. But if someone wants to filter by message type, that is an option.
  - Review code changes and documentation updates.
  - Please feel free to test the code for this branch in `seneca:/d1/projects/MET/MET_pull_requests/met-12.2.0/rc2/MET-feature_3270_main_v12.2_message_type_group_map`.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [x] Do these changes include sufficient testing updates? **[Yes]**
I made no changes to the existing unit tests.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:
The overall number of maintainability issues remains contant at 14,577.

- [x] Please complete this pull request review by **[Tues Oct 28, 2025]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **METplus-X.Y Support** project for bugfix releases or **MET-X.Y Development** project for the next coordinated release
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
