### PR TITLE
Bugfix #3370 main_v12.2 tc_rmw BEST tracks

### DIFF
--- a/src/tools/tc_utils/tc_rmw/tc_rmw.cc
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw.cc
@@ -341,6 +341,12 @@ void process_track_files(const StringArray& files,
     // Initialize counts
     tot_read = tot_add = 0;
 
+    // Set metadata pointer
+    StringArray BestTechnique;
+    BestTechnique.add("BEST");
+    BestTechnique.set_ignore_case(true);
+    line.set_best_technique(&BestTechnique);
+
     // Process input ATCF files
     for(int i = 0; i < files.n(); i++) {
 

--- a/src/tools/tc_utils/tc_rmw/tc_rmw.cc
+++ b/src/tools/tc_utils/tc_rmw/tc_rmw.cc
@@ -20,6 +20,7 @@
 //   003   09/28/22  Prestopnik      MET #2227 Remove namspace std and netCDF from header files
 //   004   04/26/23  Halley Gotway   MET #2523 Reorder NetCDF dimensions
 //   005   03/11/24  Halley Gotway   MET #2833 range/azimuth grid
+//   006   04/13/26  Halley Gotway   MET #3370 check for analysis tracks
 //
 ////////////////////////////////////////////////////////////////////////
 
@@ -372,7 +373,8 @@ void process_track_files(const StringArray& files,
             if(!is_keeper(&line)) continue;
 
             // Attempt to add current line to TrackInfoArray
-            if(tracks.add(line, true, false)) {
+            // MET #3370 check for analysis tracks
+            if(tracks.add(line, true, true)) {
                 cur_add++;
                 tot_add++;
             }


### PR DESCRIPTION
Note that this is similar to the changes for PR #3372 but for the main_v12.2 branch rather than develop and much more limited in scope.

This changes only `tc_rmw.cc` in 2 ways:
1. In the call the `tracks.add(...)` change the last `false` to a `true` to tell the library code to check for "analysis" tracks.
2. Above that, call `ATCFLine::set_best_technique(...)` to hard-code `BEST` as the expected name for best tracks. This should enable BEST tracks to be parsed well, even when the minutes are non-zero.

Please find the code for this PR compiled and available for testing in `seneca:/d1/projects/MET/MET_pull_requests/met-12.2.2/MET-bugfix_3370_main_v12.2_tc_rmw_best_tracks/bin`.

Please review this at the same time as #3372.