### PR TITLE
Bugfix #3353 develop sum_file_type

### DIFF
--- a/internal/scripts/docker/build_met_docker.sh
+++ b/internal/scripts/docker/build_met_docker.sh
@@ -16,6 +16,23 @@ if [ -z ${MET_CONFIG_OPTS+x} ]; then
   echo "Setting MET_CONFIG_OPTS=${MET_CONFIG_OPTS} to compile all available options."
 fi
 
+# Check that required MET_PYTHON environment variables
+# have been set by METbaseimage
+if [[ -z "${MET_PYTHON_BIN_EXE}" ||
+      -z "${MET_PYTHON_CC}"      ||
+      -z "${MET_PYTHON_LD}" ]]; then
+  echo
+  echo "ERROR: Required Python environment variable(s) unset:"
+  echo "ERROR: \${MET_PYTHON_BIN_EXE}, \${MET_PYTHON_CC}, \${MET_PYTHON_LD}"
+  echo
+  exit 1
+else
+  echo "Using Python environment:"
+  echo "MET_PYTHON_BIN_EXE=${MET_PYTHON_BIN_EXE}"
+  echo "MET_PYTHON_CC=${MET_PYTHON_CC}"
+  echo "MET_PYTHON_LD=${MET_PYTHON_LD}"
+fi
+
 # Create log directory
 mkdir -p /met/logs
 

--- a/internal/scripts/environment/development.docker
+++ b/internal/scripts/environment/development.docker
@@ -1,15 +1,11 @@
 # Define the development environment for Docker
+# MET_PYTHON settings defined in METbaseimage
 
 # Top-level MET project directory
 MET_PROJ_DIR=`ls -1d /met/MET*`
 
 # Variables required to build MET
 export MET_DEVELOPMENT=true
-
-export MET_PYTHON=/usr/local
-export MET_PYTHON_BIN_EXE=${MET_PYTHON}/bin/python3
-export MET_PYTHON_CC="-I${MET_PYTHON}/include/python3.12"
-export MET_PYTHON_LD="-L${MET_PYTHON}/lib -lpython3.12 -lcrypt -lpthread -ldl -lutil -lm"
 
 export CFLAGS="-DUNDERSCORE -fPIC"
 export CXXFLAGS=${CFLAGS}

--- a/internal/test_unit/xml/unit_pcp_combine.xml
+++ b/internal/test_unit/xml/unit_pcp_combine.xml
@@ -73,6 +73,22 @@
     </output>
   </test>
 
+  <!-- MET #3353 sum command with bad file type returns bad status of 1 -->
+  <!--           the input files are acually GRIB1, not GRIB2           -->
+
+  <test name="pcp_combine_sum_BAD_FILE_TYPE">
+    <exec>&MET_BIN;/pcp_combine</exec>
+    <retval>1</retval>
+    <param> \
+      20120409_00 3 20120409_18 18 \
+      &OUTPUT_DIR;/pcp_combine/nam_2012040900_F018_APCP18.nc \
+      -pcpdir &DATA_DIR_MODEL;/grib1/nam \
+      -field 'name="APCP"; level="A3"; file_type=GRIB2;'
+    </param>
+    <output>
+    </output>
+  </test>
+
   <!--                                    -->
   <!--  pcp_combine -add                  -->
   <!--                                    -->

--- a/src/tools/core/pcp_combine/pcp_combine.cc
+++ b/src/tools/core/pcp_combine/pcp_combine.cc
@@ -80,6 +80,7 @@
 //   026    01/29/24  Halley Gotway  MET #2801 Configure time difference warnings.
 //   027    05/09/24  Halley Gotway  MET #2883 Allow missing input files.
 //   028    04/30/25  Prestopnik     MET #3120 Add OpenMP 
+//   029    02/26/26  Halley Gotway  MET #3342 Support file_type for sum
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -778,9 +779,18 @@ static int search_pcp_dir(const char *cur_dir, const unixtime cur_ut,
          cur_file << cs_erase << cur_dir << '/' << dirp->d_name;
 
          //
+         // MET #3342: Parse the file type from the field string, if present.
+         //
+         GrdFileType ftype = FileType_None;
+         if(field_string.nonempty()) {
+            config.read_string(field_string.c_str());
+            ftype = parse_conf_file_type(&config);
+         }
+
+         //
          // Create a data file object.
          //
-         auto mtddf = Met2dDataFileFactory::new_met_2d_data_file(cur_file.c_str());
+         auto mtddf = factory.new_met_2d_data_file(cur_file.c_str(), ftype);
          if(!mtddf) {
             mlog << Warning << "search_pcp_dir() -> "
                  << "can't open data file \"" << cur_file << "\"\n";

--- a/src/tools/core/pcp_combine/pcp_combine.cc
+++ b/src/tools/core/pcp_combine/pcp_combine.cc
@@ -80,7 +80,7 @@
 //   026    01/29/24  Halley Gotway  MET #2801 Configure time difference warnings.
 //   027    05/09/24  Halley Gotway  MET #2883 Allow missing input files.
 //   028    04/30/25  Prestopnik     MET #3120 Add OpenMP 
-//   029    02/26/26  Halley Gotway  MET #3342 Support file_type for sum
+//   029    02/26/26  Halley Gotway  MET #3353 Support file_type for sum
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -779,7 +779,7 @@ static int search_pcp_dir(const char *cur_dir, const unixtime cur_ut,
          cur_file << cs_erase << cur_dir << '/' << dirp->d_name;
 
          //
-         // MET #3342: Parse the file type from the field string, if present.
+         // MET #3353: Parse the file type from the field string, if present.
          //
          GrdFileType ftype = FileType_None;
          if(field_string.nonempty()) {

--- a/src/tools/core/pcp_combine/pcp_combine.cc
+++ b/src/tools/core/pcp_combine/pcp_combine.cc
@@ -790,7 +790,7 @@ static int search_pcp_dir(const char *cur_dir, const unixtime cur_ut,
          //
          // Create a data file object.
          //
-         auto mtddf = factory.new_met_2d_data_file(cur_file.c_str(), ftype);
+         auto mtddf = Met2dDataFileFactory::new_met_2d_data_file(cur_file.c_str(), ftype);
          if(!mtddf) {
             mlog << Warning << "search_pcp_dir() -> "
                  << "can't open data file \"" << cur_file << "\"\n";


### PR DESCRIPTION
## Expected Differences ##

This PR proposes changes to 4 files:
- [2] `build_met_docker.sh` and `development.docker` are updated to compile using the newly updated METbaseimage version 3.4.9 which now defines the `MET_PYTHON_...` environment variables. Since METbaseimage defines the Python version to be used, we moved those env vars inside there rather than needing to update the MET environment each time the python version changes.
- [2] `pcp_combine.cc` fixes the bug by parsing `file_type` from the `-field` string, if defined.
- [1] `unit_pcp_combine.cc` adds a new unit test, described below.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Tested manually to confirm that the *correct* setting of `file_type` produces a successful result while an *incorrect* setting produces an expected failure.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Please test the updated PCP-Combine logic as you see fit i:
```
seneca:/d1/projects/MET/MET_pull_requests/met-13.0.0/beta2/MET-bugfix_3353_develop_sum_file_type
```

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [x] Do these changes include sufficient testing updates? **[Yes]**

Note that I added 1 new test to `unit_pcp_combine.xml`. This runs the sum command, but supplies the WRONG `file_type` setting. It sets it to `GRIB2` when the input files are actually `GRIB1`. This results in an expected error and bad return status. But the test still succeeds because I specify the expected `retval` of 1.

I initially wanted to test this in the affirmative rather than the negative, but we don't have any existing appropriate input data to do so. Rather than creating or adding new "bad" data, I chose to test the negative instead.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [x] Do these changes introduce new SonarQube findings? **[Not really]**</br>
If **yes**, please describe:
The one existing issue flagged as being in new code can be safely ignored for this bugfix.

- [x] Please complete this pull request review by **[Fri, Feb 27, 2026]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **METplus-X.Y Support** project for bugfix releases or **MET-X.Y Development** project for the next coordinated release
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
