### PR TITLE
Bugfix #3374 main_v12.2 false_easting_northing

### DIFF
--- a/internal/test_unit/python/comp_dir.py
+++ b/internal/test_unit/python/comp_dir.py
@@ -14,7 +14,7 @@ except TypeError as e:
     raise e
 sys.path.append(metplus_util_path)
 
-from diff_util import compare_dir
+import diff_util as du
 
 
 def comp_dir(truth_dir, output_dir, debug=True, save_diff=True):
@@ -43,11 +43,15 @@ def comp_dir(truth_dir, output_dir, debug=True, save_diff=True):
     """
 
     start_time = dt.datetime.now()
+
+    # Custom rounding overrides for MET unit test output
+    du.ROUNDING_OVERRIDES['ALAL2010_stat.out'] = 4
+
     print('******************************')
     print("Comparing output to truth data")
-    diff_files = compare_dir(truth_dir, output_dir,
-                             debug=debug,
-                             save_diff=save_diff)
+    diff_files = du.compare_dir(truth_dir, output_dir,
+                                debug=debug,
+                                save_diff=save_diff)
     
     end_time = dt.datetime.now()
     runtime = end_time - start_time

--- a/src/libcode/vx_data2d_nc_cf/nc_cf_file.cc
+++ b/src/libcode/vx_data2d_nc_cf/nc_cf_file.cc
@@ -1912,6 +1912,20 @@ void NcCfFile::get_grid_mapping_lambert_conformal_conic(const NcVar *grid_mappin
     return;
   }
 
+  // false_easting, optional
+
+  double false_east = get_nc_var_att_double(
+    grid_mapping_var, "false_easting", false);
+
+  if(is_bad_data(false_east)) false_east = 0.0;
+
+  // false_northing, optional
+
+  double false_north = get_nc_var_att_double(
+    grid_mapping_var, "false_northing", false);
+
+  if(is_bad_data(false_north)) false_north = 0.0;
+
   // Look for the x/y dimensions and x/y coordinate variables
   find_xy_vars(method_name);
 
@@ -1987,10 +2001,11 @@ void NcCfFile::get_grid_mapping_lambert_conformal_conic(const NcVar *grid_mappin
 
   get_nc_data(_yCoordVar, y_values.data());
 
-  // Unit conversion
+  // MET #3374 Support false easting and northing offsets
+  // Unit conversion and false northing and easting offsets
 
-  for (int i = 0; i<x_counts; ++i) x_values[i] *= x_coord_to_m_cf;
-  for (int i = 0; i<y_counts; ++i) y_values[i] *= y_coord_to_m_cf;
+  for (int i = 0; i<x_counts; ++i) x_values[i] = x_values[i] * x_coord_to_m_cf - false_east;
+  for (int i = 0; i<y_counts; ++i) y_values[i] = y_values[i] * y_coord_to_m_cf - false_north;
 
   // Calculate dx and dy assuming they are constant.  MET requires that dx be
   // equal to dy

--- a/src/libcode/vx_regrid/vx_regrid_budget.cc
+++ b/src/libcode/vx_regrid/vx_regrid_budget.cc
@@ -32,7 +32,7 @@ DataPlane met_regrid_budget(const DataPlane & from_data,
    const double delta = 1.0/N;
 
 #pragma omp parallel default(none) \
-   shared(from_data, from_grid, to_grid, info, to_data) \
+   shared(from_data, from_grid, to_grid, info, to_data, delta) \
    private(count, value, sum)
    {
 


### PR DESCRIPTION
## Expected Differences ##

This PR makes 2 small changes.
1. Tweak OpenMP call in one file that was causing a compilation error on Casper.
2. Update NCCF library logic to parse and apply false_easting and false_northing for lambert conformal conic projections.

While supporting false_easting and false_northing for other projection types may also be an issue, I'm only fixing the problem at hand. We'd really need data to demonstrate other issues and the better long term switch is migrating to Proj grids, as described in issue #2486.

- [x] Do these changes introduce new tools, command line arguments, or configuration file options? **[No]**</br>
If **yes**, please describe:</br>

- [x] Do these changes modify the structure of existing or add new output data types (e.g. statistic line types or NetCDF variables)? **[No]**</br>
If **yes**, please describe:</br>

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
Manually tested with `plot_data_plane` to confirm that the data is now placed correctly over North America.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
Please review this PR at the same time as #3375, which makes the same changes to the `develop` branch but also adds a new unit test. Review the output of the new unit test to confirm the expected grid location/orientation.

Please find this code available for your testing in: `seneca:/d1/projects/MET/MET_pull_requests/met-12.2.2/MET-bugfix_3374_main_v12.2_false_easting_northing/bin`.

- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[Yes]**

- [x] Do these changes include sufficient testing updates? **[Yes]**
No doc updates needed since it is already assumed that MET support CF-convention NetCDF files well.

- [x] Will this PR result in changes to the MET test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Will this PR result in changes to existing METplus Use Cases? **[No]**</br>
If **yes**, create a new **Update Truth** [METplus issue](https://github.com/dtcenter/METplus/issues/new/choose) to describe them.

- [ ] Do these changes introduce new SonarQube findings? **[Yes or No]**</br>
If **yes**, please describe:

- [x] Please complete this pull request review by **[Wed 4/29/26]**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [x] Review the source issue metadata (required labels, projects, and milestone).
- [x] Complete the PR definition above.
- [x] Ensure the PR title matches the feature or bugfix branch name.
- [x] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **METplus-X.Y Support** project for bugfix releases or **MET-X.Y Development** project for the next coordinated release
- [x] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
