### PR TITLE
Feature #3270 main_v12.2 duplicate_corrections

### DIFF
--- a/src/libcode/vx_statistics/pair_base.cc
+++ b/src/libcode/vx_statistics/pair_base.cc
@@ -2157,7 +2157,9 @@ double VxPairBase::compute_fcst_value(
 
 ////////////////////////////////////////////////////////////////////////
 
-bool VxPairBase::correct_lapse_rate(double fcst_elv, double obs_elv,
+bool VxPairBase::correct_lapse_rate(const char *pnt_obs_str,
+                                    const char *obs_sid_str,
+                                    double fcst_elv, double obs_elv,
                                     double &fcst_v, double &obs_v) const {
    const char *method_name = "PairBase::correct_lapse_rate() -> ";
 
@@ -2170,14 +2172,17 @@ bool VxPairBase::correct_lapse_rate(double fcst_elv, double obs_elv,
       is_bad_data(fcst_v)   || is_bad_data(obs_v)   ||
       is_bad_data(sfc_info.lapse_rate_correction_value)) { 
 
-      if(mlog.verbosity_level() >= CORRECTION_DEBUG_LEVEL) {
-         mlog << Debug(CORRECTION_DEBUG_LEVEL)
+      if(mlog.verbosity_level() >= REJECT_DEBUG_LEVEL) {
+         mlog << Debug(REJECT_DEBUG_LEVEL)
               << "For " << fcst_info->magic_str() << " versus "
               << obs_info->magic_str() << ", skipping lapse rate correction "
               << "due to bad (fcst, obs) elevation (" << fcst_elv << ", "
               << obs_elv << "), data (" << fcst_v << ", "
               << obs_v << "), or lapse rate ("
-              << sfc_info.lapse_rate_correction_value << ") values.\n";
+              << sfc_info.lapse_rate_correction_value << ") values"
+              << (pnt_obs_str ? ":\n" : ".")
+              << (pnt_obs_str ? pnt_obs_str : "")
+              << "\n";
       }
 
       return false;
@@ -2200,8 +2205,8 @@ bool VxPairBase::correct_lapse_rate(double fcst_elv, double obs_elv,
    // Log the lapse rate correction
    if(mlog.verbosity_level() >= CORRECTION_DEBUG_LEVEL) {
       mlog << Debug(CORRECTION_DEBUG_LEVEL)
-           << "For " << fcst_info->magic_str() << " versus "
-           << obs_info->magic_str() << ", correcting the "
+           << "For station " << obs_sid_str << ", " << fcst_info->magic_str()
+           << " versus " << obs_info->magic_str() << ", correcting the "
            << fieldtype_to_string(sfc_info.lapse_rate_correction_apply_to)
            << " temperature from " << orig_v << " to " << corr_v 
            << " for forecast (" << fcst_elv << ") minus observation ("
@@ -2215,7 +2220,9 @@ bool VxPairBase::correct_lapse_rate(double fcst_elv, double obs_elv,
 
 ////////////////////////////////////////////////////////////////////////
 
-bool VxPairBase::convert_msl_agl(double fcst_elv, double obs_elv,
+bool VxPairBase::convert_msl_agl(const char *pnt_obs_str,
+                                 const char *obs_sid_str,
+                                 double fcst_elv, double obs_elv,
                                  double &fcst_v, double &obs_v,
                                  bool update_obs) const {
    const char *method_name = "PairBase::convert_msl_agl() -> ";
@@ -2259,13 +2266,16 @@ bool VxPairBase::convert_msl_agl(double fcst_elv, double obs_elv,
    if(is_bad_data(fcst_v) || is_bad_data(obs_v) ||
       is_bad_data(corr_f) || is_bad_data(corr_o)) {
 
-      if(mlog.verbosity_level() >= CORRECTION_DEBUG_LEVEL) {
-         mlog << Debug(CORRECTION_DEBUG_LEVEL)
+      if(mlog.verbosity_level() >= REJECT_DEBUG_LEVEL) {
+         mlog << Debug(REJECT_DEBUG_LEVEL)
               << "For " << fcst_info->magic_str() << " versus "
               << obs_info->magic_str() << ", skipping msl/agl conversion "
               << "due to bad (fcst, obs) elevation (" << fcst_elv << ", "
               << obs_elv << ") or data (" << fcst_v << ", "
-              << obs_v << ") values.\n";
+              << obs_v << ") values"
+              << (pnt_obs_str ? ":\n" : ".")
+              << (pnt_obs_str ? pnt_obs_str : "")
+              << "\n";
       }
 
       return false;
@@ -2285,8 +2295,8 @@ bool VxPairBase::convert_msl_agl(double fcst_elv, double obs_elv,
    // Log the MSL/AGL conversion
    if(mlog.verbosity_level() >= CORRECTION_DEBUG_LEVEL) {
       mlog << Debug(CORRECTION_DEBUG_LEVEL)
-           << "For " << fcst_info->magic_str() << " versus "
-           << obs_info->magic_str() << ", converting "
+           << "For station " << obs_sid_str << ", " << fcst_info->magic_str()
+           << " versus " << obs_info->magic_str() << ", converting "
            << (sfc_info.msl_agl_conversion_msl_to_agl ?
                "MSL to AGL" : "AGL to MSL")
            << " using "

--- a/src/libcode/vx_statistics/pair_base.cc
+++ b/src/libcode/vx_statistics/pair_base.cc
@@ -2173,16 +2173,16 @@ bool VxPairBase::correct_lapse_rate(const char *pnt_obs_str,
       is_bad_data(sfc_info.lapse_rate_correction_value)) { 
 
       if(mlog.verbosity_level() >= REJECT_DEBUG_LEVEL) {
+         ConcatString cs;
+         if(pnt_obs_str) cs << ":\n" << pnt_obs_str << "\n";
+         else            cs << ".\n";
          mlog << Debug(REJECT_DEBUG_LEVEL)
               << "For " << fcst_info->magic_str() << " versus "
               << obs_info->magic_str() << ", skipping lapse rate correction "
               << "due to bad (fcst, obs) elevation (" << fcst_elv << ", "
               << obs_elv << "), data (" << fcst_v << ", "
               << obs_v << "), or lapse rate ("
-              << sfc_info.lapse_rate_correction_value << ") values"
-              << (pnt_obs_str ? ":\n" : ".")
-              << (pnt_obs_str ? pnt_obs_str : "")
-              << "\n";
+              << sfc_info.lapse_rate_correction_value << ") values" << cs;
       }
 
       return false;
@@ -2267,15 +2267,15 @@ bool VxPairBase::convert_msl_agl(const char *pnt_obs_str,
       is_bad_data(corr_f) || is_bad_data(corr_o)) {
 
       if(mlog.verbosity_level() >= REJECT_DEBUG_LEVEL) {
+         ConcatString cs;
+         if(pnt_obs_str) cs << ":\n" << pnt_obs_str << "\n";
+         else            cs << ".\n";
          mlog << Debug(REJECT_DEBUG_LEVEL)
               << "For " << fcst_info->magic_str() << " versus "
               << obs_info->magic_str() << ", skipping msl/agl conversion "
               << "due to bad (fcst, obs) elevation (" << fcst_elv << ", "
               << obs_elv << ") or data (" << fcst_v << ", "
-              << obs_v << ") values"
-              << (pnt_obs_str ? ":\n" : ".")
-              << (pnt_obs_str ? pnt_obs_str : "")
-              << "\n";
+              << obs_v << ") values" << cs;
       }
 
       return false;

--- a/src/libcode/vx_statistics/pair_base.h
+++ b/src/libcode/vx_statistics/pair_base.h
@@ -437,9 +437,13 @@ class VxPairBase {
                                 double, double, double,
                                 const ClimoPntInfo &) const;
 
-      bool correct_lapse_rate(double, double, double &, double &) const;
+      bool correct_lapse_rate(const char *, const char *,
+                              double, double,
+                              double &, double &) const;
 
-      bool convert_msl_agl(double, double, double &, double &,
+      bool convert_msl_agl(const char *, const char *,
+                           double, double,
+                           double &, double &,
                            bool update_obs = true) const;
 
       // Retrieve climo data for this point 

--- a/src/libcode/vx_statistics/pair_data_ensemble.cc
+++ b/src/libcode/vx_statistics/pair_data_ensemble.cc
@@ -1443,8 +1443,7 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
                double obs_v = it->o_na[i_obs];
 
                // MET #3174 Apply lapse rate surface temperature correction
-               if((sfc_info.lapse_rate_correction_apply_to == FieldType::Fcst ||
-                   (sfc_info.lapse_rate_correction_apply_to == FieldType::Obs && member == 0)) &&
+               if(sfc_info.lapse_rate_correction_apply_to != FieldType::None &&
                   (msg_typ_lapsert.all_empty() ||
                    msg_typ_lapsert.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
                   !correct_lapse_rate(nullptr, it->sid_sa[i_obs].c_str(),
@@ -1456,9 +1455,7 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
                }
 
                // MET #3174 Apply MSL/AGL height conversion
-               if((sfc_info.msl_agl_conversion_apply_to == FieldType::Fcst ||
-                   sfc_info.msl_agl_conversion_apply_to == FieldType::Both ||
-                   (sfc_info.msl_agl_conversion_apply_to == FieldType::Obs && member == 0)) &&
+               if(sfc_info.msl_agl_conversion_apply_to != FieldType::None &&
                   (msg_typ_mslagl.all_empty() ||
                    msg_typ_mslagl.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
                   !convert_msl_agl(nullptr, it->sid_sa[i_obs].c_str(),

--- a/src/libcode/vx_statistics/pair_data_ensemble.cc
+++ b/src/libcode/vx_statistics/pair_data_ensemble.cc
@@ -1446,7 +1446,8 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
                if(sfc_info.lapse_rate_correction_apply_to != FieldType::None &&
                   (msg_typ_lapsert.all_empty() ||
                    msg_typ_lapsert.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
-                  !correct_lapse_rate(topo_elv, it->elv_na[i_obs], fcst_v, obs_v)) {
+                  !correct_lapse_rate(nullptr, it->sid_sa[i_obs].c_str(),
+                                      topo_elv, it->elv_na[i_obs], fcst_v, obs_v)) {
 
                   // Skip by resetting to bad data
                   fcst_v = bad_data_double;
@@ -1457,7 +1458,9 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
                if(sfc_info.msl_agl_conversion_apply_to != FieldType::None &&
                   (msg_typ_mslagl.all_empty() ||
                    msg_typ_mslagl.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
-                  !convert_msl_agl(topo_elv, it->elv_na[i_obs], fcst_v, obs_v, member == 0)) {
+                  !convert_msl_agl(nullptr, it->sid_sa[i_obs].c_str(),
+                                   topo_elv, it->elv_na[i_obs], fcst_v, obs_v,
+                                   member == 0)) {
 
                   // Skip by resetting to bad data
                   fcst_v = bad_data_double;

--- a/src/libcode/vx_statistics/pair_data_ensemble.cc
+++ b/src/libcode/vx_statistics/pair_data_ensemble.cc
@@ -1443,7 +1443,8 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
                double obs_v = it->o_na[i_obs];
 
                // MET #3174 Apply lapse rate surface temperature correction
-               if(sfc_info.lapse_rate_correction_apply_to != FieldType::None &&
+               if((sfc_info.lapse_rate_correction_apply_to == FieldType::Fcst ||
+                   (sfc_info.lapse_rate_correction_apply_to == FieldType::Obs && member == 0)) &&
                   (msg_typ_lapsert.all_empty() ||
                    msg_typ_lapsert.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
                   !correct_lapse_rate(nullptr, it->sid_sa[i_obs].c_str(),
@@ -1455,7 +1456,9 @@ void VxPairDataEnsemble::add_ens(int member, bool mn, const Grid &gr) {
                }
 
                // MET #3174 Apply MSL/AGL height conversion
-               if(sfc_info.msl_agl_conversion_apply_to != FieldType::None &&
+               if((sfc_info.msl_agl_conversion_apply_to == FieldType::Fcst ||
+                   sfc_info.msl_agl_conversion_apply_to == FieldType::Both ||
+                   (sfc_info.msl_agl_conversion_apply_to == FieldType::Obs && member == 0)) &&
                   (msg_typ_mslagl.all_empty() ||
                    msg_typ_mslagl.reg_exp_match(it->typ_sa[i_obs].c_str())) &&
                   !convert_msl_agl(nullptr, it->sid_sa[i_obs].c_str(),

--- a/src/libcode/vx_statistics/pair_data_point.cc
+++ b/src/libcode/vx_statistics/pair_data_point.cc
@@ -550,8 +550,8 @@ void VxPairDataPoint::add_point_obs(const float *hdr_arr,
    if(!is_keeper_vld(pnt_obs_str.c_str(), hdr_ut)) return;
 
    // Check observation value
-   double obs_v = obs_arr[4];
-   if(!is_keeper_obs(pnt_obs_str.c_str(), obs_v)) return;
+   double orig_obs_v = obs_arr[4];
+   if(!is_keeper_obs(pnt_obs_str.c_str(), orig_obs_v)) return;
 
    // Check location
    double hdr_lat = hdr_arr[0];
@@ -605,6 +605,9 @@ void VxPairDataPoint::add_point_obs(const float *hdr_arr,
          // Loop through the interpolation methods
          for(int i_interp=0; i_interp<n_interp; i_interp++) {
 
+            // Store observation value
+            double obs_v = orig_obs_v;
+
             // Check climatology values
             ClimoPntInfo cpi;
             if(!is_keeper_climo(pnt_obs_str.c_str(),
@@ -625,7 +628,8 @@ void VxPairDataPoint::add_point_obs(const float *hdr_arr,
             if(sfc_info.lapse_rate_correction_apply_to != FieldType::None &&
                (msg_typ_lapsert.all_empty() ||
                 msg_typ_lapsert.reg_exp_match(hdr_typ_str)) &&
-               !correct_lapse_rate(topo_elv, hdr_elv, fcst_v, obs_v)) {
+               !correct_lapse_rate(pnt_obs_str.c_str(), hdr_sid_str,
+                                   topo_elv, hdr_elv, fcst_v, obs_v)) {
                inc_count(rej_mpr, i_msg_typ, i_mask, i_interp);
                continue;
             }
@@ -634,7 +638,8 @@ void VxPairDataPoint::add_point_obs(const float *hdr_arr,
             if(sfc_info.msl_agl_conversion_apply_to != FieldType::None &&
                (msg_typ_mslagl.all_empty() ||
                 msg_typ_mslagl.reg_exp_match(hdr_typ_str)) &&
-               !convert_msl_agl(topo_elv, hdr_elv, fcst_v, obs_v)) {
+               !convert_msl_agl(pnt_obs_str.c_str(), hdr_sid_str,
+                                topo_elv, hdr_elv, fcst_v, obs_v)) {
                inc_count(rej_mpr, i_msg_typ, i_mask, i_interp);
                continue;
             }


### PR DESCRIPTION
## Expected Differences ##

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>
Corrects existing functionality.

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Tested with the scripts described below.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
- Read through this [issue comment](https://github.com/dtcenter/MET/issues/3270#issuecomment-3488624130).
- Log on to seneca.
- Run the following:
```
cd /d1/projects/MET/MET_pull_requests/met-12.2.0/coordinated/MET-feature_3270_main_v12.2_duplicate_corrections
runas met_test
./test_ps.sh # Look at the log messages grepped out
./test_es.sh # Look at the log messages grepped out
```
Point-Stat obs values are only updated once:
```
DEBUG 8: For station 71109, HGT/P500 versus HGT/P500, converting MSL to AGL using OBS elevations to modify OBS heights from (fcst, obs) (5533.65, 5550) to (5533.65, 5533) for (fcst, obs) elevations (-9999, 17) and filtering threshold NA.
DEBUG 8: For station 71109, HGT/P500 versus HGT/P500, converting MSL to AGL using OBS elevations to modify OBS heights from (fcst, obs) (5533.65, 5550) to (5533.65, 5533) for (fcst, obs) elevations (-9999, 17) and filtering threshold NA.
DEBUG 8: For station 71109, HGT/P500 versus HGT/P500, converting MSL to AGL using OBS elevations to modify OBS heights from (fcst, obs) (5533.65, 5550) to (5533.65, 5533) for (fcst, obs) elevations (-9999, 17) and filtering threshold NA.
DEBUG 8: For station 71109, TMP/Z2 versus TMP/Z2, correcting the OBS temperature from 278.85 to 278.521 for forecast (72.6157) minus observation (22) elevation difference of 50.6157 and lapse rate value of 0.0065.
DEBUG 8: For station 71109, TMP/Z2 versus TMP/Z2, correcting the OBS temperature from 278.85 to 278.521 for forecast (72.6157) minus observation (22) elevation difference of 50.6157 and lapse rate value of 0.0065.
DEBUG 8: For station 71109, TMP/Z2 versus TMP/Z2, correcting the OBS temperature from 278.85 to 278.521 for forecast (72.6157) minus observation (22) elevation difference of 50.6157 and lapse rate value of 0.0065.
```
Ensemble-Stat obs values are only updated once:
```
DEBUG 8: For station K9L2, TMP/Z2 versus TMP/Z2, correcting the OBS temperature from 276.45 to 276.13 for forecast (750.264) minus observation (701) elevation difference of 49.2636 and lapse rate value of 0.0065.
DEBUG 8: For station K9L2, TMP/Z2 versus TMP/Z2, correcting the OBS temperature from 276.45 to 276.13 for forecast (750.264) minus observation (701) elevation difference of 49.2636 and lapse rate value of 0.0065.
DEBUG 8: For station K9L2, TMP/Z2 versus TMP/Z2, correcting the OBS temperature from 276.45 to 276.13 for forecast (750.264) minus observation (701) elevation difference of 49.2636 and lapse rate value of 0.0065.
DEBUG 8: For station 72293, HGT/P500 versus HGT/P500, converting MSL to AGL using OBS elevations to modify OBS heights from (fcst, obs) (5756.08, 5770) to (5756.08, 5633) for (fcst, obs) elevations (-9999, 137) and filtering threshold NA.
DEBUG 8: For station 72293, HGT/P500 versus HGT/P500, converting MSL to AGL using OBS elevations to modify OBS heights from (fcst, obs) (5756.08, 5770) to (5756.08, 5633) for (fcst, obs) elevations (-9999, 137) and filtering threshold NA.
DEBUG 8: For station 72293, HGT/P500 versus HGT/P500, converting MSL to AGL using OBS elevations to modify OBS heights from (fcst, obs) (5756.08, 5770) to (5756.08, 5633) for (fcst, obs) elevations (-9999, 137) and filtering threshold NA.
```
Modify and re-test as you see fit.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**
None needed

- [x] Do these changes include sufficient testing updates? **[No]**
Made no changes to the unit tests.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe:
The 2 issues flagged as being in new code are due to complexity and won't be addressed in this PR.

- [ ] Please complete this pull request review by **[Fill in date]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **METplus-X.Y Support** project for bugfix releases or **MET-X.Y Development** project for the next coordinated release
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
