### PR TITLE
Bugfix #3293 main_v12.2 set_attr_grid

### DIFF
--- a/src/libcode/vx_data2d_factory/data2d_factory_utils.cc
+++ b/src/libcode/vx_data2d_factory/data2d_factory_utils.cc
@@ -181,3 +181,36 @@ return FileType_None;
 ////////////////////////////////////////////////////////////////////////
 
 
+void update_mtddf_grid(Met2dDataFile *mtddf, VarInfo *vinfo)
+
+{
+
+   //
+   // Read the requested data to define the grid for Python and
+   // range/azimuth inputs and when set_attr_grid is specified
+   //
+
+if ( is_python_grdfiletype(mtddf->file_type()) ||
+     mtddf->grid().info().ra                   ||
+     vinfo->grid_attr().is_set() )  {
+
+   DataPlane dp;
+
+   if( !mtddf->data_plane(*vinfo, dp) )  {
+
+      mlog << Error << "\nupdate_mtddf_grid() -> "
+           << "Trouble reading \"" << vinfo->magic_str()
+           << " \"data from input file \""
+           << mtddf->filename() << "\"\n\n";
+      exit(1);
+
+   }
+
+}
+
+return;
+
+}
+
+
+////////////////////////////////////////////////////////////////////////

--- a/src/libcode/vx_data2d_factory/data2d_factory_utils.h
+++ b/src/libcode/vx_data2d_factory/data2d_factory_utils.h
@@ -25,6 +25,8 @@
 
 extern GrdFileType grd_file_type(const char * filename);
 
+extern void update_mtddf_grid(Met2dDataFile *, VarInfo *);
+
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/tools/core/grid_stat/grid_stat.cc
+++ b/src/tools/core/grid_stat/grid_stat.cc
@@ -116,6 +116,7 @@
 //   058    10/03/24  Halley Gotway  MET #2887 Compute weighted contingency tables.
 //   059    11/15/24  Halley Gotway  MET #3020 SEEPS NetCDF output.
 //   060    05/05/24  Halley Gotway  MET #3145 Add OpenMP.
+//   061    12/08/25  Halley Gotway  MET #3293 Fix set_attr_grid.
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -147,13 +148,7 @@
 using namespace std;
 using namespace netCDF;
 
-
 ////////////////////////////////////////////////////////////////////////
-
-
-
-////////////////////////////////////////////////////////////////////////
-
 
 static void process_command_line(int, char **);
 static void setup_first_pass    (const DataPlane &);
@@ -233,7 +228,6 @@ void process_command_line(int argc, char **argv) {
    CommandLine cline;
    GrdFileType ftype, otype;
    ConcatString default_config_file;
-   DataPlane dp;
    const char *method_name = "process_command_line() -> ";
 
    // Set the default output directory
@@ -349,24 +343,9 @@ void process_command_line(int argc, char **argv) {
 #endif
    }
 
-   // For python types and range/azimuth grids, read the first field to set the grid
-   if(is_python_grdfiletype(ftype) ||
-      fcst_mtddf->grid().info().ra) {
-      if(!fcst_mtddf->data_plane(*conf_info.vx_opt[0].fcst_info, dp)) {
-         mlog << Error << "\nTrouble reading data from forecast file \""
-              << fcst_file << "\"\n\n";
-         exit(1);
-      }
-   }
-
-   if(is_python_grdfiletype(otype) ||
-      obs_mtddf->grid().info().ra) {
-      if(!obs_mtddf->data_plane(*conf_info.vx_opt[0].obs_info, dp)) {
-         mlog << Error << "\nTrouble reading data from observation file \""
-              << obs_file << "\"\n\n";
-         exit(1);
-      }
-   }
+   // Update the input grid, if needed
+   update_mtddf_grid(fcst_mtddf, conf_info.vx_opt[0].fcst_info);
+   update_mtddf_grid(obs_mtddf, conf_info.vx_opt[0].obs_info);
 
    // Determine the verification grid
    grid = parse_vx_grid(conf_info.vx_opt[0].fcst_info->regrid(),

--- a/src/tools/core/wavelet_stat/wavelet_stat.cc
+++ b/src/tools/core/wavelet_stat/wavelet_stat.cc
@@ -41,6 +41,7 @@
 //   016    10/03/22  Prestopnik      MET #2227 Remove using namespace netCDF from header files
 //   017    01/29/24  Halley Gotway   MET #2801 Configure time difference warnings
 //   018    05/07/25  Halley Gotway   MET #3145 Add OpenMP
+//   019    12/08/25  Halley Gotway   MET #3293 Fix set_attr_grid.
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -165,7 +166,6 @@ static void process_command_line(int argc, char **argv) {
    CommandLine cline;
    GrdFileType ftype, otype;
    ConcatString default_config_file;
-   DataPlane dp;
 
    // Set the default output directory
    out_dir = replace_path(default_out_dir);
@@ -231,24 +231,9 @@ static void process_command_line(int argc, char **argv) {
    // Process the configuration
    conf_info.process_config(ftype, otype);
 
-   // For python types and range/azimuth grids, read the first field to set the grid
-   if(is_python_grdfiletype(ftype) ||
-      fcst_mtddf->grid().info().ra) {
-      if(!fcst_mtddf->data_plane(*conf_info.fcst_info[0], dp)) {
-         mlog << Error << "\nTrouble reading data from forecast file \""
-              << fcst_file << "\"\n\n";
-         exit(1);
-      }
-   }
-
-   if(is_python_grdfiletype(otype) ||
-      obs_mtddf->grid().info().ra) {
-      if(!obs_mtddf->data_plane(*conf_info.obs_info[0], dp)) {
-         mlog << Error << "\nTrouble reading data from observation file \""
-              << obs_file << "\"\n\n";
-         exit(1);
-      }
-   }
+   // Update the input grid, if needed
+   update_mtddf_grid(fcst_mtddf, conf_info.fcst_info[0]);
+   update_mtddf_grid(obs_mtddf, conf_info.obs_info[0]);
 
    // Determine the verification grid
    grid = parse_vx_grid(conf_info.fcst_info[0]->regrid(),

--- a/src/tools/other/regrid_data_plane/regrid_data_plane.cc
+++ b/src/tools/other/regrid_data_plane/regrid_data_plane.cc
@@ -25,6 +25,7 @@
 //   005    04-09-20  Halley Gotway  Add convert and censor options.
 //   006    07-06-22  Howard Soh     METplus-Internal #19 Rename main to met_main
 //   007    09-29-22  Prestopnik     MET #2227 Remove namespace std and netCDF from header files
+//   008    12-08-25  Halley Gotway  MET #3293 Fix set_attr_grid.
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -254,8 +255,7 @@ void process_data_file() {
 
    // Setup the VarInfo request object
    VarInfoFactory v_factory;
-   VarInfo *vinfo;
-   vinfo = v_factory.new_var_info(ftype);
+   VarInfo *vinfo = v_factory.new_var_info(ftype);
 
    if(!vinfo) {
       mlog << Error << "\nprocess_data_file() -> "
@@ -263,18 +263,11 @@ void process_data_file() {
            << "\"\n\n";
       exit(1);
    }
+   config.read_string(FieldSA[0].c_str());
+   vinfo->set_dict(config);
 
-   // For python types and range/azimuth grids, read the first field to set the grid
-   if(is_python_grdfiletype(ftype) ||
-      fr_mtddf->grid().info().ra) {
-      config.read_string(FieldSA[0].c_str());
-      vinfo->set_dict(config);
-      if(!fr_mtddf->data_plane(*vinfo, fr_dp)) {
-         mlog << Error << "\nTrouble reading data from file \""
-              << InputFilename << "\"\n\n";
-         exit(1);
-      }
-   }
+   // Update the input grid, if needed
+   update_mtddf_grid(fr_mtddf, vinfo);
 
    fr_grid = fr_mtddf->grid();
    mlog << Debug(2) << "Input grid: " << fr_grid.serialize() << "\n";


### PR DESCRIPTION
Same changes as PR #3299 but for the `main_v12.2` branch instead of `develop` without the update to the Grid-Stat unit test. Please review these PR's at the same time.

Please find the code for this PR compiled for your testing in:
`seneca:/d1/projects/MET/MET_pull_requests/met-12.2.1/MET-bugfix_3293_main_v12.2_set_attr_grid`