### PR TITLE
Bugfix #3362 develop seeps_pairs_nc

### DIFF
--- a/.github/workflows/build_docker_and_trigger_metplus.yml
+++ b/.github/workflows/build_docker_and_trigger_metplus.yml
@@ -19,14 +19,14 @@ jobs:
     name: Handle Docker Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get branch name
         id: get_branch_name
         run: echo branch_name=${GITHUB_REF#refs/heads/} >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/compilation_options.yml
+++ b/.github/workflows/compilation_options.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set job controls
         id: job_status
         run: .github/jobs/set_job_controls.sh
@@ -71,13 +71,13 @@ jobs:
             config: '--disable-openmp'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create directories to store output
         run: mkdir -p ${RUNNER_WORKSPACE}/logs
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/logs

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,8 +18,8 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.8'
       - name: Install dependencies
@@ -29,12 +29,12 @@ jobs:
           python -m pip install -r docs/requirements.txt
       - name: Build docs
         run: ./.github/jobs/build_documentation.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: documentation
           path: artifact/documentation
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: documentation_warnings.log

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Scan Docker Images
         id: security-scan
         continue-on-error: false
-        uses: dtcenter/metplus-action-scan-docker-images@v1
+        uses: dtcenter/metplus-action-scan-docker-images@v2
         with:
           images: |
             [

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -35,7 +35,7 @@ jobs:
       update_latest: ${{ steps.get-versions.outputs.update_latest }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'dtcenter/metplus'
           ref: 'develop'
@@ -80,9 +80,9 @@ jobs:
       - name: Free Disk Space
         uses: dtcenter/metplus-action-free-disk-space@v1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ matrix.version }}
           path: ${{ matrix.version }}
@@ -93,7 +93,7 @@ jobs:
         run: mkdir -p ${RUNNER_WORKSPACE}/logs
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload build logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build_logs_${{ matrix.version }}
           path: ${{ runner.workspace }}/logs

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Disable shallow clones for better analysis
           fetch-depth: 0
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_sonarqube
           path: ${{ runner.workspace }}/logs

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set job controls
         id: job_status
         run: .github/jobs/set_job_controls.sh
@@ -76,13 +76,13 @@ jobs:
     needs: job_control
     if: ${{ needs.job_control.outputs.run_compile == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create directories to store output
         run: mkdir -p ${RUNNER_WORKSPACE}/logs
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_compile
           path: ${{ runner.workspace }}/logs
@@ -122,7 +122,7 @@ jobs:
     if: ${{ needs.job_control.outputs.run_unit_tests == 'true' }}
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -151,7 +151,7 @@ jobs:
             tests: 'pb2nc madis2nc pcp_combine gen_ens_prod regrid'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space
         uses: dtcenter/metplus-action-free-disk-space@v1
@@ -164,14 +164,14 @@ jobs:
           INPUT_DATA_VERSION: ${{ needs.job_control.outputs.input_data_version }}-all
 
       - name: Upload output as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit_1a_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/output
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_unit_1a_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/logs
@@ -191,7 +191,7 @@ jobs:
             tests: 'met_test_scripts mode_multivar mtd airnow gsi_tools netcdf modis series_analysis wwmca_regrid gen_vx_mask interp_shape grid_diag grib_tables lidar2nc shift_data_plane trmm2nc aeronet wwmca_plot ioda2nc gaussian'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space
         uses: dtcenter/metplus-action-free-disk-space@v1
@@ -204,14 +204,14 @@ jobs:
           INPUT_DATA_VERSION: ${{ needs.job_control.outputs.input_data_version }}-all
 
       - name: Upload output as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit_1b_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/output
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_unit_1b_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/logs
@@ -233,7 +233,7 @@ jobs:
             tests: 'ref_config_lead_36'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space
         uses: dtcenter/metplus-action-free-disk-space@v1
@@ -246,14 +246,14 @@ jobs:
           INPUT_DATA_VERSION: ${{ needs.job_control.outputs.input_data_version }}-all
 
       - name: Upload output as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit_1c_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/output
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_rc_leads_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/logs
@@ -271,13 +271,13 @@ jobs:
             tests: 'ref_config'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space
         uses: dtcenter/metplus-action-free-disk-space@v1
 
       - name: Download ref_config_leads output from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.workspace }}/output
           pattern: unit_1c_job*
@@ -291,14 +291,14 @@ jobs:
           INPUT_DATA_VERSION: 'none'
 
       - name: Upload output as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit_2c_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/output
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_unit_2c_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/logs
@@ -326,13 +326,13 @@ jobs:
             tests: 'grid_weight point_weight'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space
         uses: dtcenter/metplus-action-free-disk-space@v1
 
       - name: Download 1a output from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.workspace }}/output
           pattern: unit_1a_job*
@@ -346,14 +346,14 @@ jobs:
           INPUT_DATA_VERSION: ${{ needs.job_control.outputs.input_data_version }}-all
 
       - name: Upload output as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit_2a_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/output
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_unit_2a_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/logs
@@ -379,13 +379,13 @@ jobs:
             tests: 'python point2grid plot_data_plane mode mode_analysis perc_thresh hira plot_point_obs quality_filter obs_summary duplicate_flag'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space
         uses: dtcenter/metplus-action-free-disk-space@v1
 
       - name: Download 1a output from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.workspace }}/output
           pattern: unit_1a_job*
@@ -399,14 +399,14 @@ jobs:
           INPUT_DATA_VERSION: ${{ needs.job_control.outputs.input_data_version }}-all
 
       - name: Upload output as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit_2b_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/output
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_unit_2b_${{ matrix.jobid }}
           path: ${{ runner.workspace }}/logs
@@ -419,14 +419,14 @@ jobs:
     if: ${{ needs.job_control.outputs.run_diff == 'true' }}
     steps:
       - name: Download data from previous jobs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Copy test output into single directory
         run: |
           mkdir ${RUNNER_WORKSPACE}/output
           cp -r unit_*/* ${RUNNER_WORKSPACE}/output/
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Diff Tests in Docker
         run: .github/jobs/run_diff_docker.sh
@@ -437,7 +437,7 @@ jobs:
 
       - name: Upload diff files as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: diff
           path: ${{ runner.workspace }}/diff
@@ -445,7 +445,7 @@ jobs:
 
       - name: Upload logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs_diff
           path: ${{ runner.workspace }}/logs
@@ -458,7 +458,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Upload merged logs as artifact
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs
           pattern: logs_*
@@ -470,13 +470,13 @@ jobs:
     needs: [job_control, unit_1b, unit_2a, unit_2b, unit_2c]
     if: ${{ needs.job_control.outputs.run_update_truth == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free disk space
         uses: dtcenter/metplus-action-free-disk-space@v1
 
       - name: Download data from previous jobs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Copy test output into single directory
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -458,7 +458,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Upload merged logs as artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact/merge@v7
         with:
           name: logs
           pattern: logs_*

--- a/.github/workflows/update_truth.yml
+++ b/.github/workflows/update_truth.yml
@@ -26,7 +26,7 @@ jobs:
           fi
           echo ERROR: Branch is $branch_name - must be develop or match main_vX.Y
           exit 1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Checkout repository
         with:
           fetch-depth: 0

--- a/internal/test_unit/config/GridStatConfig_SEEPS
+++ b/internal/test_unit/config/GridStatConfig_SEEPS
@@ -67,7 +67,19 @@ fcst = {
       }
    ];
 }
-obs = fcst;
+obs = {
+   field = [
+      {
+         name = "precipitation_amount";
+         level = [ "(*,*)" ];
+         is_precipitation = TRUE;
+         set_attr_init = "20211201_00";
+         set_attr_valid = "20211202_00";
+         set_attr_accum = "24";
+      }
+   ];
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/libcode/vx_statistics/compute_stats.cc
+++ b/src/libcode/vx_statistics/compute_stats.cc
@@ -1492,7 +1492,7 @@ void compute_ecnt_mean(const ECNTInfo *ecnt_info, int n,
 ////////////////////////////////////////////////////////////////////////
 
 void compute_aggregated_seeps(const PairDataPoint *pd, SeepsAggScore *seeps_agg) {
-   static const char *method_name = "compute_seeps_agg() -> ";
+   static const char *method_name = "compute_aggregated_seeps() -> ";
 
    //
    // Check that the forecast and observation arrays of the same length
@@ -1848,35 +1848,6 @@ void compute_aggregated_seeps_grid(const DataPlane &fcst_dp, const DataPlane &ob
 
 }
 
-////////////////////////////////////////////////////////////////////////
-// IDL code:
-//
-// my_pi = 3.1415926
-// r0 = density_radius*my_pi/180
-// lat =  reform(float(data_geo(0,*)))
-// lon =  reform( ((float(data_geo(1,*)+360.) mod 360.)))
-// n = n_elements(lat)
-// lat = lat * my_pi / 180
-// slat = sin(lat)
-// clat = cos(lat)
-// lon = lon * my_pi / 180
-// slon = sin(lon)
-// clon = cos(lon)
-// r=(clat#transpose(clat))*(slon#transpose(slon)) + (clon#transpose(clon))*(slat#transpose(slat))
-// r=r*((r lt 1.) and (r gt -1.)) + (r ge 1.) - (r le -1.)
-// r=acos(r)
-// if r0 gt 0.0 then r = exp( -(r / r0) ^ 2) * ( r le 4. * r0) else r = (r*0.) + 1
-// r=sum(r,1)
-//
-// SUM function (not built-in)
-// PRINT, array2
-// ; PV-WAVE prints the following:
-// ; 0.00000      1.00000
-// ; 2.00000      3.00000
-// PRINT, SUM(array2, 0)
-// ; PV-WAVE prints: 1.00000      5.00000
-// PRINT, SUM(array2, 1)
-// ; PV-WAVE prints: 2.00000      4.00000
 ////////////////////////////////////////////////////////////////////////
 
 void compute_seeps_density_vector(const PairDataPoint *pd, SeepsAggScore *seeps,

--- a/src/libcode/vx_statistics/compute_stats.cc
+++ b/src/libcode/vx_statistics/compute_stats.cc
@@ -1699,9 +1699,11 @@ void compute_aggregated_seeps_grid(const DataPlane &fcst_dp, const DataPlane &ob
    double obs_sum = 0.0;
    double fcst_sum = 0.0;
 
-   seeps_dp.set_size(nx, ny);
-   seeps_dp_fcat.set_size(nx, ny);
-   seeps_dp_ocat.set_size(nx, ny);
+   // MET #3362: Initialize dimensions and timing info
+   seeps_dp = fcst_dp;
+   seeps_dp.set_constant(0.0);
+   seeps_dp_fcat = seeps_dp;
+   seeps_dp_ocat = seeps_dp;
 
    seeps_agg->clear();
    mlog << Debug(9) << method_name


### PR DESCRIPTION
Same changes as PR #3363 but for `develop` instead of `main_v12.2`. Please review them at the same time.

In addition, this PR modifies the existing Grid-Stat unit test configuration to use `set_attr_valid`, `set_attr_init`, and `set_attr_accum` to correct the metadata that's read from the observation file.

Please find the code compiled on seneca in:
```
/d1/projects/MET/MET_pull_requests/met-13.0.0/beta2/MET-bugfix_3362_develop_seeps_pairs_nc
```

The timing information of all output files for the Grid-Stat SEEPS unit test (`.stat` and `_pairs.nc`) will be impacted by this change.

> [!NOTE]
> I found that NetCDF variable attribute differences are NOT currently flagged by the METplus diffing logic. Work to update the METplus diffing logic is in progress in the [bugfix_MET_3362_diff_nc_var_att](https://github.com/dtcenter/METplus/tree/bugfix_MET_3362_diff_nc_var_att) branch.