### PR TITLE
Bugfix #3429 develop obs_error_table_lookup

### DIFF
--- a/docs/Users_Guide/config_options.rst
+++ b/docs/Users_Guide/config_options.rst
@@ -373,6 +373,13 @@ values and randomly perturbed ensemble member values. Values less than MIN are
 reset to the minimum value and values greater than MAX are reset to the maximum
 value. A value of NA indicates that the variable is unbounded.
 
+If the observation error table contains no entries for the variable being
+evaluated, MET prints a warning message and disables the observation error
+logic. If the table does contain entries for the variable, but the lookup for
+an individual observation fails, that observation is excluded from the analysis.
+This situation would occur, for example, when the observation value falls outside
+the range of values in the VAL_RANGE column.
+
 MET_GRIB_TABLES
 ---------------
 

--- a/internal/test_unit/unit_ensemble_stat.sh
+++ b/internal/test_unit/unit_ensemble_stat.sh
@@ -1,0 +1,277 @@
+export 'DESC=NA'
+export 'OBS_ERROR_FLAG=FALSE'
+export 'OUTPUT_PREFIX=CMD_LINE'
+export 'SKIP_CONST=FALSE'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      6 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep1/arw-fer-gep1_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep5/arw-fer-gep5_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep2/arw-sch-gep2_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep6/arw-sch-gep6_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep7/arw-tom-gep7_2012040912_F024.grib \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/obs_data/laps/laps_2012041012_F000.grib \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ascii2nc/gauge_2012041012_24hr.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset OBS_ERROR_FLAG
+unset OUTPUT_PREFIX
+unset SKIP_CONST
+
+
+export 'DESC=NA'
+export 'OBS_ERROR_FLAG=FALSE'
+export 'OUTPUT_PREFIX=FILE_LIST'
+export 'SKIP_CONST=FALSE'
+echo "/d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep1/arw-fer-gep1_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep5/arw-fer-gep5_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep2/arw-sch-gep2_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep6/arw-sch-gep6_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep7/arw-tom-gep7_2012040912_F024.grib" \
+                > /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat/input_file_list; \
+          /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat/input_file_list \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/obs_data/laps/laps_2012041012_F000.grib \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ascii2nc/gauge_2012041012_24hr.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset OBS_ERROR_FLAG
+unset OUTPUT_PREFIX
+unset SKIP_CONST
+
+
+export 'CENSOR_THRESH='
+export 'CENSOR_VAL='
+export 'CONFIG_DIR=${MET_TEST_BASE}/config'
+export 'OUTPUT_PREFIX=MASK_SID'
+export 'SKIP_CONST=FALSE'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      6 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep1/arw-fer-gep1_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep5/arw-fer-gep5_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep2/arw-sch-gep2_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep6/arw-sch-gep6_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep7/arw-tom-gep7_2012040912_F024.grib \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_MASK_SID \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ascii2nc/gauge_2012041012_24hr.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset CENSOR_THRESH
+unset CENSOR_VAL
+unset CONFIG_DIR
+unset OUTPUT_PREFIX
+unset SKIP_CONST
+
+
+export 'CENSOR_THRESH='
+export 'CENSOR_VAL='
+export 'CONFIG_DIR=${MET_TEST_BASE}/config'
+export 'OUTPUT_PREFIX=MASK_SID_CTRL'
+export 'SKIP_CONST=FALSE'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      5 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep5/arw-fer-gep5_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep2/arw-sch-gep2_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep6/arw-sch-gep6_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep7/arw-tom-gep7_2012040912_F024.grib \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_MASK_SID \
+      -ctrl /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep1/arw-fer-gep1_2012040912_F024.grib \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ascii2nc/gauge_2012041012_24hr.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset CENSOR_THRESH
+unset CENSOR_VAL
+unset CONFIG_DIR
+unset OUTPUT_PREFIX
+unset SKIP_CONST
+
+
+export 'CENSOR_THRESH=lt0, gt5'
+export 'CENSOR_VAL=  0,   5'
+export 'CONFIG_DIR=${MET_TEST_BASE}/config'
+export 'OUTPUT_PREFIX=MASK_SID_CENSOR'
+export 'SKIP_CONST=FALSE'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      6 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep1/arw-fer-gep1_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep5/arw-fer-gep5_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep2/arw-sch-gep2_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep6/arw-sch-gep6_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep7/arw-tom-gep7_2012040912_F024.grib \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_MASK_SID \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ascii2nc/gauge_2012041012_24hr.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset CENSOR_THRESH
+unset CENSOR_VAL
+unset CONFIG_DIR
+unset OUTPUT_PREFIX
+unset SKIP_CONST
+
+
+export 'DESC=SKIP_CONST'
+export 'OBS_ERROR_FLAG=FALSE'
+export 'OUTPUT_PREFIX=SKIP_CONST'
+export 'SKIP_CONST=TRUE'
+echo "/d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep1/arw-fer-gep1_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep5/arw-fer-gep5_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep2/arw-sch-gep2_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep6/arw-sch-gep6_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep7/arw-tom-gep7_2012040912_F024.grib" \
+                > /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat/input_file_list; \
+          /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat/input_file_list \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/obs_data/laps/laps_2012041012_F000.grib \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ascii2nc/gauge_2012041012_24hr.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset OBS_ERROR_FLAG
+unset OUTPUT_PREFIX
+unset SKIP_CONST
+
+
+export 'DESC=OBSERR'
+export 'OBS_ERROR_FLAG=TRUE'
+export 'OUTPUT_PREFIX=OBSERR'
+export 'SKIP_CONST=TRUE'
+echo "/d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep1/arw-fer-gep1_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep5/arw-fer-gep5_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep2/arw-sch-gep2_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep6/arw-sch-gep6_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep3/arw-tom-gep3_2012040912_F024.grib \
+                /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep7/arw-tom-gep7_2012040912_F024.grib" \
+                > /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat/input_file_list; \
+          /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat/input_file_list \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/obs_data/laps/laps_2012041012_F000.grib \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ascii2nc/gauge_2012041012_24hr.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset OBS_ERROR_FLAG
+unset OUTPUT_PREFIX
+unset SKIP_CONST
+
+
+export 'DESC=OBSERR_BAD_LOOKUP'
+export 'MET_OBS_ERROR_TABLE=${MET_TEST_OUTPUT}/ensemble_stat/obs_error_table_truncated.txt'
+export 'OBS_ERROR_FLAG=TRUE'
+export 'OUTPUT_PREFIX=OBSERR_BAD_LOOKUP'
+export 'SKIP_CONST=TRUE'
+grep -E "OBS_VAR|APCP" /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/table_files/obs_error_table.txt | head -2 \
+          > /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat/obs_error_table_truncated.txt; \
+          /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat/input_file_list \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/obs_data/laps/laps_2012041012_F000.grib \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ascii2nc/gauge_2012041012_24hr.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset MET_OBS_ERROR_TABLE
+unset OBS_ERROR_FLAG
+unset OUTPUT_PREFIX
+unset SKIP_CONST
+
+
+export 'DESC=SINGLE_FILE_NC_NO_CTRL'
+export 'OUTPUT_PREFIX=SINGLE_FILE_NC_NO_CTRL'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      1 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/CPC_NMME/CFSv2.tmp2m.198201.fcst.nc \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_single_file_nc \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/model_data/CPC_NMME/CFSv2.tmp2m.198201.fcst.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset OUTPUT_PREFIX
+
+
+export 'DESC=SINGLE_FILE_NC_WITH_CTRL'
+export 'OUTPUT_PREFIX=SINGLE_FILE_NC_WITH_CTRL'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      1 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/CPC_NMME/CFSv2.tmp2m.198201.fcst.nc \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_single_file_nc \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/model_data/CPC_NMME/CFSv2.tmp2m.198201.fcst.nc \
+      -ctrl /d1/projects/MET/MET_test_data/unit_test/model_data/CPC_NMME/CFSv2.tmp2m.198201.fcst.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset OUTPUT_PREFIX
+
+
+export 'DESC=SINGLE_FILE_GRIB_NO_CTRL'
+export 'OUTPUT_PREFIX=SINGLE_FILE_GRIB_NO_CTRL'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      1 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib2/gefs/enspost_grb2.t00z.prmsl \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_single_file_grib \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/model_data/grib2/gefs/enspost_grb2.t00z.prmsl \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset OUTPUT_PREFIX
+
+
+export 'DESC=SINGLE_FILE_GRIB_WITH_CTRL'
+export 'OUTPUT_PREFIX=SINGLE_FILE_GRIB_WITH_CTRL'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      1 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib2/gefs/enspost_grb2.t00z.prmsl \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_single_file_grib \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/model_data/grib2/gefs/enspost_grb2.t00z.prmsl \
+      -ctrl /d1/projects/MET/MET_test_data/unit_test/model_data/grib2/gefs/enspost_grb2.t00z.prmsl \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset OUTPUT_PREFIX
+
+
+export 'DESC=RPS_CLIMO_BIN_PROB'
+export 'OUTPUT_PREFIX=RPS_CLIMO_BIN_PROB'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      1 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/cpc_climo_prob/gefs-00z_aer-rfcst-cal_tmean_20210101_week2_cats_33-67ptile.nc \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_rps_climo_bin_prob \
+      -grid_obs /d1/projects/MET/MET_test_data/unit_test/model_data/cpc_climo_prob/tmean_07d_20210115_cats_33-67ptile.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 1
+unset DESC
+unset OUTPUT_PREFIX
+
+
+export 'GEOG_FILE="${MET_TEST_INPUT}/model_data/grib1/nam/nam_2012040900_F012.grib"'
+export 'OUTPUT_PREFIX=LAND_TOPO_MASK'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      6 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep1/arw-fer-gep1_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep5/arw-fer-gep5_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep2/arw-sch-gep2_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep6/arw-sch-gep6_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep3/arw-tom-gep3_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep7/arw-tom-gep7_2012040900_F012.grib \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_LAND_TOPO_MASK \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/pb2nc/gdas1.20120409.t12z.prepbufr.nc \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 2
+unset GEOG_FILE
+unset OUTPUT_PREFIX
+
+
+export 'GEOG_FILE="${MET_TEST_INPUT}/model_data/grib1/nam/nam_2012040900_F012.grib"'
+export 'OUTPUT_PREFIX=LAPSE_RATE_MSL_AGL'
+/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/../../bin/ensemble_stat \
+      6 \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep1/arw-fer-gep1_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-fer-gep5/arw-fer-gep5_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep2/arw-sch-gep2_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-sch-gep6/arw-sch-gep6_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep3/arw-tom-gep3_2012040900_F012.grib \
+      /d1/projects/MET/MET_test_data/unit_test/model_data/grib1/arw-tom-gep7/arw-tom-gep7_2012040900_F012.grib \
+      /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/config/EnsembleStatConfig_LAPSE_RATE_MSL_AGL \
+      -point_obs /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/pb2nc/gdas1.20120409.t12z.prepbufr.nc \
+      -point_obs 'PYTHON_NUMPY=/d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../share/met/python/examples/read_ascii_point.py /d1/projects/MET/MET_test_data/unit_test/obs_data/ascii/sample_ascii_KMUO_BAD_ELEVATION.txt' \
+      -outdir /d1/personal/johnhg/METplus/development/METplus-13.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup/internal/test_unit/../../test_output/ensemble_stat -v 2
+unset GEOG_FILE
+unset OUTPUT_PREFIX
+
+

--- a/internal/test_unit/xml/unit_ensemble_stat.xml
+++ b/internal/test_unit/xml/unit_ensemble_stat.xml
@@ -252,7 +252,7 @@
           > &OUTPUT_DIR;/ensemble_stat/obs_error_table_truncated.txt; \
           &MET_BIN;/ensemble_stat</exec>
     <env>
-      <pair><name>DESC</name>                <value>OBSERR_BAD_LOOKUP</value></pair>
+      <pair><name>DESC</name>                <value>OBSERR</value></pair>
       <pair><name>OBS_ERROR_FLAG</name>      <value>TRUE</value></pair>
       <pair><name>MET_OBS_ERROR_TABLE</name> <value>&OUTPUT_DIR;/ensemble_stat/obs_error_table_truncated.txt</value></pair>
       <pair><name>SKIP_CONST</name>          <value>TRUE</value></pair>

--- a/internal/test_unit/xml/unit_ensemble_stat.xml
+++ b/internal/test_unit/xml/unit_ensemble_stat.xml
@@ -245,6 +245,37 @@
     </output>
   </test>
 
+  <!--  MET #3429 use a truncated observation error table to cause bad lookups.  -->
+
+  <test name="ensemble_stat_OBSERR_BAD_LOOKUP">
+    <exec>grep -E "OBS_VAR|APCP" &MET_BASE;/table_files/obs_error_table.txt | head -2 \
+          > &OUTPUT_DIR;/ensemble_stat/obs_error_table_truncated.txt; \
+          &MET_BIN;/ensemble_stat</exec>
+    <env>
+      <pair><name>DESC</name>                <value>OBSERR_BAD_LOOKUP</value></pair>
+      <pair><name>OBS_ERROR_FLAG</name>      <value>TRUE</value></pair>
+      <pair><name>MET_OBS_ERROR_TABLE</name> <value>&OUTPUT_DIR;/ensemble_stat/obs_error_table_truncated.txt</value></pair>
+      <pair><name>SKIP_CONST</name>          <value>TRUE</value></pair>
+      <pair><name>OUTPUT_PREFIX</name>       <value>OBSERR_BAD_LOOKUP</value></pair>
+    </env>
+    <param> \
+      &OUTPUT_DIR;/ensemble_stat/input_file_list \
+      &CONFIG_DIR;/EnsembleStatConfig \
+      -grid_obs &DATA_DIR_OBS;/laps/laps_2012041012_F000.grib \
+      -point_obs &OUTPUT_DIR;/ascii2nc/gauge_2012041012_24hr.nc \
+      -outdir &OUTPUT_DIR;/ensemble_stat -v 1
+    </param>
+    <output>
+      <stat>&OUTPUT_DIR;/ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V.stat</stat>
+      <stat>&OUTPUT_DIR;/ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_ecnt.txt</stat>
+      <stat>&OUTPUT_DIR;/ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_rhist.txt</stat>
+      <stat>&OUTPUT_DIR;/ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_phist.txt</stat>
+      <stat>&OUTPUT_DIR;/ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_orank.txt</stat>
+      <stat>&OUTPUT_DIR;/ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_ssvar.txt</stat>
+      <grid_nc>&OUTPUT_DIR;/ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_orank.nc</grid_nc>
+    </output>
+  </test>
+
   <!--  Single NetCDF input file with all ensembles - no control member.  -->
 
   <test name="ensemble_stat_SINGLE_FILE_NC_NO_CTRL">

--- a/src/libcode/vx_statistics/obs_error.cc
+++ b/src/libcode/vx_statistics/obs_error.cc
@@ -547,7 +547,7 @@ ObsErrorEntry *ObsErrorTable::lookup(
    // Check for no match
    if(e_match == (ObsErrorEntry *) 0) {
       mlog << Warning << "\nObsErrorTable::lookup() -> "
-           << "no observation error table match found for "
+           << "skipping observation since no match found for "
            << "var_name = \"" << cur_var_name
            << "\", msg_type = \"" << cur_msg_type
            << "\", sid = \"" << cur_sid

--- a/src/libcode/vx_statistics/pair_data_ensemble.cc
+++ b/src/libcode/vx_statistics/pair_data_ensemble.cc
@@ -1274,6 +1274,9 @@ void VxPairDataEnsemble::add_point_obs(const float *hdr_arr,
                obs_info->name().c_str(), hdr_typ_str, hdr_sid_str,
                hdr_typ_arr[0], hdr_typ_arr[1], hdr_typ_arr[2],
                obs_lvl, obs_hgt, obs_v);
+
+            // MET #3429: Skip observation if the table lookup fails
+            if(!oerr_ptr) return;
          }
       }
    }

--- a/src/tools/core/ensemble_stat/ensemble_stat.cc
+++ b/src/tools/core/ensemble_stat/ensemble_stat.cc
@@ -1749,6 +1749,22 @@ static void process_grid_scores(int i_vx,
          if(is_bad_data(obs_dp(x, y)) ||
             !mask_mp.s_is_on(x, y)) continue;
 
+         // Get the observation error entry pointer
+         if(oerr_ptr) {
+            e = oerr_ptr;
+         }
+         else if(conf_info.vx_opt[i_vx].obs_error.flag) {
+            e = obs_error_table.lookup(
+                   conf_info.vx_opt[i_vx].vx_pd.obs_info->name().c_str(),
+                   conf_info.obtype.c_str(), oraw_dp(x,y));
+
+            // MET #3429: Skip observation if the table lookup fails
+            if(!e) continue;
+         }
+         else {
+            e = (ObsErrorEntry *) nullptr;
+         }
+
          // Get current climatology values
          ClimoPntInfo cpi(
             (fcmn_flag ? fcmn_dp(x, y) : bad_data_double),
@@ -1758,19 +1774,6 @@ static void process_grid_scores(int i_vx,
 
          // Add the observation point
          pd.add_grid_obs(x, y, oraw_dp(x, y), cpi, wgt_dp(x, y));
-
-         // Get the observation error entry pointer
-         if(oerr_ptr) {
-            e = oerr_ptr;
-         }
-         else if(conf_info.vx_opt[i_vx].obs_error.flag) {
-            e = obs_error_table.lookup(
-                   conf_info.vx_opt[i_vx].vx_pd.obs_info->name().c_str(),
-                   conf_info.obtype.c_str(), oraw_dp(x,y));
-         }
-         else {
-            e = (ObsErrorEntry *) nullptr;
-         }
 
          // Store the observation error entry pointer
          pd.add_obs_error_entry(e);


### PR DESCRIPTION
These are the same changes as PR #3430, but for the `develop` branch instead. Also note that this adds a new unit test to demonstrate the bad observation error table lookup. This is accomplished by truncated the default `obs_error_table.txt` file to only include the first `APCP` entry for values between 0 and 0.1. All `APCP_24` precip observations outside of this range are excluded from the output of that new test.

Please review this at the same time as #3430, and note the following:
- Find the branch available for testing in `seneca:/d1/projects/MET/MET_pull_requests/met-13.0.0/rc1/MET-bugfix_3429_develop_obs_error_table_lookup`.
- The following new output test files are created:
```
ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_ecnt.txt
ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_orank.nc
ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_orank.txt
ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_phist.txt
ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_relp.txt
ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_rhist.txt
ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_ssvar.txt
ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V.stat
```
- Compare `ensemble_stat/ensemble_stat_OBSERR_20120410_120000V_ecnt.txt` to `ensemble_stat/ensemble_stat_OBSERR_BAD_LOOKUP_20120410_120000V_ecnt.txt` and note that it has fewer lines since there are no pairs for `OBS_THRESH = >=2.54` and fewer for `OBS_THRESH = >0`. As expected, the number of matched pairs in the `TOTAL` column are greatly reduced for `APCP_24` but remain constant for `TMP`, to which observation error is NOT applied.
